### PR TITLE
Align loan module with shared shell

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>LifeOS — Budżet (ulepszona wersja)</title>
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="styles.css">
     <style>
     .row {
       display: flex;
@@ -87,12 +87,225 @@
       font-size: 10px;
     }
 
+    .heatmap-card {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .recent-calendar-card {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .recent-calendar {
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+      gap: 8px;
+    }
+
+    .recent-day {
+      background: var(--surface);
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      border-radius: 14px;
+      padding: 8px 8px 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      min-height: 0;
+      transition: border-color .2s ease, transform .2s ease;
+    }
+
+    .recent-day:hover {
+      border-color: rgba(59, 130, 246, 0.35);
+      transform: translateY(-1px);
+    }
+
+    .recent-day-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 4px;
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+    }
+
+    .recent-day-header span {
+      display: block;
+      line-height: 1.1;
+    }
+
+    .recent-day-weekday {
+      font-size: 10px;
+      font-weight: 600;
+    }
+
+    .recent-day-date {
+      font-size: 11px;
+      font-weight: 700;
+      color: var(--ink);
+      text-transform: none;
+      letter-spacing: 0.02em;
+    }
+
+    .recent-day-total {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 11px;
+      font-weight: 700;
+      color: var(--ink);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .recent-day-body {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .recent-entry {
+      display: flex;
+      gap: 6px;
+      align-items: flex-start;
+      padding: 4px 6px;
+      border-radius: 10px;
+      border: 1px solid transparent;
+      background: rgba(148, 163, 184, 0.08);
+      transition: border-color .2s ease, background .2s ease;
+      font-size: 10px;
+    }
+
+    .recent-entry-emoji {
+      width: 20px;
+      height: 20px;
+      display: grid;
+      place-items: center;
+      border-radius: 8px;
+      background: rgba(255, 255, 255, 0.7);
+      font-size: 14px;
+      line-height: 1;
+      flex-shrink: 0;
+    }
+
+    .recent-entry-text {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      min-width: 0;
+    }
+
+    .recent-entry-amount {
+      font-variant-numeric: tabular-nums;
+      font-weight: 700;
+      font-size: 11px;
+      line-height: 1.2;
+      color: var(--ink);
+    }
+
+    .recent-entry-note {
+      font-size: 9px;
+      color: var(--muted);
+      line-height: 1.2;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+
+    .recent-entry.top-spend {
+      border-color: rgba(248, 113, 113, 0.55);
+      background: rgba(248, 113, 113, 0.12);
+    }
+
+    .recent-entry.top-spend .recent-entry-emoji {
+      background: rgba(248, 113, 113, 0.18);
+    }
+
+    .recent-entry.top-spend .recent-entry-amount {
+      color: #b91c1c;
+    }
+
+    .recent-entry-hidden {
+      display: none;
+    }
+
+    .recent-more {
+      border: none;
+      background: transparent;
+      color: var(--blue);
+      font-size: 9px;
+      font-weight: 600;
+      padding: 0;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      align-self: flex-start;
+    }
+
+    .recent-more::after {
+      content: '›';
+      font-size: 10px;
+      transition: transform .2s ease;
+    }
+
+    .recent-day.expanded .recent-more::after {
+      transform: rotate(90deg);
+    }
+
+    .recent-empty {
+      font-size: 9px;
+      color: var(--muted);
+      text-align: center;
+      padding: 8px 0 4px;
+    }
+
+    .recent-day.recent-day-empty {
+      border-style: dashed;
+    }
+
+    .recent-day.recent-day-empty .recent-day-total {
+      color: var(--muted);
+    }
+
+    @media (max-width: 1100px) {
+      .recent-calendar {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      }
+    }
+
+    .heatmap-strip {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      padding: 8px;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: var(--surface);
+      max-height: 120px;
+      overflow-y: auto;
+    }
+
     .heat-legend {
       display: flex;
       gap: 6px;
       align-items: center;
       font-size: 12px;
       color: #64748b;
+    }
+
+    .table-compact thead th,
+    .table-compact tbody td {
+      padding: 6px 8px;
+      font-size: 12px;
+      line-height: 1.25;
+    }
+
+    .table-compact tbody tr:nth-child(even) {
+      background: transparent;
     }
 
     .editor-section {
@@ -313,17 +526,39 @@
     }
   </style>
 </head>
-<body class="module-shell">
-  <section class="module-hero">
-    <div class="wrap module-hero-inner">
-      <div class="module-hero-top">
-        <div>
-          <a href="index.html" class="back-link">← Powrót</a>
-          <div class="module-eyebrow">Budżet</div>
-          <h1 class="module-title">Mój Budżet</h1>
-          <p class="module-subtitle">Wersja lokalna</p>
+<body data-page="budget">
+  <div class="layout">
+    <aside class="sidebar" aria-label="Główna nawigacja">
+      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
+        <a class="nav-link active" href="budget.html" aria-current="page"><span class="icon">💰</span><span>Budżet</span></a>
+        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
+        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
+        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
+        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
+        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
+        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      </nav>
+      <div class="sidebar-footer">
+        <strong>Twój cyfrowy dom</strong>
+        Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
+      </div>
+    </aside>
+
+    <div class="main">
+      <header class="topbar">
+        <div class="row" style="align-items:center;justify-content:space-between;gap:16px">
+          <div>
+            <p class="topbar-eyebrow">Finanse</p>
+            <h1 class="topbar-title">Budżet</h1>
+          </div>
+          <div class="row" style="gap:8px;flex-wrap:wrap">
+            <span class="badge">💾 Dane lokalne</span>
+            <span class="badge">📈 Analiza offline</span>
+          </div>
         </div>
-        <div class="module-hero-actions">
+        <div class="topbar-actions" style="gap:16px">
           <div class="toolbar budget-month-nav">
             <button class="btn soft" id="prevMonthBtn" title="Poprzedni miesiąc">←</button>
             <span class="pill" id="workingMonth">YYYY-MM</span>
@@ -335,34 +570,10 @@
             <input type="file" id="importFile" accept="application/json" style="display:none" />
           </div>
         </div>
-      </div>
-      <div class="module-hero-stats">
-        <div class="module-hero-stat">
-          <div class="label">Zostało do wydania</div>
-          <div class="big-number" id="dash-remaining">0</div>
-          <div class="note muted">na wydatki zmienne</div>
-        </div>
-        <div class="module-hero-stat">
-          <div class="label">Dzienny limit</div>
-          <div class="big-number" id="dash-daily-budget">0</div>
-          <div class="note" id="dash-daily-trend">—</div>
-        </div>
-        <div class="module-hero-stat">
-          <div class="label">Wydano dzisiaj</div>
-          <div class="big-number" id="dash-today-spent">0</div>
-          <div class="note" id="dash-today-vs-budget">—</div>
-        </div>
-        <div class="module-hero-stat">
-          <div class="label">Średnia dzienna</div>
-          <div class="big-number" id="dash-avg-daily">0</div>
-          <div class="note" id="dash-avg-trend">—</div>
-        </div>
-      </div>
-    </div>
-  </section>
+      </header>
 
-  <main class="module-content">
-    <div class="wrap">
+      <div class="content">
+        <main class="page-content content-main stack">
     <div class="tabs budget-tabs" style="margin-top:12px">
       <button class="tab active" data-tab="dashboard">Dashboard</button>
       <button class="tab" data-tab="overview">Przegląd</button>
@@ -379,7 +590,7 @@
     <!-- Dashboard -->
     <section id="tab-dashboard" class="card" style="margin-top:12px">
       <h3 class="title">Dashboard finansowy</h3>
-      <div class="grid g-2" style="margin-top:12px">
+      <div class="grid-2" style="margin-top:12px">
         <div class="card">
           <div class="title">Wydatki dzień po dniu</div>
           <div class="chart-box"><canvas id="dailyLine"></canvas></div>
@@ -391,19 +602,56 @@
         </div>
       </div>
 
-      <div class="card" style="margin-top:16px">
+      <div class="card heatmap-card" style="margin-top:16px">
         <div class="title">Wydatki dzienne — heatmap</div>
-        <div class="muted" style="margin-bottom:8px">Zielone = w budżecie, Pomarańczowe = przekroczenie, Czerwone = duże przekroczenie</div>
-        <div id="daily-spending-calendar" style="display:flex;flex-wrap:wrap;gap:4px"></div>
-        <div class="heat-legend" style="margin-top:6px">
+        <div class="muted" style="margin-bottom:4px">Zielone = w budżecie, Pomarańczowe = przekroczenie, Czerwone = duże przekroczenie</div>
+        <div id="daily-spending-calendar" class="heatmap-strip"></div>
+        <div class="heat-legend">
           <span class="heat-day" style="background:#dcfce7"> </span> w normie
           <span class="heat-day" style="background:#ffedd5"> </span> lekko powyżej
           <span class="heat-day" style="background:#fee2e2"> </span> mocno powyżej
         </div>
       </div>
 
+      <div class="card recent-calendar-card" style="margin-top:16px">
+        <div class="row" style="justify-content:space-between;align-items:flex-start;gap:12px">
+          <div>
+            <div class="title">Ostatnie 7 dni — wydatki</div>
+            <p class="muted tiny">Największe wydatki z ostatnich dni, posegregowane malejąco. Top 5 oznaczone na czerwono.</p>
+          </div>
+          <div class="chip" style="margin:0" id="recent-seven-total">Łącznie: —</div>
+        </div>
+        <div id="recent-spending-calendar" class="recent-calendar"></div>
+      </div>
+
+      <div id="var-table-dashboard-slot" style="display:none">
+        <div id="var-transactions-card" class="card">
+          <div class="row" style="justify-content:space-between;align-items:flex-end;gap:12px">
+            <div>
+              <div class="title">Transakcje w miesiącu</div>
+              <p class="muted tiny">Monitoruj wszystkie wydatki zmienne w aktywnym okresie.</p>
+            </div>
+            <div class="chip" style="margin:0">
+              Suma: <b id="var-sum">0</b>
+            </div>
+          </div>
+          <div class="row" style="margin:12px 0;gap:8px;align-items:center;flex-wrap:wrap">
+            <label class="tiny" style="display:flex;flex-direction:column;gap:6px">
+              Filtr kategorii
+              <select id="var-filter-cat"><option value="">Wszystkie kategorie</option></select>
+            </label>
+          </div>
+          <div class="table-wrapper" style="max-height:320px;overflow:auto">
+            <table class="table-compact">
+              <thead><tr><th>Data</th><th>Kategoria</th><th>Konto</th><th>Kwota</th><th>Notatka</th><th></th></tr></thead>
+              <tbody id="var-rows"></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
       <!-- NEW: Forecast and Buffer Banners -->
-      <div class="grid g-2" style="margin-top:12px">
+      <div class="grid-2" style="margin-top:12px">
         <div class="banner" style="background: #f0fdf4; border-color: #dcfce7;">
           <b>🔮 Prognozowane oszczędności</b>
           <div class="big-number" id="forecast-content" style="font-size: 24px; margin-top: 4px;">0</div>
@@ -573,16 +821,10 @@
         <input name="note" placeholder="Notatka" />
         <button class="btn" type="submit">Dodaj wydatek</button>
       </form>
-      
-      <div class="row" style="margin-bottom:8px">
-        <div class="muted">Suma wydatków zmiennych: <b id="var-sum">0</b></div>
-        <select id="var-filter-cat"><option value="">Wszystkie kategorie</option></select>
-      </div>
 
-      <table>
-        <thead><tr><th>Data</th><th>Kategoria</th><th>Konto</th><th>Kwota</th><th>Notatka</th><th></th></tr></thead>
-        <tbody id="var-rows"></tbody>
-      </table>
+      <div id="var-table-variable-slot" style="margin-top:12px"></div>
+
+      <div class="insight-bubble" style="margin-top:12px">📊 Szczegółową tabelę transakcji znajdziesz poniżej lub w panelu „Dashboard finansowy”.</div>
     </section>
 
     <!-- Categories -->
@@ -1070,8 +1312,44 @@
         </div>
       </div>
     </section>
+        </main>
+        <aside class="right-rail">
+          <div class="kpi-compact">
+            <div class="kpi-emoji">💸</div>
+            <div>
+              <div class="kpi-label">Pozostały budżet</div>
+              <div class="kpi-value" id="dash-remaining">0</div>
+              <div class="muted tiny">na wydatki zmienne</div>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <div class="kpi-emoji">📉</div>
+            <div>
+              <div class="kpi-label">Limit dzienny</div>
+              <div class="kpi-value" id="dash-daily-budget">0</div>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <div class="kpi-emoji">📅</div>
+            <div>
+              <div class="kpi-label">Wydane dziś</div>
+              <div class="kpi-value" id="dash-today-spent">0</div>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <div class="kpi-emoji">📊</div>
+            <div>
+              <div class="kpi-label">Średnia dzienna</div>
+              <div class="kpi-value" id="dash-avg-daily">0</div>
+            </div>
+          </div>
+          <div class="insight-bubble">📉 Trend limitu: <span id="dash-daily-trend">—</span></div>
+          <div class="insight-bubble">📅 Status dnia: <span id="dash-today-vs-budget">—</span></div>
+          <div class="insight-bubble">📊 Średnia vs plan: <span id="dash-avg-trend">—</span></div>
+        </aside>
+      </div>
+    </div>
   </div>
-  </main>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
@@ -1319,12 +1597,23 @@
   }
   const tabs=document.querySelectorAll('.tab');
   const sections={dashboard:tab('dashboard'),overview:tab('overview'),incomes:tab('incomes'),fixed:tab('fixed'),variable:tab('variable'),categories:tab('categories'),eom:tab('eom'),goals:tab('goals'),analytics:tab('analytics'),inventory:tab('inventory')};
+  const varCard=document.getElementById('var-transactions-card');
+  const varSlots={dashboard:document.getElementById('var-table-dashboard-slot'),variable:document.getElementById('var-table-variable-slot')};
+  function placeVarCard(target){
+    if(!varCard) return;
+    const slot=varSlots[target];
+    if(slot && varCard.parentElement!==slot){
+      slot.appendChild(varCard);
+    }
+  }
+  placeVarCard('dashboard');
   function tab(id){return document.getElementById('tab-'+id)}
   for(const t of tabs){
     t.addEventListener('click',()=>{
       tabs.forEach(x=>x.classList.remove('active')); t.classList.add('active');
       Object.values(sections).forEach(s=>s.style.display='none'); sections[t.dataset.tab].style.display='block';
-      if(t.dataset.tab==='variable'){setDefaultDate()}
+      if(t.dataset.tab==='variable'){placeVarCard('variable'); setDefaultDate()}
+      else if(t.dataset.tab==='dashboard'){placeVarCard('dashboard')}
       if(t.dataset.tab==='analytics') renderAnalytics(); // Render analytics when tab is clicked
       if(t.dataset.tab==='eom') renderEOMHistory(); // Render history when tab is clicked
       if(t.dataset.tab==='inventory') renderInventory();
@@ -1526,8 +1815,8 @@
     const days=daysInYm(ym);
     const dailyBudget=Math.max(0,(incSum-fixSum)/days);
 
-    const entries=entriesForMonth(ym);
-    const cb=catsById();
+      const entries=entriesForMonth(ym);
+      const cb=catsById();
     
     const variableSpent = entries.reduce((s, e) => {
         const c = cb[e.categoryId];
@@ -1568,7 +1857,9 @@
       box.className='heat-day'; box.style.background=bg; box.title=`${String(d).padStart(2,'0')}: ${fmt(val, state.currency)}`; box.textContent=String(d);
       cal.appendChild(box);
     }
-    
+
+    renderRecentSpendingTiles();
+
     // --- Forecast & Buffer Section (NEW) ---
     const daysLeft = getDaysRemaining(ym);
     const totalVariableBudget = incSum - fixSum;
@@ -1607,6 +1898,151 @@
         return `${integerPart}\u00A0${state.currency || 'PLN'}`;
     } catch {
         return `${Math.round(Number(v || 0))}\u00A0${state.currency || 'PLN'}`;
+    }
+  }
+
+  function renderRecentSpendingTiles(){
+    const container=document.getElementById('recent-spending-calendar');
+    if(!container) return;
+    container.innerHTML='';
+    const totalChip=document.getElementById('recent-seven-total');
+    const today=new Date();
+    today.setHours(0,0,0,0);
+    const dayKeyFromDate=d=>`${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+    const dayDates=[];
+    for(let offset=6; offset>=0; offset--){
+      const d=new Date(today);
+      d.setDate(today.getDate()-offset);
+      dayDates.push(d);
+    }
+    const months=[...new Set(dayDates.map(d=>monthKey(d)))];
+    let allEntries=[];
+    for(const ym of months){
+      allEntries=allEntries.concat(entriesForMonth(ym));
+    }
+    const cb=catsById();
+    const accountsById=Object.fromEntries((b().accounts||[]).map(acc=>[acc.id,acc]));
+    const startKey=dayKeyFromDate(dayDates[0]);
+    const endKey=dayKeyFromDate(dayDates[dayDates.length-1]);
+    const filteredBase=[];
+    for(const entry of allEntries){
+      if(entry.date<startKey || entry.date>endKey) continue;
+      const cat=cb[entry.categoryId];
+      if(!cat || cat.type!=='expense' || cat.id==='c_fixed') continue;
+      const amount=Math.abs(entry.amount);
+      if(amount<=0) continue;
+      filteredBase.push({entry, amount, cat});
+    }
+    const filtered=filteredBase.map((item, idx)=>({...item, idx}));
+    const totalAmount=filtered.reduce((sum,item)=>sum+item.amount,0);
+    if(totalChip){
+      totalChip.textContent=filtered.length?`Łącznie: ${fmt(totalAmount, state.currency)}`:'Łącznie: —';
+    }
+    const topIdx=new Set(filtered.slice().sort((a,b)=>b.amount-a.amount).slice(0,5).map(item=>item.idx));
+    const grouped=new Map();
+    for(const item of filtered){
+      if(!grouped.has(item.entry.date)) grouped.set(item.entry.date, []);
+      grouped.get(item.entry.date).push(item);
+    }
+    const weekdayFmt=new Intl.DateTimeFormat('pl-PL',{weekday:'short'});
+    const dateFmt=new Intl.DateTimeFormat('pl-PL',{day:'2-digit',month:'2-digit'});
+    const tooltipDateFmt=new Intl.DateTimeFormat('pl-PL',{year:'numeric',month:'short',day:'2-digit'});
+    for(const dateObj of dayDates){
+      const key=dayKeyFromDate(dateObj);
+      const tile=document.createElement('div');
+      tile.className='recent-day';
+      const header=document.createElement('div');
+      header.className='recent-day-header';
+      const weekdayEl=document.createElement('span');
+      weekdayEl.className='recent-day-weekday';
+      weekdayEl.textContent=weekdayFmt.format(dateObj).replace('.', '').toUpperCase();
+      const dateEl=document.createElement('span');
+      dateEl.className='recent-day-date';
+      dateEl.textContent=dateFmt.format(dateObj);
+      header.append(weekdayEl, dateEl);
+      tile.appendChild(header);
+      const dayItems=(grouped.get(key)||[]).sort((a,b)=>b.amount-a.amount);
+      const dayTotal=dayItems.reduce((sum,item)=>sum+item.amount,0);
+      const total=document.createElement('div');
+      total.className='recent-day-total';
+      const totalIcon=document.createElement('span');
+      totalIcon.setAttribute('aria-hidden','true');
+      totalIcon.textContent='💰';
+      total.append(totalIcon, document.createTextNode(dayItems.length?fmt(dayTotal, state.currency):'—'));
+      if(dayItems.length===0){
+        tile.classList.add('recent-day-empty');
+      }
+      tile.appendChild(total);
+      const body=document.createElement('div');
+      body.className='recent-day-body';
+      if(dayItems.length===0){
+        const empty=document.createElement('div');
+        empty.className='recent-empty';
+        empty.textContent='brak ruchu';
+        body.appendChild(empty);
+      }else{
+        const maxVisible=2;
+        const extraRows=[];
+        dayItems.forEach((item, idx)=>{
+          const row=document.createElement('div');
+          row.className='recent-entry';
+          if(topIdx.has(item.idx)) row.classList.add('top-spend');
+          if(idx>=maxVisible){
+            row.classList.add('recent-entry-hidden');
+            extraRows.push(row);
+          }
+          const emoji=item.cat?.emoji||'💸';
+          const emojiEl=document.createElement('span');
+          emojiEl.className='recent-entry-emoji';
+          emojiEl.textContent=emoji;
+          const textWrap=document.createElement('div');
+          textWrap.className='recent-entry-text';
+          const amountEl=document.createElement('span');
+          amountEl.className='recent-entry-amount';
+          amountEl.textContent=fmt(item.amount, state.currency);
+          textWrap.appendChild(amountEl);
+          const noteText=(item.entry.note||'').trim();
+          if(noteText){
+            const noteEl=document.createElement('span');
+            noteEl.className='recent-entry-note';
+            noteEl.textContent=noteText;
+            textWrap.appendChild(noteEl);
+          }
+          const [yy,mm,dd]=item.entry.date.split('-').map(Number);
+          const entryDate=new Date(yy, (mm||1)-1, dd||1);
+          const tooltipParts=[
+            [emoji, item.cat?.name||'Wydatek'].filter(Boolean).join(' '),
+            `Kwota: ${fmt(item.amount, state.currency)}`,
+            `Data: ${tooltipDateFmt.format(entryDate)}`,
+            `Konto: ${accountsById[item.entry.accountId]?.name||'—'}`
+          ];
+          if(item.entry.note){
+            tooltipParts.push(`Notatka: ${item.entry.note}`);
+          }
+          row.title=tooltipParts.join('\n');
+          row.setAttribute('aria-label', tooltipParts.join(', '));
+          row.append(emojiEl, textWrap);
+          body.appendChild(row);
+        });
+        if(extraRows.length){
+          const collapsedLabel=`+${extraRows.length}`;
+          const toggle=document.createElement('button');
+          toggle.type='button';
+          toggle.className='recent-more';
+          toggle.textContent=collapsedLabel;
+          toggle.title='Pokaż więcej wydatków';
+          toggle.setAttribute('aria-expanded','false');
+          toggle.addEventListener('click',()=>{
+            const expanded=tile.classList.toggle('expanded');
+            extraRows.forEach(row=>row.classList.toggle('recent-entry-hidden', !expanded));
+            toggle.textContent=expanded?'−':collapsedLabel;
+            toggle.setAttribute('aria-expanded', expanded?'true':'false');
+          });
+          body.appendChild(toggle);
+        }
+      }
+      tile.appendChild(body);
+      container.appendChild(tile);
     }
   }
 

--- a/budget.html
+++ b/budget.html
@@ -1316,7 +1316,7 @@
         <aside class="right-rail">
           <div class="kpi-compact">
             <div class="kpi-emoji">💸</div>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Pozostały budżet</div>
               <div class="kpi-value" id="dash-remaining">0</div>
               <div class="muted tiny">na wydatki zmienne</div>
@@ -1324,21 +1324,21 @@
           </div>
           <div class="kpi-compact">
             <div class="kpi-emoji">📉</div>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Limit dzienny</div>
               <div class="kpi-value" id="dash-daily-budget">0</div>
             </div>
           </div>
           <div class="kpi-compact">
             <div class="kpi-emoji">📅</div>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Wydane dziś</div>
               <div class="kpi-value" id="dash-today-spent">0</div>
             </div>
           </div>
           <div class="kpi-compact">
             <div class="kpi-emoji">📊</div>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Średnia dzienna</div>
               <div class="kpi-value" id="dash-avg-daily">0</div>
             </div>

--- a/fuel.html
+++ b/fuel.html
@@ -233,7 +233,7 @@
         <aside class="right-rail">
           <div class="kpi-compact">
             <div class="kpi-emoji">⛽</div>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Saldo rozliczeń</div>
               <div class="kpi-value ok" id="fuel-balance">0,00 PLN</div>
               <p class="tiny muted" id="balance-info">—</p>
@@ -241,7 +241,7 @@
           </div>
           <div class="kpi-compact">
             <div class="kpi-emoji">🧾</div>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Śr. cena/L (12m)</div>
               <div class="kpi-value" id="avg-price-12m">—</div>
               <p class="tiny muted" id="avg-price-12m-note">Brak danych z ostatniego roku</p>
@@ -249,7 +249,7 @@
           </div>
           <div class="kpi-compact">
             <div class="kpi-emoji">🟢</div>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Najlepsza cena</div>
               <div class="kpi-value" id="best-price">—</div>
               <p class="tiny muted" id="best-price-note">Dodaj faktury z litrami</p>
@@ -257,7 +257,7 @@
           </div>
           <div class="kpi-compact">
             <div class="kpi-emoji">🔴</div>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Najwyższa cena</div>
               <div class="kpi-value" id="worst-price">—</div>
               <p class="tiny muted" id="worst-price-note">Dodaj faktury z litrami</p>
@@ -265,7 +265,7 @@
           </div>
           <div class="kpi-compact">
             <div class="kpi-emoji">💳</div>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Śr. faktura</div>
               <div class="kpi-value" id="avg-invoice">—</div>
               <p class="tiny muted" id="avg-invoice-note">Czekamy na nowe dane</p>

--- a/fuel.html
+++ b/fuel.html
@@ -4,26 +4,25 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>LifeOS — Paliwo</title>
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="styles.css">
   <style>
     .fuel-insights-grid {
-      display: grid;
-      gap: 14px;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     }
 
-    .insight-card {
+    .fuel-insight-card {
       background: var(--surface);
       border: 1px solid var(--line);
       border-radius: 14px;
       padding: 16px;
       display: flex;
       flex-direction: column;
-      gap: 6px;
+      gap: 10px;
       box-shadow: var(--shadow-sm);
     }
 
-    .insight-card .label {
+    .fuel-insight-card .label {
       font-size: 12px;
       color: var(--muted);
       text-transform: uppercase;
@@ -31,13 +30,13 @@
       font-weight: 600;
     }
 
-    .insight-card .value {
-      font-size: 22px;
+    .fuel-insight-card .value {
+      font-size: 20px;
       font-weight: 700;
       color: var(--ink);
     }
 
-    .insight-card .note {
+    .fuel-insight-card .note {
       font-size: 12px;
       color: var(--muted);
     }
@@ -74,137 +73,209 @@
     .summary-delta.flat {
       color: var(--muted);
     }
+
+    .last-invoice-card {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .table-wrapper.scrollable {
+      max-height: 320px;
+      overflow: auto;
+    }
   </style>
 </head>
-<body class="module-shell">
-  <section class="module-hero">
-    <div class="wrap module-hero-inner">
-      <div class="module-hero-top">
-        <div>
-          <a href="index.html" class="back-link">← Powrót</a>
-          <div class="module-eyebrow">Finanse</div>
-          <h1 class="module-title">Moduł paliwowy</h1>
-          <p class="module-subtitle">Rozliczaj wydatki służbowe i prywatne tankowania w jednym miejscu.</p>
+<body data-page="fuel">
+  <div class="layout">
+    <aside class="sidebar" aria-label="Główna nawigacja">
+      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
+        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
+        <a class="nav-link active" href="fuel.html" aria-current="page"><span class="icon">⛽</span><span>Paliwo</span></a>
+        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
+        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
+        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
+        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
+        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      </nav>
+      <div class="sidebar-footer">
+        <strong>Twój cyfrowy dom</strong>
+        Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
+      </div>
+    </aside>
+
+    <div class="main">
+      <header class="topbar">
+        <div class="topbar-info">
+          <p class="topbar-eyebrow">Finanse</p>
+          <h1 class="topbar-title">Paliwo</h1>
         </div>
-        <div class="module-hero-actions">
+        <div class="topbar-actions">
           <button id="import-csv-btn" class="btn soft">Importuj z CSV</button>
           <input type="file" id="csv-file-input" accept=".csv" style="display:none;">
           <button id="export-csv-btn" class="btn soft">Eksportuj do CSV</button>
           <button id="clear-all-btn" class="btn danger">Wyczyść wszystko</button>
         </div>
-      </div>
-      <div class="module-hero-stats">
-        <div class="module-hero-stat">
-          <div class="label">Aktualne saldo</div>
-          <div class="value ok" id="fuel-balance">0,00 PLN</div>
-          <div class="note muted" id="balance-info">—</div>
-        </div>
-        <div class="module-hero-stat" id="last-invoice-card">
-          <div class="muted">Brak faktur w historii</div>
-        </div>
-      </div>
-    </div>
-  </section>
+      </header>
 
-  <main class="module-content">
-    <div class="wrap">
-      <section class="card card-section">
-        <div class="section-heading">
-          <h2 class="title">Kluczowe wnioski</h2>
-          <span class="tiny muted">Aktualizowane automatycznie na podstawie historii tankowań</span>
-        </div>
-        <div id="insights-grid" class="fuel-insights-grid"></div>
-      </section>
+      <div class="content">
+        <main class="content-main stack">
+          <section class="card card-section">
+            <div class="section-heading">
+              <h2 class="title">Kluczowe wnioski</h2>
+              <span class="tiny muted">Aktualizowane automatycznie na podstawie historii tankowań</span>
+            </div>
+            <div id="insights-grid" class="grid-3 fuel-insights-grid"></div>
+            <div class="insight-bubble" id="fuel-kpi-insight">Dodaj pierwszą transakcję, aby zobaczyć trend wydatków.</div>
+          </section>
 
-      <section class="card card-section">
-        <div class="section-heading">
-          <h2 class="title">Podsumowanie miesięczne</h2>
-          <p class="tiny muted" id="monthly-summary-caption">Ostatnie 6 miesięcy</p>
-        </div>
-        <div class="table-wrapper">
-          <table>
-            <thead>
-              <tr>
-                <th>Miesiąc</th>
-                <th>Faktury</th>
-                <th>Litry</th>
-                <th>Śr. cena</th>
-                <th>Zmiana m/m</th>
-              </tr>
-            </thead>
-            <tbody id="monthly-summary-body"></tbody>
-          </table>
-        </div>
-      </section>
+          <section class="card card-section">
+            <div class="section-heading">
+              <h2 class="title">Ostatnia faktura</h2>
+              <span class="tiny muted">Historia aktualizuje się po każdym dodaniu faktury</span>
+            </div>
+            <div class="last-invoice-card" id="last-invoice-card">
+              <div class="muted">Brak faktur w historii</div>
+            </div>
+          </section>
 
-      <section class="card card-section">
-        <div class="section-heading">
-          <h2 class="title" id="form-title">Dodaj transakcję</h2>
-          <span class="tiny muted">Obsługujemy faktury i zaliczki firmowe</span>
-        </div>
-        <div class="grid g-4 fuel-form-grid">
-          <input type="hidden" id="tx-id">
-          <input type="date" id="tx-date">
-          <select id="tx-type">
-            <option value="invoice">Faktura (koszt)</option>
-            <option value="advance">Zaliczka (wpływ)</option>
-          </select>
-          <input type="text" id="tx-ref" placeholder="Nr faktury / Opis">
-          <input type="text" id="tx-liters" placeholder="Litry (opcjonalnie)" inputmode="decimal">
-          <input type="text" id="tx-amount" placeholder="Kwota" inputmode="decimal" required>
-          <div class="fuel-form-actions">
-            <button id="cancel-edit-btn" class="btn soft" style="display:none;">Anuluj</button>
-            <button id="add-tx-btn" class="btn primary">Dodaj</button>
+          <section class="card card-section">
+            <div class="section-heading">
+              <h2 class="title">Podsumowanie miesięczne</h2>
+              <p class="tiny muted" id="monthly-summary-caption">Ostatnie 6 miesięcy</p>
+            </div>
+            <div class="table-wrapper scrollable">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Miesiąc</th>
+                    <th>Faktury</th>
+                    <th>Litry</th>
+                    <th>Śr. cena</th>
+                    <th>Zmiana m/m</th>
+                  </tr>
+                </thead>
+                <tbody id="monthly-summary-body"></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="card card-section">
+            <div class="section-heading">
+              <h2 class="title">Analityka</h2>
+              <select id="analytics-period-filter" style="width:auto;">
+                <option value="12" selected>Ostatni rok</option>
+                <option value="24">Ostatnie 2 lata</option>
+                <option value="36">Ostatnie 3 lata</option>
+                <option value="all">Wszystkie dane</option>
+              </select>
+            </div>
+            <div class="fuel-analytics-grid">
+              <article class="chart-card">
+                <h3 class="title">Miesięczne koszty i liczba tankowań</h3>
+                <div class="chart-area"><canvas id="monthly-costs-chart"></canvas></div>
+              </article>
+              <article class="chart-card">
+                <h3 class="title">Średnia cena za litr</h3>
+                <div class="chart-area"><canvas id="avg-price-chart"></canvas></div>
+              </article>
+            </div>
+          </section>
+
+          <section class="card card-section">
+            <div class="section-heading">
+              <h2 class="title" id="form-title">Dodaj transakcję</h2>
+              <span class="tiny muted">Obsługujemy faktury i zaliczki firmowe</span>
+            </div>
+            <div class="grid g-4 fuel-form-grid">
+              <input type="hidden" id="tx-id">
+              <input type="date" id="tx-date">
+              <select id="tx-type">
+                <option value="invoice">Faktura (koszt)</option>
+                <option value="advance">Zaliczka (wpływ)</option>
+              </select>
+              <input type="text" id="tx-ref" placeholder="Nr faktury / Opis">
+              <input type="text" id="tx-liters" placeholder="Litry (opcjonalnie)" inputmode="decimal">
+              <input type="text" id="tx-amount" placeholder="Kwota" inputmode="decimal" required>
+              <div class="fuel-form-actions">
+                <button id="cancel-edit-btn" class="btn soft" style="display:none;">Anuluj</button>
+                <button id="add-tx-btn" class="btn primary">Dodaj</button>
+              </div>
+            </div>
+          </section>
+
+          <section class="card card-section">
+            <div class="section-heading">
+              <h2 class="title">Historia transakcji</h2>
+              <span class="tiny muted">Kliknij wpis, aby edytować lub usuń w przypadku pomyłki</span>
+            </div>
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Data</th>
+                    <th>Typ</th>
+                    <th>Opis/Nr faktury</th>
+                    <th>Litry</th>
+                    <th>Cena/l</th>
+                    <th>Kwota</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody id="history-tbody"></tbody>
+              </table>
+            </div>
+          </section>
+        </main>
+
+        <aside class="right-rail">
+          <div class="kpi-compact">
+            <div class="kpi-emoji">⛽</div>
+            <div>
+              <div class="kpi-label">Saldo rozliczeń</div>
+              <div class="kpi-value ok" id="fuel-balance">0,00 PLN</div>
+              <p class="tiny muted" id="balance-info">—</p>
+            </div>
           </div>
-        </div>
-      </section>
-
-      <section class="card card-section">
-        <div class="section-heading">
-          <h2 class="title">Analityka</h2>
-          <select id="analytics-period-filter" style="width:auto;">
-            <option value="12" selected>Ostatni rok</option>
-            <option value="24">Ostatnie 2 lata</option>
-            <option value="36">Ostatnie 3 lata</option>
-            <option value="all">Wszystkie dane</option>
-          </select>
-        </div>
-        <div class="fuel-analytics-grid">
-          <article class="chart-card">
-            <h3 class="title">Miesięczne koszty i liczba tankowań</h3>
-            <div class="chart-area"><canvas id="monthly-costs-chart"></canvas></div>
-          </article>
-          <article class="chart-card">
-            <h3 class="title">Średnia cena za litr</h3>
-            <div class="chart-area"><canvas id="avg-price-chart"></canvas></div>
-          </article>
-        </div>
-      </section>
-
-      <section class="card card-section">
-        <div class="section-heading">
-          <h2 class="title">Historia transakcji</h2>
-          <span class="tiny muted">Kliknij wpis, aby edytować lub usuń w przypadku pomyłki</span>
-        </div>
-        <div class="table-wrapper">
-          <table>
-            <thead>
-              <tr>
-                <th>Data</th>
-                <th>Typ</th>
-                <th>Opis/Nr faktury</th>
-                <th>Litry</th>
-                <th>Cena/l</th>
-                <th>Kwota</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody id="history-tbody"></tbody>
-          </table>
-        </div>
-      </section>
+          <div class="kpi-compact">
+            <div class="kpi-emoji">🧾</div>
+            <div>
+              <div class="kpi-label">Śr. cena/L (12m)</div>
+              <div class="kpi-value" id="avg-price-12m">—</div>
+              <p class="tiny muted" id="avg-price-12m-note">Brak danych z ostatniego roku</p>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <div class="kpi-emoji">🟢</div>
+            <div>
+              <div class="kpi-label">Najlepsza cena</div>
+              <div class="kpi-value" id="best-price">—</div>
+              <p class="tiny muted" id="best-price-note">Dodaj faktury z litrami</p>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <div class="kpi-emoji">🔴</div>
+            <div>
+              <div class="kpi-label">Najwyższa cena</div>
+              <div class="kpi-value" id="worst-price">—</div>
+              <p class="tiny muted" id="worst-price-note">Dodaj faktury z litrami</p>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <div class="kpi-emoji">💳</div>
+            <div>
+              <div class="kpi-label">Śr. faktura</div>
+              <div class="kpi-value" id="avg-invoice">—</div>
+              <p class="tiny muted" id="avg-invoice-note">Czekamy na nowe dane</p>
+            </div>
+          </div>
+          <div class="insight-bubble" id="kpi-context-bubble">Wprowadź historyczne faktury, aby zobaczyć trend kosztów paliwa.</div>
+        </aside>
+      </div>
     </div>
-  </main>
+  </div>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
@@ -300,24 +371,175 @@ const cancelEditBtn = document.getElementById('cancel-edit-btn');
 const historyTbody = document.getElementById('history-tbody');
 const balanceEl = document.getElementById('fuel-balance');
 const balanceInfoEl = document.getElementById('balance-info');
+const avgPriceEl = document.getElementById('avg-price-12m');
+const avgPriceNoteEl = document.getElementById('avg-price-12m-note');
+const bestPriceEl = document.getElementById('best-price');
+const bestPriceNoteEl = document.getElementById('best-price-note');
+const worstPriceEl = document.getElementById('worst-price');
+const worstPriceNoteEl = document.getElementById('worst-price-note');
+const avgInvoiceEl = document.getElementById('avg-invoice');
+const avgInvoiceNoteEl = document.getElementById('avg-invoice-note');
+const kpiContextBubble = document.getElementById('kpi-context-bubble');
+const fuelInsightBubble = document.getElementById('fuel-kpi-insight');
 const lastInvoiceCard = document.getElementById('last-invoice-card');
 const exportBtn = document.getElementById('export-csv-btn');
 const importBtn = document.getElementById('import-csv-btn');
 const csvFileInput = document.getElementById('csv-file-input');
 const clearAllBtn = document.getElementById('clear-all-btn');
 
+function computeFuelMetrics() {
+    const transactions = Array.isArray(state.transactions) ? state.transactions : [];
+    const invoices = transactions.filter(tx => tx.type === 'invoice');
+    const advances = transactions.filter(tx => tx.type === 'advance');
+
+    const lastYearThreshold = (() => {
+        const d = new Date();
+        d.setHours(0, 0, 0, 0);
+        d.setFullYear(d.getFullYear() - 1);
+        return d;
+    })();
+
+    const invoicesLastYear = invoices.filter(tx => {
+        if (!tx.date) return false;
+        const parsed = new Date(tx.date);
+        if (Number.isNaN(parsed.valueOf())) return false;
+        return parsed >= lastYearThreshold;
+    });
+
+    const costLastYear = invoicesLastYear.reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
+    const litersLastYear = invoicesLastYear.reduce((sum, tx) => sum + (tx.liters || 0), 0);
+    const avgPrice = litersLastYear > 0 ? costLastYear / litersLastYear : 0;
+    const avgInvoice = invoicesLastYear.length > 0 ? costLastYear / invoicesLastYear.length : 0;
+
+    const last30Threshold = new Date();
+    last30Threshold.setDate(last30Threshold.getDate() - 30);
+    const last30Invoices = invoices.filter(tx => tx.date && new Date(tx.date) >= last30Threshold);
+    const last30Cost = last30Invoices.reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
+
+    const bestPriceInvoice = invoices.reduce((best, tx) => {
+        if (!tx.liters) return best;
+        const unitPrice = Math.abs(tx.amount) / tx.liters;
+        if (!best || unitPrice < best.unitPrice) {
+            return { unitPrice, ref: tx.ref, date: tx.date };
+        }
+        return best;
+    }, null);
+
+    const worstPriceInvoice = invoices.reduce((worst, tx) => {
+        if (!tx.liters) return worst;
+        const unitPrice = Math.abs(tx.amount) / tx.liters;
+        if (!worst || unitPrice > worst.unitPrice) {
+            return { unitPrice, ref: tx.ref, date: tx.date };
+        }
+        return worst;
+    }, null);
+
+    const balance = transactions.reduce((acc, tx) => acc + tx.amount, 0);
+    const advancesValue = advances.reduce((sum, tx) => sum + tx.amount, 0);
+
+    const monthlyTotals = invoices.reduce((acc, tx) => {
+        if (!tx.date) return acc;
+        const key = tx.date.slice(0, 7);
+        acc[key] = (acc[key] || 0) + Math.abs(tx.amount);
+        return acc;
+    }, {});
+    const sortedMonths = Object.keys(monthlyTotals).sort();
+    const latestMonthKey = sortedMonths.length ? sortedMonths[sortedMonths.length - 1] : null;
+    const prevMonthKey = sortedMonths.length > 1 ? sortedMonths[sortedMonths.length - 2] : null;
+    const latestTotal = latestMonthKey ? monthlyTotals[latestMonthKey] : 0;
+    const prevTotal = prevMonthKey ? monthlyTotals[prevMonthKey] : 0;
+    let monthDelta = null;
+    if (latestMonthKey) {
+        const diff = latestTotal - prevTotal;
+        const percent = prevTotal ? (diff / prevTotal) * 100 : null;
+        const direction = diff > 0 ? 'up' : (diff < 0 ? 'down' : 'flat');
+        monthDelta = { latestMonthKey, prevMonthKey, latestTotal, prevTotal, diff, percent, direction };
+    }
+
+    const lastInvoice = transactions.find(tx => tx.type === 'invoice' && tx.date);
+
+    return {
+        balance,
+        advancesValue,
+        invoicesLastYearCount: invoicesLastYear.length,
+        litersLastYear,
+        avgPrice,
+        avgInvoice,
+        bestPriceInvoice,
+        worstPriceInvoice,
+        last30Cost,
+        last30InvoicesCount: last30Invoices.length,
+        monthDelta,
+        lastInvoice,
+        costLastYear,
+        monthlyTotals
+    };
+}
 
 function render() {
     state.transactions = normalizeTransactions(state.transactions || []);
     state.transactions.sort((a,b) => (b.date || '').localeCompare(a.date || ''));
-    
-    // Render Balance and Last Invoice
-    const totalBalance = state.transactions.reduce((acc, tx) => acc + tx.amount, 0);
-    balanceEl.textContent = fmt(totalBalance);
-    balanceEl.className = `value ${totalBalance >= 0 ? 'ok' : 'bad'}`;
-    balanceInfoEl.textContent = totalBalance >= 0 ? 'Masz jeszcze środki z zaliczki do wykorzystania' : 'Musisz zwrócić pieniądze firmie';
-    
-    const lastInvoice = state.transactions.find(tx => tx.type === 'invoice' && tx.date);
+
+    const metrics = computeFuelMetrics();
+
+    // Render KPI rail
+    balanceEl.textContent = fmt(metrics.balance);
+    balanceEl.className = `kpi-value ${metrics.balance >= 0 ? 'ok' : 'bad'}`;
+    balanceInfoEl.textContent = metrics.balance >= 0
+        ? 'Masz jeszcze środki z zaliczki do wykorzystania'
+        : 'Musisz zwrócić pieniądze firmie';
+
+    if (metrics.avgPrice > 0) {
+        avgPriceEl.textContent = fmt(metrics.avgPrice, 'PLN/L');
+        avgPriceNoteEl.textContent = `${metrics.litersLastYear.toFixed(1)} L w ${metrics.invoicesLastYearCount} fakturach (12 mies.)`;
+    } else {
+        avgPriceEl.textContent = '—';
+        avgPriceNoteEl.textContent = 'Brak danych z ostatniego roku';
+    }
+
+    if (metrics.bestPriceInvoice) {
+        bestPriceEl.textContent = fmt(metrics.bestPriceInvoice.unitPrice, 'PLN/L');
+        const bestLabel = metrics.bestPriceInvoice.ref || 'Faktura';
+        bestPriceNoteEl.textContent = `${bestLabel} • ${metrics.bestPriceInvoice.date}`;
+    } else {
+        bestPriceEl.textContent = '—';
+        bestPriceNoteEl.textContent = 'Dodaj faktury z litrami';
+    }
+
+    if (metrics.worstPriceInvoice) {
+        worstPriceEl.textContent = fmt(metrics.worstPriceInvoice.unitPrice, 'PLN/L');
+        const worstLabel = metrics.worstPriceInvoice.ref || 'Faktura';
+        worstPriceNoteEl.textContent = `${worstLabel} • ${metrics.worstPriceInvoice.date}`;
+    } else {
+        worstPriceEl.textContent = '—';
+        worstPriceNoteEl.textContent = 'Dodaj faktury z litrami';
+    }
+
+    if (metrics.avgInvoice > 0) {
+        avgInvoiceEl.textContent = fmt(metrics.avgInvoice);
+        avgInvoiceNoteEl.textContent = `${metrics.invoicesLastYearCount} faktur w ostatnich 12 mies.`;
+    } else {
+        avgInvoiceEl.textContent = '—';
+        avgInvoiceNoteEl.textContent = metrics.advancesValue > 0
+            ? `Zaliczki: ${fmt(metrics.advancesValue)}`
+            : 'Czekamy na nowe dane';
+    }
+
+    if (metrics.monthDelta && metrics.monthDelta.percent !== null) {
+        const directionWord = metrics.monthDelta.direction === 'down' ? 'spadły' : (metrics.monthDelta.direction === 'up' ? 'wzrosły' : 'pozostały bez zmian');
+        const percentText = `${Math.abs(metrics.monthDelta.percent).toFixed(1)}%`;
+        const compareLabel = metrics.monthDelta.prevMonthKey ? ` vs ${metrics.monthDelta.prevMonthKey}` : '';
+        kpiContextBubble.textContent = `Wydatki m/m ${directionWord} o ${percentText}${compareLabel}.`;
+    } else if (metrics.monthDelta && metrics.monthDelta.diff) {
+        const directionWord = metrics.monthDelta.diff < 0 ? 'spadły' : 'wzrosły';
+        kpiContextBubble.textContent = `Wydatki m/m ${directionWord} o ${fmt(Math.abs(metrics.monthDelta.diff))}.`;
+    } else if (metrics.last30Cost > 0) {
+        kpiContextBubble.textContent = `Ostatnie 30 dni kosztowały ${fmt(metrics.last30Cost)} (${metrics.last30InvoicesCount} faktur).`;
+    } else {
+        kpiContextBubble.textContent = 'Wprowadź historyczne faktury, aby zobaczyć trend kosztów paliwa.';
+    }
+
+    const lastInvoice = metrics.lastInvoice;
     if (lastInvoice) {
         const daysSince = Math.floor((new Date() - new Date(lastInvoice.date)) / (1000 * 60 * 60 * 24));
         const litersValue = typeof lastInvoice.liters === 'number' ? lastInvoice.liters : num(lastInvoice.liters);
@@ -372,107 +594,78 @@ function render() {
         };
     });
 
-    renderInsightsSection();
+    renderInsightsSection(metrics);
     renderMonthlySummary();
     renderAnalytics();
 }
 
-function renderInsightsSection() {
+function renderInsightsSection(metrics) {
     const grid = document.getElementById('insights-grid');
     if (!grid) return;
 
     if (!state.transactions.length) {
         grid.innerHTML = '<p class="tiny muted">Dodaj pierwszą transakcję, aby zobaczyć kluczowe wskaźniki.</p>';
+        if (fuelInsightBubble) {
+            fuelInsightBubble.textContent = 'Gdy pojawią się pierwsze faktury pokażemy tu dynamikę kosztów.';
+        }
         return;
     }
 
-    const invoices = state.transactions.filter(tx => tx.type === 'invoice');
-    const advances = state.transactions.filter(tx => tx.type === 'advance');
-    const lastYearThreshold = (() => {
-        const d = new Date();
-        d.setHours(0, 0, 0, 0);
-        d.setFullYear(d.getFullYear() - 1);
-        return d;
-    })();
-
-    const invoicesLastYear = invoices.filter(tx => {
-        if (!tx.date) return false;
-        const parsed = new Date(tx.date);
-        if (Number.isNaN(parsed.valueOf())) return false;
-        return parsed >= lastYearThreshold;
-    });
-
-    const costLastYear = invoicesLastYear.reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
-    const litersLastYear = invoicesLastYear.reduce((sum, tx) => sum + (tx.liters || 0), 0);
-    const avgPrice = litersLastYear > 0 ? costLastYear / litersLastYear : 0;
-    const avgInvoice = invoicesLastYear.length > 0 ? costLastYear / invoicesLastYear.length : 0;
-
-    const last30Threshold = new Date();
-    last30Threshold.setDate(last30Threshold.getDate() - 30);
-    const last30Invoices = invoices.filter(tx => tx.date && new Date(tx.date) >= last30Threshold);
-    const last30Cost = last30Invoices.reduce((sum, tx) => sum + Math.abs(tx.amount), 0);
-
-    const bestPriceInvoice = invoices.reduce((best, tx) => {
-        if (!tx.liters) return best;
-        const unitPrice = Math.abs(tx.amount) / tx.liters;
-        if (!best || unitPrice < best.unitPrice) {
-            return { unitPrice, ref: tx.ref, date: tx.date };
-        }
-        return best;
-    }, null);
-
-    const worstPriceInvoice = invoices.reduce((worst, tx) => {
-        if (!tx.liters) return worst;
-        const unitPrice = Math.abs(tx.amount) / tx.liters;
-        if (!worst || unitPrice > worst.unitPrice) {
-            return { unitPrice, ref: tx.ref, date: tx.date };
-        }
-        return worst;
-    }, null);
-
-    const balance = state.transactions.reduce((acc, tx) => acc + tx.amount, 0);
-    const advancesValue = advances.reduce((sum, tx) => sum + tx.amount, 0);
+    const monthEntries = metrics.monthlyTotals ? Object.entries(metrics.monthlyTotals) : [];
+    const referenceStart = '2022-01';
+    const recentEntries = monthEntries.filter(([month]) => month >= referenceStart);
+    const monthsWithData = recentEntries.length;
+    const totalMonthlyCost = recentEntries.reduce((sum, [, value]) => sum + value, 0);
+    const avgMonthlyCost = monthsWithData ? totalMonthlyCost / monthsWithData : 0;
 
     const cards = [
         {
-            label: 'Średnia cena za litr',
-            value: litersLastYear > 0 ? fmt(avgPrice, 'PLN/L') : '—',
-            note: litersLastYear > 0 ? `${litersLastYear.toFixed(1)} L w ${invoicesLastYear.length} fakturach (12 mies.)` : 'Brak danych z ostatniego roku'
-        },
-        {
             label: 'Koszt ostatnich 30 dni',
-            value: last30Invoices.length ? fmt(last30Cost) : '—',
-            note: last30Invoices.length ? `${last30Invoices.length} tankowania` : 'Brak nowych faktur'
+            value: metrics.last30Cost > 0 ? fmt(metrics.last30Cost) : '—',
+            note: metrics.last30InvoicesCount ? `${metrics.last30InvoicesCount} faktur w tym okresie` : 'Brak nowych faktur'
         },
         {
-            label: 'Najlepsza cena',
-            value: bestPriceInvoice ? fmt(bestPriceInvoice.unitPrice, 'PLN/L') : '—',
-            note: bestPriceInvoice ? `${bestPriceInvoice.ref || 'Faktura'} (${bestPriceInvoice.date})` : 'Brak danych o litrach'
+            label: 'Śr. miesięczny koszt',
+            value: avgMonthlyCost > 0 ? fmt(avgMonthlyCost) : '—',
+            note: monthsWithData ? `${monthsWithData} mies. z fakturami` : 'Dodaj więcej danych do analizy'
         },
         {
-            label: 'Najwyższa cena',
-            value: worstPriceInvoice ? fmt(worstPriceInvoice.unitPrice, 'PLN/L') : '—',
-            note: worstPriceInvoice ? `${worstPriceInvoice.ref || 'Faktura'} (${worstPriceInvoice.date})` : 'Brak danych o litrach'
-        },
-        {
-            label: 'Śr. kwota faktury',
-            value: invoicesLastYear.length ? fmt(avgInvoice) : '—',
-            note: invoicesLastYear.length ? `${invoicesLastYear.length} faktur z ostatnich 12 miesięcy` : (advances.length ? `${advances.length} zaliczek na ${fmt(advancesValue)}` : 'Brak danych z ostatniego roku')
-        },
-        {
-            label: 'Saldo rozliczeń',
-            value: fmt(balance),
-            note: balance >= 0 ? 'Pozostałe środki z zaliczki' : 'Do zwrotu dla firmy'
+            label: 'Zaliczki przyjęte',
+            value: metrics.advancesValue > 0 ? fmt(metrics.advancesValue) : '—',
+            note: metrics.advancesValue > 0 ? 'Wliczone w saldo rozliczeń' : 'Brak nowych zaliczek'
         }
     ];
 
+    if (metrics.costLastYear > 0) {
+        cards.push({
+            label: 'Łączny koszt (12 mies.)',
+            value: fmt(metrics.costLastYear),
+            note: `${metrics.invoicesLastYearCount} faktur w roku`
+        });
+    }
+
     grid.innerHTML = cards.map(card => `
-        <div class="insight-card">
+        <div class="fuel-insight-card">
             <div class="label">${card.label}</div>
             <div class="value">${card.value}</div>
             <div class="note">${card.note}</div>
         </div>
     `).join('');
+
+    if (fuelInsightBubble) {
+        if (metrics.bestPriceInvoice && metrics.worstPriceInvoice) {
+            const spread = metrics.worstPriceInvoice.unitPrice - metrics.bestPriceInvoice.unitPrice;
+            const spreadText = spread > 0 ? fmt(spread, 'PLN/L') : fmt(0, 'PLN/L');
+            fuelInsightBubble.textContent = `Różnica pomiędzy najlepszą a najdroższą ceną paliwa to ${spreadText}.`;
+        } else if (metrics.monthDelta && metrics.monthDelta.diff) {
+            const directionWord = metrics.monthDelta.diff < 0 ? 'spadły' : 'wzrosły';
+            fuelInsightBubble.textContent = `Wydatki miesiąc do miesiąca ${directionWord} o ${fmt(Math.abs(metrics.monthDelta.diff))}.`;
+        } else if (metrics.last30Cost > 0) {
+            fuelInsightBubble.textContent = `W ciągu 30 dni zatankowano za ${fmt(metrics.last30Cost)}.`;
+        } else {
+            fuelInsightBubble.textContent = 'Dodaj litraż przy fakturach, by porównać ceny za litr.';
+        }
+    }
 }
 
 function renderMonthlySummary() {

--- a/house.html
+++ b/house.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BuildMaster Pro — Centrum Zarządzania Budową</title>
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
@@ -1940,51 +1940,81 @@
     }
   </style>
 </head>
-<body class="module-shell">
-  <section class="module-hero">
-    <div class="wrap module-hero-inner">
-      <div class="module-hero-top">
-        <div>
-          <a href="index.html" class="back-link">← Powrót</a>
-          <div class="module-eyebrow">Dom i budowa</div>
-          <h1 class="module-title">BuildMaster Pro</h1>
-          <p class="module-subtitle">Monitoruj postęp projektu domu, kontroluj budżet i reaguj na zagrożenia w jednym miejscu.</p>
+<body data-page="house">
+  <div class="app-shell">
+    <aside class="sidebar" aria-label="Główna nawigacja">
+      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
+        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
+        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
+        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
+        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
+        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
+        <a class="nav-link active" href="house.html" aria-current="page"><span class="icon">🏠</span><span>Budowa</span></a>
+        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      </nav>
+      <div class="sidebar-footer">
+        <strong>Twój cyfrowy dom</strong>
+        Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
+      </div>
+    </aside>
+
+    <div class="app-main">
+      <header class="topbar">
+        <div class="topbar-info">
+          <p class="topbar-eyebrow">Dom i budowa</p>
+          <h1 class="topbar-title">BuildMaster Pro</h1>
+          <p class="topbar-subtitle">Monitoruj postęp projektu domu, kontroluj budżet i reaguj na zagrożenia w jednym miejscu.</p>
         </div>
-        <div class="module-hero-actions house-hero-actions">
+        <div class="topbar-actions house-hero-actions">
           <button class="btn soft" type="button" onclick="exportData()">📥 Eksport</button>
           <button class="btn soft" type="button" onclick="importData()">📤 Import</button>
           <button class="btn soft" type="button" onclick="generateReport()">📋 Raport</button>
           <button class="btn soft" type="button" onclick="openSettingsModal()">⚙️ Ustawienia</button>
           <button class="btn ghost icon-btn" id="theme-toggle" type="button" onclick="toggleTheme()">🌙</button>
         </div>
-      </div>
-      <div class="module-hero-stats">
-        <div class="module-hero-stat">
-          <div class="label">Postęp projektu</div>
-          <div class="value" id="hero-progress">0%</div>
-          <div class="note" id="hero-progress-note">Średnia ukończenia zadań</div>
-        </div>
-        <div class="module-hero-stat">
-          <div class="label">Wydatki</div>
-          <div class="value" id="hero-budget">0 zł</div>
-          <div class="note" id="hero-budget-note">z planowanego budżetu</div>
-        </div>
-        <div class="module-hero-stat">
-          <div class="label">Opóźnienia</div>
-          <div class="value" id="hero-overdue">0</div>
-          <div class="note" id="hero-overdue-note">Zadań po terminie</div>
-        </div>
-        <div class="module-hero-stat">
-          <div class="label">Do terminu</div>
-          <div class="value" id="hero-timeline">—</div>
-          <div class="note" id="hero-timeline-note">Brak planowanej daty zakończenia</div>
-        </div>
-      </div>
-    </div>
-  </section>
+      </header>
 
-  <main class="module-content">
-    <div class="wrap">
+      <section class="module-hero">
+        <div class="wrap module-hero-inner">
+          <div class="module-hero-top">
+            <div>
+              <div class="module-eyebrow">Stan projektu</div>
+              <p class="module-subtitle">Najważniejsze wskaźniki Twojej budowy.</p>
+            </div>
+            <div class="module-hero-actions">
+              <span class="badge">🏗️ Budowa</span>
+              <span class="badge">📊 Kontrola budżetu</span>
+            </div>
+          </div>
+          <div class="module-hero-stats">
+            <div class="module-hero-stat">
+              <div class="label">Postęp projektu</div>
+              <div class="value" id="hero-progress">0%</div>
+              <div class="note" id="hero-progress-note">Średnia ukończenia zadań</div>
+            </div>
+            <div class="module-hero-stat">
+              <div class="label">Wydatki</div>
+              <div class="value" id="hero-budget">0 zł</div>
+              <div class="note" id="hero-budget-note">z planowanego budżetu</div>
+            </div>
+            <div class="module-hero-stat">
+              <div class="label">Opóźnienia</div>
+              <div class="value" id="hero-overdue">0</div>
+              <div class="note" id="hero-overdue-note">Zadań po terminie</div>
+            </div>
+            <div class="module-hero-stat">
+              <div class="label">Do terminu</div>
+              <div class="value" id="hero-timeline">—</div>
+              <div class="note" id="hero-timeline-note">Brak planowanej daty zakończenia</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <main class="page-content">
+        <div class="wrap">
       <nav class="page-tabs house-tabs" id="nav-menu">
         <button type="button" class="page-tab active" data-tab="dashboard"><span class="nav-icon">📊</span><span>Panel główny</span></button>
         <button type="button" class="page-tab" data-tab="timeline"><span class="nav-icon">📅</span><span>Harmonogram</span></button>
@@ -2297,7 +2327,9 @@
       </div>
       </div>
     </div>
-  </main>
+      </main>
+    </div>
+  </div>
 
   <!-- Quick Actions -->
   <div class="quick-actions">

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
   </style>
 </head>
 <body data-page="dashboard">
-  <div class="app-shell">
+  <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
       <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
       <nav class="sidebar-nav">
@@ -181,104 +181,104 @@
       </div>
     </aside>
 
-    <div class="app-main">
-      <header class="topbar hero-header">
-        <div class="hero-content">
-          <div class="hero-copy">
-            <p class="topbar-eyebrow">Twój dzień w skrócie</p>
-            <h1 id="greeting" class="greeting-text">Dzień dobry!</h1>
-            <p id="current-date" class="date-text"></p>
-            <p id="dynamic-message" class="dynamic-message"></p>
+    <div class="main">
+      <header class="topbar">
+        <div class="stack" style="gap:6px;">
+          <p class="topbar-eyebrow">Twój dzień w skrócie</p>
+          <h1 class="topbar-title">Dashboard</h1>
+          <div class="tiny muted" style="display:flex; flex-direction:column; gap:2px;">
+            <span id="greeting">Dzień dobry!</span>
+            <span id="current-date"></span>
           </div>
-          <div class="quick-actions">
-            <a href="#" class="quick-action" title="Ustawienia" onclick="openSettingsModal()">⚙️</a>
-            <a href="#" class="quick-action" title="Odśwież" onclick="refreshDashboard()">↻</a>
-          </div>
+          <p id="dynamic-message" class="tiny"></p>
+        </div>
+        <div class="topbar-actions" role="toolbar" aria-label="Akcje dashboardu">
+          <button class="btn ghost" type="button" title="Odśwież" onclick="refreshDashboard()">↻ Odśwież</button>
+          <button class="btn ghost" type="button" title="Ustawienia" onclick="openSettingsModal()">⚙️ Ustawienia</button>
         </div>
       </header>
 
-      <main class="page-content">
-        <div class="wrap">
-          <div class="page-columns">
-            <section class="stack tight">
-              <div class="card">
-                <h3 class="title">📊 Kluczowe wskaźniki</h3>
-                <div class="grid g-2 kpi-grid">
-                  <a href="budget.html" id="kpi-budget" class="kpi-tile-large"></a>
-                  <a href="fuel.html" id="kpi-fuel" class="kpi-tile-large"></a>
-                  <a href="tasks.html" id="kpi-tasks" class="kpi-tile-large"></a>
-                  <a href="trainings.html" id="kpi-progress" class="kpi-tile-large"></a>
-                  <a href="house.html" id="kpi-house" class="kpi-tile-large"></a>
-                  <a href="loan.html" id="kpi-loan" class="kpi-tile-large"></a>
-                </div>
-              </div>
-
-              <div class="card">
-                <h3 class="title">🎯 Cele treningowe na ten tydzień</h3>
-                <div id="weekly-activities-list" class="activity-feed"></div>
-              </div>
-
-              <div class="card">
-                <h3 class="title">🗂️ Moduły</h3>
-                <div class="grid modules-grid" style="margin-top: 14px;">
-                  <a class="tile" href="budget.html">
-                    <div class="pill">💰 Budżet</div>
-                    <div style="font-weight: 600;">Finanse</div>
-                    <div class="tiny muted">Zarządzaj wydatkami</div>
-                  </a>
-                  <a class="tile" href="fuel.html">
-                    <div class="pill">⛽ Paliwo</div>
-                    <div style="font-weight: 600;">Rozliczenia</div>
-                    <div class="tiny muted">Tankowania i faktury</div>
-                  </a>
-                  <a class="tile" href="tasks.html">
-                    <div class="pill">✅ Zadania</div>
-                    <div style="font-weight: 600;">Organizacja</div>
-                    <div class="tiny muted">Listy i kalendarz</div>
-                  </a>
-                  <a class="tile" href="trainings.html">
-                    <div class="pill">💪 Treningi</div>
-                    <div style="font-weight: 600;">Cele</div>
-                    <div class="tiny muted">Plany i progres</div>
-                  </a>
-                  <a class="tile" href="house.html">
-                    <div class="pill">🏗️ Budowa</div>
-                    <div style="font-weight: 600;">Projekt</div>
-                    <div class="tiny muted">Kontroluj budowę</div>
-                  </a>
-                  <a class="tile" href="loan.html">
-                    <div class="pill">🏦 Kredyt</div>
-                    <div style="font-weight: 600;">Spłata</div>
-                    <div class="tiny muted">Monitoruj postępy</div>
-                  </a>
-                </div>
-                <div style="border-top: 1px solid var(--line); margin: 18px 0;"></div>
-                <h3 class="title" style="margin-bottom: 10px;">💾 Zarządzanie Danymi</h3>
-                <div class="grid g-2" style="gap: 10px;">
-                  <button class="btn" id="export-all-btn">📤 Eksportuj wszystko</button>
-                  <button class="btn" id="import-all-btn">📥 Importuj wszystko</button>
-                  <input type="file" id="import-file-input" style="display:none" accept="application/json"/>
-                </div>
-                <p id="backup-status" class="tiny" style="margin-top: 12px; text-align: center;"></p>
-              </div>
+      <div class="content">
+        <main class="page-content content-main stack">
+          <div class="grid-2" style="align-items: start;">
+            <section class="card stack">
+              <h3 class="title">🎯 Cele treningowe na ten tydzień</h3>
+              <div id="weekly-activities-list" class="activity-feed"></div>
             </section>
-
-            <aside class="stack tight">
-              <div class="card weather-widget" id="weather-widget" aria-live="polite">
-                <!-- Weather content will be dynamically inserted here -->
+            <section class="card priorities-card" id="priorities-card">
+              <div class="upcoming-header">
+                <h3 class="title" style="margin:0;">📅 Najbliższe zadania</h3>
+                <p id="priorities-summary" class="tiny muted" style="margin:0;"></p>
               </div>
-              <div class="card priorities-card" id="priorities-card">
-                <div class="upcoming-header">
-                  <h3 class="title" style="margin:0;">📅 Najbliższe zadania</h3>
-                  <p id="priorities-summary" class="tiny muted" style="margin:0;"></p>
-                </div>
-                <div id="upcoming-tasks-list"></div>
-                <a href="tasks.html" class="btn" style="margin-top: 14px;">Zobacz wszystkie</a>
-              </div>
-            </aside>
+              <div id="upcoming-tasks-list"></div>
+              <a href="tasks.html" class="btn" style="margin-top: 14px;">Zobacz wszystkie</a>
+            </section>
+            <section class="card stack">
+              <h3 class="title">💸 Wydatki dzienne</h3>
+              <div id="budget-daily-feed" class="stack" style="gap:8px;"></div>
+            </section>
           </div>
-        </div>
-      </main>
+
+          <section class="card">
+            <h3 class="title">🗂️ Moduły</h3>
+            <div class="grid modules-grid" style="margin-top: 14px;">
+              <a class="tile" href="budget.html">
+                <div class="pill">💰 Budżet</div>
+                <div style="font-weight: 600;">Finanse</div>
+                <div class="tiny muted">Zarządzaj wydatkami</div>
+              </a>
+              <a class="tile" href="fuel.html">
+                <div class="pill">⛽ Paliwo</div>
+                <div style="font-weight: 600;">Rozliczenia</div>
+                <div class="tiny muted">Tankowania i faktury</div>
+              </a>
+              <a class="tile" href="tasks.html">
+                <div class="pill">✅ Zadania</div>
+                <div style="font-weight: 600;">Organizacja</div>
+                <div class="tiny muted">Listy i kalendarz</div>
+              </a>
+              <a class="tile" href="trainings.html">
+                <div class="pill">💪 Treningi</div>
+                <div style="font-weight: 600;">Cele</div>
+                <div class="tiny muted">Plany i progres</div>
+              </a>
+              <a class="tile" href="house.html">
+                <div class="pill">🏗️ Budowa</div>
+                <div style="font-weight: 600;">Projekt</div>
+                <div class="tiny muted">Kontroluj budowę</div>
+              </a>
+              <a class="tile" href="loan.html">
+                <div class="pill">🏦 Kredyt</div>
+                <div style="font-weight: 600;">Spłata</div>
+                <div class="tiny muted">Monitoruj postępy</div>
+              </a>
+            </div>
+          </section>
+
+          <section class="card">
+            <h3 class="title">💾 Zarządzanie Danymi</h3>
+            <div class="grid g-2" style="gap: 10px;">
+              <button class="btn" id="export-all-btn">📤 Eksportuj wszystko</button>
+              <button class="btn" id="import-all-btn">📥 Importuj wszystko</button>
+              <input type="file" id="import-file-input" style="display:none" accept="application/json"/>
+            </div>
+            <p id="backup-status" class="tiny" style="margin-top: 12px; text-align: center;"></p>
+          </section>
+        </main>
+
+        <aside class="right-rail">
+          <div class="insight-bubble">
+            📌 Dane ze wszystkich modułów odświeżaj regularnie, aby mieć pełny obraz sytuacji.
+          </div>
+          <a href="budget.html" id="kpi-budget" class="kpi-tile-large"></a>
+          <a href="fuel.html" id="kpi-fuel" class="kpi-tile-large"></a>
+          <a href="tasks.html" id="kpi-tasks" class="kpi-tile-large"></a>
+          <a href="trainings.html" id="kpi-progress" class="kpi-tile-large"></a>
+          <a href="house.html" id="kpi-house" class="kpi-tile-large"></a>
+          <a href="loan.html" id="kpi-loan" class="kpi-tile-large"></a>
+          <div class="card weather-widget" id="weather-widget" aria-live="polite"></div>
+        </aside>
+      </div>
     </div>
   </div>
 
@@ -613,6 +613,10 @@ function renderKPIData(){
       house: document.getElementById('kpi-house'),
       loan: document.getElementById('kpi-loan'),
   };
+  const budgetFeed = document.getElementById('budget-daily-feed');
+  if(budgetFeed){
+    budgetFeed.innerHTML = '<p class="tiny muted">Ładowanie danych budżetu...</p>';
+  }
 
   // --- Budget KPI ---
   const budgetRaw = localStorage.getItem(BUDGET_STORAGE_KEY);
@@ -627,25 +631,40 @@ function renderKPIData(){
       const incSum = incomes.reduce((s,x)=> s+num(x.amount),0);
       const fixSum = fixed.reduce((s,x)=> s+num(x.amount),0);
       const daysInMonth = new Date(ym.split('-')[0], ym.split('-')[1], 0).getDate();
-      const currentDay = new Date().getDate();
+      const today = new Date();
+      const currentDay = today.getDate();
+      const todayStr = today.toISOString().slice(0,10);
 
       const dailyBudget = Math.max(0, (incSum - fixSum)/daysInMonth);
       const budgetForToday = dailyBudget * currentDay;
 
       const catsById = Object.fromEntries((Array.isArray(bState?.categories)?bState.categories:[]).map(c=>[c.id,c]));
       const txs = Array.isArray(bState?.transactions) ? bState.transactions : [];
-      const spentUntilToday = txs.filter(t=> String(t.date||'').startsWith(ym) && new Date(t.date).getDate()<=currentDay).reduce((sum,t)=>{
-        if(t.splits?.length){ return sum + t.splits.reduce((ss,sp)=>{ const cat=catsById[sp.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving') && cat.id!=='c_fixed') ? ss+Math.abs(num(sp.amount)) : ss },0) }
-        const cat=catsById[t.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving') && cat.id!=='c_fixed') ? sum+Math.abs(num(t.amount)) : sum
-      },0);
+      const expenseAmount = (tx) => {
+        if(!tx) return 0;
+        if(Array.isArray(tx.splits) && tx.splits.length){
+          return tx.splits.reduce((acc, sp)=>{
+            const cat = catsById[sp.categoryId];
+            return (cat && (cat.type==='expense' || cat.type==='saving') && cat.id!=='c_fixed') ? acc + Math.abs(num(sp.amount)) : acc;
+          },0);
+        }
+        const cat = catsById[tx.categoryId];
+        return (cat && (cat.type==='expense' || cat.type==='saving') && cat.id!=='c_fixed') ? Math.abs(num(tx.amount)) : 0;
+      };
+
+      const spentUntilToday = txs
+        .filter(t=> String(t.date||'').startsWith(ym) && new Date(t.date).getDate()<=currentDay)
+        .reduce((sum,t)=> sum + expenseAmount(t),0);
 
       const buffer = budgetForToday - spentUntilToday;
       const bufferClass = buffer > budgetForToday * 0.2 ? 'value-ok' : buffer >= 0 ? 'value-warn' : 'value-bad';
 
-      const totalSpentMonth = txs.filter(t=> String(t.date||'').startsWith(ym)).reduce((sum,t)=>{
-        if(t.splits?.length){ return sum + t.splits.reduce((ss,sp)=>{ const cat=catsById[sp.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving')) ? ss+Math.abs(num(sp.amount)) : ss },0) }
-        const cat=catsById[t.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving')) ? sum+Math.abs(num(t.amount)) : sum
-      },0);
+      const totalSpentMonth = txs
+        .filter(t=> String(t.date||'').startsWith(ym))
+        .reduce((sum,t)=> sum + expenseAmount(t),0);
+      const todaySpent = txs
+        .filter(t=> String(t.date||'') === todayStr)
+        .reduce((sum,t)=> sum + expenseAmount(t),0);
       const monthlyBudget = incSum;
       const spentPct = monthlyBudget > 0 ? (totalSpentMonth / monthlyBudget) * 100 : 0;
 
@@ -664,15 +683,33 @@ function renderKPIData(){
           </div>
           <div class="progress"><i style="width:${spentPct}%"></i></div>
         </div>`;
+      if(budgetFeed){
+        const statusText = buffer >= 0 ? 'Jesteś w limicie dziennym.' : 'Limit dzienny przekroczony.';
+        const statusClass = buffer >= 0 ? 'value-ok' : 'value-bad';
+        budgetFeed.innerHTML = `
+          <div class="tiny muted">Dzień ${currentDay} z ${daysInMonth}</div>
+          <div class="kpi-value ${bufferClass}" style="font-size:20px;">${fmt(buffer)}</div>
+          <div class="tiny muted">Bufor na dziś</div>
+          <div class="tiny">Wydano dziś: <strong>${fmt(todaySpent)}</strong> z ${fmt(dailyBudget)}.</div>
+          <div class="tiny muted">Miesiąc: ${fmt(totalSpentMonth)} / ${fmt(monthlyBudget)} (${Math.round(spentPct)}%).</div>
+          <div class="tiny ${statusClass}" style="margin-top:4px;">${statusText}</div>
+        `;
+      }
     } else {
       kpiElements.budget.innerHTML = `
         <div class="kpi-header"><span>💰</span><h4>Budżet</h4></div>
         <div class="kpi-main-value">—</div>
         <div class="kpi-details">${renderDetailLines(['Brak danych na ten miesiąc.'])}</div>
         <div class="kpi-progress-container"></div>`;
+      if(budgetFeed){
+        budgetFeed.innerHTML = '<p class="tiny muted">Brak danych na ten miesiąc.</p>';
+      }
     }
   } else {
     kpiElements.budget.innerHTML = `<div class="kpi-header"><span>💰</span><h4>Budżet</h4></div><div class="kpi-details">${renderDetailLines(['Brak danych.'])}</div>`;
+    if(budgetFeed){
+      budgetFeed.innerHTML = '<p class="tiny muted">Dodaj transakcje, aby zobaczyć dzienny przegląd.</p>';
+    }
   }
 
   // --- Fuel KPI ---

--- a/index.html
+++ b/index.html
@@ -199,84 +199,53 @@
       </header>
 
       <div class="content">
-        <main class="page-content content-main stack">
+        <main class="page-content content-main stack" style="gap: 20px;">
+          <section class="stack" style="gap: 16px;">
+            <div class="grid kpi-grid">
+              <a href="budget.html" id="kpi-budget" class="kpi-compact"></a>
+              <a href="fuel.html" id="kpi-fuel" class="kpi-compact"></a>
+              <a href="tasks.html" id="kpi-tasks" class="kpi-compact"></a>
+              <a href="trainings.html" id="kpi-progress" class="kpi-compact"></a>
+              <a href="house.html" id="kpi-house" class="kpi-compact"></a>
+              <a href="loan.html" id="kpi-loan" class="kpi-compact"></a>
+            </div>
+            <div class="insight-bubble">
+              📌 Dane ze wszystkich modułów odświeżaj regularnie, aby mieć pełny obraz sytuacji.
+            </div>
+          </section>
+
+          <section class="card stack">
+            <h3 class="title">💸 Wydatki dzienne</h3>
+            <div id="budget-daily-feed" class="stack" style="gap:8px;"></div>
+          </section>
+
           <div class="grid-2" style="align-items: start;">
             <section class="card stack">
               <h3 class="title">🎯 Cele treningowe na ten tydzień</h3>
               <div id="weekly-activities-list" class="activity-feed"></div>
             </section>
-            <section class="card priorities-card" id="priorities-card">
-              <div class="upcoming-header">
-                <h3 class="title" style="margin:0;">📅 Najbliższe zadania</h3>
-                <p id="priorities-summary" class="tiny muted" style="margin:0;"></p>
-              </div>
-              <div id="upcoming-tasks-list"></div>
-              <a href="tasks.html" class="btn" style="margin-top: 14px;">Zobacz wszystkie</a>
-            </section>
             <section class="card stack">
-              <h3 class="title">💸 Wydatki dzienne</h3>
-              <div id="budget-daily-feed" class="stack" style="gap:8px;"></div>
+              <h3 class="title">💾 Zarządzanie danymi</h3>
+              <div class="grid" style="gap: 10px; grid-template-columns: repeat(2, minmax(0, 1fr));">
+                <button class="btn" id="export-all-btn">📤 Eksportuj wszystko</button>
+                <button class="btn" id="import-all-btn">📥 Importuj wszystko</button>
+                <input type="file" id="import-file-input" style="display:none" accept="application/json"/>
+              </div>
+              <p id="backup-status" class="tiny muted" style="margin-top: 8px; text-align: center;"></p>
             </section>
           </div>
-
-          <section class="card">
-            <h3 class="title">🗂️ Moduły</h3>
-            <div class="grid modules-grid" style="margin-top: 14px;">
-              <a class="tile" href="budget.html">
-                <div class="pill">💰 Budżet</div>
-                <div style="font-weight: 600;">Finanse</div>
-                <div class="tiny muted">Zarządzaj wydatkami</div>
-              </a>
-              <a class="tile" href="fuel.html">
-                <div class="pill">⛽ Paliwo</div>
-                <div style="font-weight: 600;">Rozliczenia</div>
-                <div class="tiny muted">Tankowania i faktury</div>
-              </a>
-              <a class="tile" href="tasks.html">
-                <div class="pill">✅ Zadania</div>
-                <div style="font-weight: 600;">Organizacja</div>
-                <div class="tiny muted">Listy i kalendarz</div>
-              </a>
-              <a class="tile" href="trainings.html">
-                <div class="pill">💪 Treningi</div>
-                <div style="font-weight: 600;">Cele</div>
-                <div class="tiny muted">Plany i progres</div>
-              </a>
-              <a class="tile" href="house.html">
-                <div class="pill">🏗️ Budowa</div>
-                <div style="font-weight: 600;">Projekt</div>
-                <div class="tiny muted">Kontroluj budowę</div>
-              </a>
-              <a class="tile" href="loan.html">
-                <div class="pill">🏦 Kredyt</div>
-                <div style="font-weight: 600;">Spłata</div>
-                <div class="tiny muted">Monitoruj postępy</div>
-              </a>
-            </div>
-          </section>
-
-          <section class="card">
-            <h3 class="title">💾 Zarządzanie Danymi</h3>
-            <div class="grid g-2" style="gap: 10px;">
-              <button class="btn" id="export-all-btn">📤 Eksportuj wszystko</button>
-              <button class="btn" id="import-all-btn">📥 Importuj wszystko</button>
-              <input type="file" id="import-file-input" style="display:none" accept="application/json"/>
-            </div>
-            <p id="backup-status" class="tiny" style="margin-top: 12px; text-align: center;"></p>
-          </section>
         </main>
 
         <aside class="right-rail">
-          <div class="insight-bubble">
-            📌 Dane ze wszystkich modułów odświeżaj regularnie, aby mieć pełny obraz sytuacji.
-          </div>
-          <a href="budget.html" id="kpi-budget" class="kpi-tile-large"></a>
-          <a href="fuel.html" id="kpi-fuel" class="kpi-tile-large"></a>
-          <a href="tasks.html" id="kpi-tasks" class="kpi-tile-large"></a>
-          <a href="trainings.html" id="kpi-progress" class="kpi-tile-large"></a>
-          <a href="house.html" id="kpi-house" class="kpi-tile-large"></a>
-          <a href="loan.html" id="kpi-loan" class="kpi-tile-large"></a>
           <div class="card weather-widget" id="weather-widget" aria-live="polite"></div>
+          <section class="card priorities-card" id="priorities-card">
+            <div class="upcoming-header">
+              <h3 class="title" style="margin:0;">📅 Najbliższe zadania</h3>
+              <p id="priorities-summary" class="tiny muted" style="margin:0;"></p>
+            </div>
+            <div id="upcoming-tasks-list"></div>
+            <a href="tasks.html" class="btn" style="margin-top: 14px;">Zobacz wszystkie</a>
+          </section>
         </aside>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="styles.css">
   <style>
     :root {
       --gradient-primary: radial-gradient(1200px 400px at 20% -10%, hsl(var(--accent-h) 80% 92%) 0%, transparent 55%),
@@ -63,19 +63,20 @@
 
     /* === Hero === */
     .hero-header{
-      margin:-32px -20px 24px -20px; padding: 28px 20px; color: var(--ink); position:relative; overflow:hidden;
+      padding: 28px 32px; color: var(--ink); position:relative; overflow:hidden;
       background: var(--gradient-primary);
-      border-bottom: 1px solid var(--line);
+      border-bottom: 1px solid rgba(15,23,42,0.08);
     }
     .hero-content{
-        position:relative; z-index:1; max-width:1280px; margin:0 auto;
-        width: 100%;
+        position:relative; z-index:1; width: 100%;
+        display:flex; flex-wrap: wrap; align-items:flex-start; justify-content:space-between; gap:24px;
     }
+    .hero-copy{ display:flex; flex-direction:column; gap:6px; max-width: 560px; }
     .greeting-text{ font-size: clamp(20px, 4vw, 28px); font-weight:800; margin:0 0 6px 0; animation: fadeInUp .5s ease-out }
     .date-text{ opacity:.9; font-size: 13px; margin:0 0 10px 0; animation: fadeInUp .5s ease-out .1s both }
     .dynamic-message{ font-style: italic; opacity:.85; font-size:12px; animation: fadeInUp .5s ease-out .2s both }
 
-    .quick-actions{ position:absolute; top:20px; right:20px; display:flex; gap:10px; animation: slideInRight .5s ease-out .2s both; }
+    .quick-actions{ display:flex; gap:10px; align-items:center; animation: slideInRight .5s ease-out .2s both; }
     .quick-action{
       width:42px; height:42px; background: hsl(0 0% 100% / .6);
       border:1px solid hsl(0 0% 100% / .7); border-radius:10px; display:flex; align-items:center; justify-content:center;
@@ -154,104 +155,131 @@
     @keyframes spin{ to{ transform: translate(-50%,-50%) rotate(360deg) } }
 
     @media (max-width: 768px){
-      .hero-header{ padding: 24px; margin:-28px -20px 20px -20px }
-      .quick-actions{ position: static; margin-top: 12px; justify-content: center }
+      .hero-header{ padding: 24px; }
+      .hero-content{ flex-direction: column; align-items: flex-start; }
+      .quick-actions{ width: 100%; justify-content: flex-start; }
     }
   </style>
 </head>
-<body>
-  <div class="wrap">
-    <header class="hero-header">
-      <div class="hero-content">
-        <div class="quick-actions">
-          <a href="#" class="quick-action" title="Ustawienia" onclick="openSettingsModal()">⚙️</a>
-          <a href="#" class="quick-action" title="Odśwież" onclick="refreshDashboard()">↻</a>
-        </div>
-        <h1 id="greeting" class="greeting-text">Dzień dobry!</h1>
-        <p id="current-date" class="date-text"></p>
-        <p id="dynamic-message" class="dynamic-message"></p>
+<body data-page="dashboard">
+  <div class="app-shell">
+    <aside class="sidebar" aria-label="Główna nawigacja">
+      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-link active" href="index.html" aria-current="page"><span class="icon">📊</span><span>Dashboard</span></a>
+        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
+        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
+        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
+        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
+        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
+        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
+        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      </nav>
+      <div class="sidebar-footer">
+        <strong>Twój cyfrowy dom</strong>
+        Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
-    </header>
+    </aside>
 
-    <div class="grid g-main">
-      <div style="display: grid; gap: 14px; align-content: start;">
-        <div class="card">
-          <h3 class="title">📊 Kluczowe wskaźniki</h3>
-          <div class="grid g-2 kpi-grid">
-            <a href="budget.html" id="kpi-budget" class="kpi-tile-large"></a>
-            <a href="fuel.html" id="kpi-fuel" class="kpi-tile-large"></a>
-            <a href="tasks.html" id="kpi-tasks" class="kpi-tile-large"></a>
-            <a href="trainings.html" id="kpi-progress" class="kpi-tile-large"></a>
-            <a href="house.html" id="kpi-house" class="kpi-tile-large"></a>
-            <a href="loan.html" id="kpi-loan" class="kpi-tile-large"></a>
+    <div class="app-main">
+      <header class="topbar hero-header">
+        <div class="hero-content">
+          <div class="hero-copy">
+            <p class="topbar-eyebrow">Twój dzień w skrócie</p>
+            <h1 id="greeting" class="greeting-text">Dzień dobry!</h1>
+            <p id="current-date" class="date-text"></p>
+            <p id="dynamic-message" class="dynamic-message"></p>
+          </div>
+          <div class="quick-actions">
+            <a href="#" class="quick-action" title="Ustawienia" onclick="openSettingsModal()">⚙️</a>
+            <a href="#" class="quick-action" title="Odśwież" onclick="refreshDashboard()">↻</a>
           </div>
         </div>
+      </header>
 
-        <div class="card">
-          <h3 class="title">🎯 Cele treningowe na ten tydzień</h3>
-          <div id="weekly-activities-list" class="activity-feed"></div>
-        </div>
-        
-        <div class="card">
-          <h3 class="title">🗂️ Moduły</h3>
-          <div class="grid modules-grid" style="margin-top: 14px;">
-            <a class="tile" href="budget.html">
-              <div class="pill">💰 Budżet</div>
-              <div style="font-weight: 600;">Finanse</div>
-              <div class="tiny muted">Zarządzaj wydatkami</div>
-            </a>
-            <a class="tile" href="fuel.html">
-              <div class="pill">⛽ Paliwo</div>
-              <div style="font-weight: 600;">Rozliczenia</div>
-              <div class="tiny muted">Tankowania i faktury</div>
-            </a>
-            <a class="tile" href="tasks.html">
-              <div class="pill">✅ Zadania</div>
-              <div style="font-weight: 600;">Organizacja</div>
-              <div class="tiny muted">Listy i kalendarz</div>
-            </a>
-            <a class="tile" href="trainings.html">
-              <div class="pill">💪 Treningi</div>
-              <div style="font-weight: 600;">Cele</div>
-              <div class="tiny muted">Plany i progres</div>
-            </a>
-            <a class="tile" href="house.html">
-                <div class="pill">🏗️ Budowa</div>
-                <div style="font-weight: 600;">Projekt</div>
-                <div class="tiny muted">Kontroluj budowę</div>
-            </a>
-            <a class="tile" href="loan.html">
-                <div class="pill">🏦 Kredyt</div>
-                <div style="font-weight: 600;">Spłata</div>
-                <div class="tiny muted">Monitoruj postępy</div>
-            </a>
-          </div>
-          <div style="border-top: 1px solid var(--line); margin: 18px 0;"></div>
-          <h3 class="title" style="margin-bottom: 10px;">💾 Zarządzanie Danymi</h3>
-          <div class="grid g-2" style="gap: 10px;">
-            <button class="btn" id="export-all-btn">📤 Eksportuj wszystko</button>
-            <button class="btn" id="import-all-btn">📥 Importuj wszystko</button>
-            <input type="file" id="import-file-input" style="display:none" accept="application/json"/>
-          </div>
-          <p id="backup-status" class="tiny" style="margin-top: 12px; text-align: center;"></p>
-        </div>
-      </div>
+      <main class="page-content">
+        <div class="wrap">
+          <div class="page-columns">
+            <section class="stack tight">
+              <div class="card">
+                <h3 class="title">📊 Kluczowe wskaźniki</h3>
+                <div class="grid g-2 kpi-grid">
+                  <a href="budget.html" id="kpi-budget" class="kpi-tile-large"></a>
+                  <a href="fuel.html" id="kpi-fuel" class="kpi-tile-large"></a>
+                  <a href="tasks.html" id="kpi-tasks" class="kpi-tile-large"></a>
+                  <a href="trainings.html" id="kpi-progress" class="kpi-tile-large"></a>
+                  <a href="house.html" id="kpi-house" class="kpi-tile-large"></a>
+                  <a href="loan.html" id="kpi-loan" class="kpi-tile-large"></a>
+                </div>
+              </div>
 
-      <div style="display: flex; flex-direction: column; gap: 14px;">
-        <div class="card weather-widget" id="weather-widget" aria-live="polite">
-          <!-- Weather content will be dynamically inserted here -->
-        </div>
-        <div class="card priorities-card" id="priorities-card">
-          <div class="upcoming-header">
-            <h3 class="title" style="margin:0;">📅 Najbliższe zadania</h3>
-            <p id="priorities-summary" class="tiny muted" style="margin:0;"></p>
+              <div class="card">
+                <h3 class="title">🎯 Cele treningowe na ten tydzień</h3>
+                <div id="weekly-activities-list" class="activity-feed"></div>
+              </div>
+
+              <div class="card">
+                <h3 class="title">🗂️ Moduły</h3>
+                <div class="grid modules-grid" style="margin-top: 14px;">
+                  <a class="tile" href="budget.html">
+                    <div class="pill">💰 Budżet</div>
+                    <div style="font-weight: 600;">Finanse</div>
+                    <div class="tiny muted">Zarządzaj wydatkami</div>
+                  </a>
+                  <a class="tile" href="fuel.html">
+                    <div class="pill">⛽ Paliwo</div>
+                    <div style="font-weight: 600;">Rozliczenia</div>
+                    <div class="tiny muted">Tankowania i faktury</div>
+                  </a>
+                  <a class="tile" href="tasks.html">
+                    <div class="pill">✅ Zadania</div>
+                    <div style="font-weight: 600;">Organizacja</div>
+                    <div class="tiny muted">Listy i kalendarz</div>
+                  </a>
+                  <a class="tile" href="trainings.html">
+                    <div class="pill">💪 Treningi</div>
+                    <div style="font-weight: 600;">Cele</div>
+                    <div class="tiny muted">Plany i progres</div>
+                  </a>
+                  <a class="tile" href="house.html">
+                    <div class="pill">🏗️ Budowa</div>
+                    <div style="font-weight: 600;">Projekt</div>
+                    <div class="tiny muted">Kontroluj budowę</div>
+                  </a>
+                  <a class="tile" href="loan.html">
+                    <div class="pill">🏦 Kredyt</div>
+                    <div style="font-weight: 600;">Spłata</div>
+                    <div class="tiny muted">Monitoruj postępy</div>
+                  </a>
+                </div>
+                <div style="border-top: 1px solid var(--line); margin: 18px 0;"></div>
+                <h3 class="title" style="margin-bottom: 10px;">💾 Zarządzanie Danymi</h3>
+                <div class="grid g-2" style="gap: 10px;">
+                  <button class="btn" id="export-all-btn">📤 Eksportuj wszystko</button>
+                  <button class="btn" id="import-all-btn">📥 Importuj wszystko</button>
+                  <input type="file" id="import-file-input" style="display:none" accept="application/json"/>
+                </div>
+                <p id="backup-status" class="tiny" style="margin-top: 12px; text-align: center;"></p>
+              </div>
+            </section>
+
+            <aside class="stack tight">
+              <div class="card weather-widget" id="weather-widget" aria-live="polite">
+                <!-- Weather content will be dynamically inserted here -->
+              </div>
+              <div class="card priorities-card" id="priorities-card">
+                <div class="upcoming-header">
+                  <h3 class="title" style="margin:0;">📅 Najbliższe zadania</h3>
+                  <p id="priorities-summary" class="tiny muted" style="margin:0;"></p>
+                </div>
+                <div id="upcoming-tasks-list"></div>
+                <a href="tasks.html" class="btn" style="margin-top: 14px;">Zobacz wszystkie</a>
+              </div>
+            </aside>
           </div>
-          <div id="upcoming-tasks-list"></div>
-          <a href="tasks.html" class="btn" style="margin-top: 14px;">Zobacz wszystkie</a>
         </div>
-      </div>
+      </main>
     </div>
-
   </div>
 
   <!-- Modals -->

--- a/loan.html
+++ b/loan.html
@@ -513,6 +513,9 @@
                     <button class="loan-tab-btn" data-chart="line">Kapitał vs odsetki</button>
                     <button class="loan-tab-btn" data-chart="share">Udziały w czasie</button>
                     <button class="loan-tab-btn" data-chart="cumulative">Kumulacja spłat</button>
+                    <button class="loan-tab-btn" data-chart="balance">Saldo kredytu</button>
+                    <button class="loan-tab-btn" data-chart="overpay">Nadpłaty</button>
+                    <button class="loan-tab-btn" data-chart="rate">Trend oprocentowania</button>
                   </div>
                   <div id="loan-chart-placeholder" class="loan-chart-placeholder">
                     Dodaj raty, aby zobaczyć analizy spłaty kredytu.
@@ -541,6 +544,21 @@
                     <div class="loan-tab-panel" data-chart="cumulative">
                       <div class="loan-chart-area" style="min-height:320px;">
                         <canvas id="cumulative-chart"></canvas>
+                      </div>
+                    </div>
+                    <div class="loan-tab-panel" data-chart="balance">
+                      <div class="loan-chart-area" style="min-height:320px;">
+                        <canvas id="balance-chart"></canvas>
+                      </div>
+                    </div>
+                    <div class="loan-tab-panel" data-chart="overpay">
+                      <div class="loan-chart-area" style="min-height:320px;">
+                        <canvas id="overpayment-chart"></canvas>
+                      </div>
+                    </div>
+                    <div class="loan-tab-panel" data-chart="rate">
+                      <div class="loan-chart-area" style="min-height:320px;">
+                        <canvas id="rate-trend-chart"></canvas>
                       </div>
                     </div>
                   </div>
@@ -1153,7 +1171,9 @@ function renderCharts() {
   Chart.defaults.color = getComputedStyle(document.body).getPropertyValue('--muted').trim();
 
   const paymentLabels = payments.map(p => new Date(p.date + '-02').toLocaleDateString('pl-PL', { month: 'short', year: '2-digit' }));
-  const principalSeries = payments.map(p => p.capital + (p.overpayment || 0));
+  const basePrincipalSeries = payments.map(p => p.capital);
+  const overpaymentSeries = payments.map(p => p.overpayment || 0);
+  const principalSeries = payments.map((p, index) => basePrincipalSeries[index] + overpaymentSeries[index]);
   const interestSeries = payments.map(p => p.interest);
   const totalSeries = principalSeries.map((value, index) => value + interestSeries[index]);
   const cumulativePrincipal = [];
@@ -1183,12 +1203,28 @@ function renderCharts() {
 
   const rateHistory = loanDetails.interestRateHistory || [];
   const interestRateData = payments.map(p => getRateForDate(p.date, rateHistory));
+  const totalCapitalAmount = Number(loanDetails.totalCapital || 0);
+  let runningBalance = totalCapitalAmount;
+  const remainingBalances = payments.map((p, index) => {
+    runningBalance -= principalSeries[index];
+    return Math.max(runningBalance, 0);
+  });
+
+  const sortedRateHistory = [...rateHistory].sort((a, b) => a.date.localeCompare(b.date));
+  const rateHistoryLabels = sortedRateHistory.length
+    ? sortedRateHistory.map(entry => new Date(`${entry.date}-02`).toLocaleDateString('pl-PL', { month: 'short', year: '2-digit' }))
+    : paymentLabels;
+  const rateHistoryValues = sortedRateHistory.length
+    ? sortedRateHistory.map(entry => Number(entry.rate || 0))
+    : interestRateData.map(rate => Number(rate || 0));
   const totalCapitalPaid = principalSeries.reduce((sum, value) => sum + value, 0);
   const totalInterestPaid = interestSeries.reduce((sum, value) => sum + value, 0);
 
   chartDataCache = {
     labels: paymentLabels,
     principalSeries,
+    basePrincipalSeries,
+    overpaymentSeries,
     interestSeries,
     totalSeries,
     cumulativePrincipal,
@@ -1196,6 +1232,9 @@ function renderCharts() {
     sharePrincipal,
     shareInterest,
     interestRateData,
+    remainingBalances,
+    rateHistoryLabels,
+    rateHistoryValues,
     totals: { principal: totalCapitalPaid, interest: totalInterestPaid }
   };
 
@@ -1231,7 +1270,22 @@ function getLoanPalette() {
 function renderChartForPanel(panelType) {
   if (!chartDataCache) return;
   const palette = getLoanPalette();
-  const { labels, principalSeries, interestSeries, interestRateData, totals, sharePrincipal, shareInterest, cumulativePrincipal, cumulativeInterest } = chartDataCache;
+  const {
+    labels,
+    principalSeries,
+    basePrincipalSeries,
+    overpaymentSeries,
+    interestSeries,
+    interestRateData,
+    totals,
+    sharePrincipal,
+    shareInterest,
+    cumulativePrincipal,
+    cumulativeInterest,
+    remainingBalances,
+    rateHistoryLabels,
+    rateHistoryValues
+  } = chartDataCache;
 
   if (panelType === 'mix') {
     const capitalCanvas = $('#capital-chart');
@@ -1458,6 +1512,7 @@ function renderChartForPanel(panelType) {
           options: {
             responsive: true,
             maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
             plugins: {
               legend: { position: 'bottom' },
               tooltip: {
@@ -1476,6 +1531,183 @@ function renderChartForPanel(panelType) {
         });
       }
       setTimeout(() => charts.cumulative && charts.cumulative.resize(), 30);
+    }
+  }
+
+  if (panelType === 'balance') {
+    const balanceCanvas = $('#balance-chart');
+    if (balanceCanvas) {
+      const balanceCtx = balanceCanvas.getContext('2d');
+      if (charts.balance) {
+        charts.balance.data.labels = labels;
+        charts.balance.data.datasets[0].data = remainingBalances;
+        charts.balance.update();
+      } else {
+        charts.balance = new Chart(balanceCtx, {
+          type: 'line',
+          data: {
+            labels,
+            datasets: [
+              {
+                label: 'Saldo po spłacie',
+                data: remainingBalances,
+                borderColor: palette.blue,
+                backgroundColor: palette.blueSoft,
+                fill: 'start',
+                tension: 0.25,
+                pointRadius: 4,
+                pointHoverRadius: 6
+              }
+            ]
+          },
+          plugins: [ChartDataLabels],
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: (context) => `Saldo: ${fmt(context.raw)}`
+                }
+              },
+              datalabels: {
+                align: 'top',
+                anchor: 'end',
+                color: palette.ink,
+                font: { weight: 700, size: 11 },
+                formatter: (value, context) => {
+                  const dataset = context.dataset.data || [];
+                  return context.dataIndex === dataset.length - 1 ? fmt(value) : '';
+                }
+              }
+            },
+            scales: {
+              y: {
+                grid: { color: palette.line },
+                ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') }
+              }
+            }
+          }
+        });
+      }
+      setTimeout(() => charts.balance && charts.balance.resize(), 30);
+    }
+  }
+
+  if (panelType === 'overpay') {
+    const overpaymentCanvas = $('#overpayment-chart');
+    if (overpaymentCanvas) {
+      const overpaymentCtx = overpaymentCanvas.getContext('2d');
+      if (charts.overpayment) {
+        charts.overpayment.data.labels = labels;
+        charts.overpayment.data.datasets[0].data = basePrincipalSeries;
+        charts.overpayment.data.datasets[1].data = overpaymentSeries;
+        charts.overpayment.update();
+      } else {
+        charts.overpayment = new Chart(overpaymentCtx, {
+          type: 'bar',
+          data: {
+            labels,
+            datasets: [
+              { label: 'Kapitał planowy', data: basePrincipalSeries, backgroundColor: palette.green, borderRadius: 4, stack: 'stacked' },
+              { label: 'Nadpłata', data: overpaymentSeries, backgroundColor: palette.blue, borderRadius: 4, stack: 'stacked' }
+            ]
+          },
+          plugins: [ChartDataLabels],
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            scales: {
+              x: { stacked: true, grid: { display: false } },
+              y: { stacked: true, grid: { color: palette.line }, ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') } }
+            },
+            plugins: {
+              legend: { position: 'bottom' },
+              tooltip: {
+                callbacks: {
+                  label: (context) => `${context.dataset.label}: ${fmt(context.raw)}`
+                }
+              },
+              datalabels: {
+                color: palette.ink,
+                anchor: 'end',
+                align: 'top',
+                font: { weight: 600, size: 10 },
+                formatter: (value, context) => {
+                  if (context.dataset.label !== 'Nadpłata' || !value) return '';
+                  return fmt(value);
+                }
+              }
+            }
+          }
+        });
+      }
+      setTimeout(() => charts.overpayment && charts.overpayment.resize(), 30);
+    }
+  }
+
+  if (panelType === 'rate') {
+    const rateCanvas = $('#rate-trend-chart');
+    if (rateCanvas) {
+      const rateCtx = rateCanvas.getContext('2d');
+      if (charts.rateTrend) {
+        charts.rateTrend.data.labels = rateHistoryLabels;
+        charts.rateTrend.data.datasets[0].data = rateHistoryValues;
+        charts.rateTrend.update();
+      } else {
+        charts.rateTrend = new Chart(rateCtx, {
+          type: 'line',
+          data: {
+            labels: rateHistoryLabels,
+            datasets: [
+              {
+                label: 'Oprocentowanie',
+                data: rateHistoryValues,
+                borderColor: palette.orange,
+                backgroundColor: palette.orangeSoft,
+                fill: 'start',
+                tension: 0.25,
+                pointRadius: 4,
+                pointHoverRadius: 6
+              }
+            ]
+          },
+          plugins: [ChartDataLabels],
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: (context) => `${context.dataset.label}: ${Number(context.raw || 0).toFixed(2)}%`
+                }
+              },
+              datalabels: {
+                align: 'top',
+                anchor: 'end',
+                color: palette.orange,
+                font: { weight: 700, size: 11 },
+                formatter: (value, context) => {
+                  const dataset = context.dataset.data || [];
+                  return context.dataIndex === dataset.length - 1 ? `${Number(value || 0).toFixed(2)}%` : '';
+                }
+              }
+            },
+            scales: {
+              y: {
+                grid: { color: palette.line },
+                ticks: { callback: (value) => `${value}%` }
+              }
+            }
+          }
+        });
+      }
+      setTimeout(() => charts.rateTrend && charts.rateTrend.resize(), 30);
     }
   }
 }

--- a/loan.html
+++ b/loan.html
@@ -7,260 +7,531 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
   <style>
-    :root, [data-theme="light"]{
-      --accent-h: 222; --accent-s: 83%; --accent-l: 53%;
-      --accent: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
-      --accent-weak: hsl(var(--accent-h) 60% 94%);
-      --bg:#f6f7fb; --card:#ffffff; --ink:#0f172a; --muted:#667085; --line:#e7eaf0;
-      --surface:#f9fafb;
-      --green:#059669; --red:#dc2626; --orange:#ea580c; --blue:#2563eb;
-      --shadow-sm:0 1px 2px 0 rgb(0 0 0 / 0.05);
-      --shadow:0 1px 3px 0 rgb(0 0 0 / 0.08), 0 1px 2px -1px rgb(0 0 0 / 0.04);
-      --shadow-md:0 6px 16px -6px rgb(0 0 0 / 0.12);
-    }
-
-    * { box-sizing: border-box; }
-    html, body { height: 100%; }
-    body {
-      margin: 0; background: var(--bg); color: var(--ink);
-      font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto;
-      font-size: 14px; line-height: 1.6;
-    }
-    
-    @keyframes fadeInUp { from{opacity:0; transform:translateY(10px)} to{opacity:1; transform:translateY(0)} }
-
-    .wrap { max-width: 1280px; margin: 0 auto; padding: 28px 20px; }
-    .grid { display: grid; gap: 24px; }
+    .grid { display: grid; gap: 14px; }
     .g-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .g-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-    @media(max-width:1024px){ .g-3{grid-template-columns: repeat(2,1fr)} .g-2{grid-template-columns:1fr} }
-    @media(max-width:640px){ .g-3{grid-template-columns:1fr} }
-    
-    .card{
-      background: var(--card); border: 1px solid var(--line); border-radius: 16px; padding: 24px;
-      box-shadow: var(--shadow); animation: fadeInUp .4s ease-out;
+    @media (max-width: 900px) {
+      .g-2 { grid-template-columns: 1fr; }
+      .g-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+    @media (max-width: 640px) {
+      .g-3 { grid-template-columns: 1fr; }
     }
 
-    .title { margin: 0 0 16px 0; font-weight: 700; font-size: 18px; letter-spacing: .2px; }
-    .muted { color: var(--muted); }
-    .tiny { font-size: 12px }
-
-    .btn{
-      display:inline-flex; gap:8px; align-items:center; justify-content:center;
-      border-radius: 12px; padding: 12px 20px; border: 1px solid var(--line);
-      background: var(--surface); color: var(--ink); cursor:pointer; text-decoration:none; font-weight:600;
-      font-size: 14px; transition: transform .15s ease, box-shadow .15s ease, background .2s ease, border-color .2s ease;
+    .loan-setup-card {
+      text-align: center;
+      padding: 48px 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      align-items: center;
     }
-    .btn:hover{ transform: translateY(-1px); box-shadow: var(--shadow-sm); border-color:hsl(var(--accent-h) 30% 75% / .6) }
-    .btn.primary{ background: var(--accent); color:#fff; border-color: transparent }
-    .btn.danger{ background: var(--red); color:#fff; border-color: transparent }
 
-    .header {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-between;
-        align-items: center;
-        margin-bottom: 24px;
-        gap: 16px;
-        animation: fadeInUp .3s ease-out;
+    .setup-icon {
+      font-size: 48px;
     }
-    .header-title { font-size: 28px; font-weight: 800; margin: 0; }
-    .header-actions { display: flex; gap: 10px; flex-wrap: wrap; }
 
-    .kpi-card {
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
+    .loan-progress-card {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
     }
-    .kpi-label { font-size: 13px; color: var(--muted); font-weight: 500; }
-    .kpi-value { font-size: 28px; font-weight: 700; line-height: 1.2; }
-    .kpi-value .currency { font-size: 16px; font-weight: 600; color: var(--muted); margin-left: 4px; }
-    .kpi-sub { font-size: 12px; color: var(--muted); }
 
-    .insights-grid {
-        display: grid;
-        gap: 14px;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    .loan-progress-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
     }
-    .insight-card {
-        background: var(--surface);
-        border: 1px solid var(--line);
-        border-radius: 14px;
-        padding: 16px;
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-    }
-    .insight-card .label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; }
-    .insight-card .value { font-size: 22px; font-weight: 700; }
-    .insight-card .note { font-size: 12px; color: var(--muted); }
 
-    .progress-bar { background: #e2e8f0; border-radius: 8px; height: 16px; overflow: hidden; }
-    .progress-bar-inner {
+    .loan-progress-header .title {
+      margin: 0;
+    }
+
+    .loan-progress-percent {
+      font-size: 24px;
+      font-weight: 800;
+      color: var(--ink);
+    }
+
+    .loan-progress-bar {
+      height: 14px;
+      border-radius: 999px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      overflow: hidden;
+    }
+
+    .loan-progress-fill {
       height: 100%;
-      border-radius: 8px;
-      background: linear-gradient(90deg, var(--green), hsl(145, 50%, 60%));
+      background: linear-gradient(90deg, var(--green), hsl(152 76% 48%));
       transition: width 0.5s ease-out;
     }
-    
-    .table-wrapper { overflow-x: auto; }
-    table { width: 100%; border-collapse: collapse; }
-    th, td { padding: 12px 16px; text-align: left; border-bottom: 1px solid var(--line); }
-    td { vertical-align: middle; }
-    th { font-size: 12px; font-weight: 600; color: var(--muted); text-transform: uppercase; }
-    tbody tr:hover { background-color: var(--surface); }
 
-    .rate-history-list { display: flex; flex-direction: column; gap: 10px; }
-    .rate-history-entry { display: flex; justify-content: space-between; align-items: baseline; padding: 10px 12px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); }
-    .rate-history-entry.current { border-color: var(--accent); background: var(--accent-weak); }
-    .rate-history-entry .rate { font-weight: 700; font-size: 16px; }
-    .rate-history-entry .date { font-size: 12px; color: var(--muted); }
+    .loan-progress-stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
+    }
 
-    .modal-overlay{
-      position:fixed; inset:0; background: rgba(15,23,42,.6); display:flex; justify-content:center; align-items:flex-start;
-      padding-top: 5vh; z-index:1000; backdrop-filter: blur(8px); opacity:0; pointer-events:none; transition: opacity .2s ease-out; overflow-y: auto;
+    .loan-progress-stat {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 12px 14px;
+      border-radius: 12px;
+      border: 1px solid var(--line);
+      background: var(--surface);
     }
-    .modal-overlay.visible{ opacity:1; pointer-events: all }
-    .modal-card{ background: var(--card); padding: 0; border-radius: 16px; box-shadow: var(--shadow-lg); max-width: 520px; width: 92%;
-      transform: scale(.96); transition: transform .2s ease; border:1px solid var(--line); overflow: hidden; margin-bottom: 5vh;
+
+    .loan-progress-stat .label {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--muted);
+      font-weight: 600;
     }
-    .modal-overlay.visible .modal-card{ transform: scale(1) }
-    .modal-header { padding: 20px; border-bottom: 1px solid var(--line); }
-    .modal-title { font-size: 18px; font-weight: 700; margin: 0; }
-    .modal-body { padding: 20px; }
-    .modal-footer { padding: 16px 20px; border-top: 1px solid var(--line); background: var(--surface); display:flex; justify-content:flex-end; gap:10px }
-    
-    .form-group { margin-bottom: 16px; }
-    .form-label { display: block; font-size: 12px; font-weight: 600; color: var(--muted); margin-bottom: 6px; }
+
+    .loan-progress-stat .value {
+      font-size: 16px;
+      font-weight: 700;
+      color: var(--ink);
+    }
+
+    .loan-progress-stat .note {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .loan-progress-stat .value .currency {
+      font-size: 12px;
+      color: var(--muted);
+      margin-left: 4px;
+      font-weight: 600;
+    }
+
+    .kpi-value .currency {
+      font-size: 12px;
+      color: var(--muted);
+      margin-left: 4px;
+      font-weight: 600;
+    }
+
+    .loan-insights-panel {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 14px;
+      border-radius: 14px;
+      background: var(--surface);
+      border: 1px dashed var(--line);
+    }
+
+    .loan-insights-panel .panel-title {
+      margin: 0;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      font-weight: 700;
+    }
+
+    .insights-grid {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+
+    .insight-card {
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .insight-card .label {
+      font-size: 11px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-weight: 600;
+    }
+
+    .insight-card .value {
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--ink);
+    }
+
+    .insight-card .note {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .loan-charts-card {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+
+    .loan-chart-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+      gap: 18px;
+    }
+
+    .loan-chart-area,
+    .loan-donut-area {
+      position: relative;
+      min-height: 300px;
+    }
+
+    .loan-donut-area { min-height: 260px; }
+
+    @media (max-width: 1200px) {
+      .loan-chart-grid { grid-template-columns: 1fr; }
+      .loan-donut-area { min-height: 240px; }
+    }
+
+    .loan-table-card {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .table-wrapper.scrollable {
+      max-height: 360px;
+      overflow: auto;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th,
+    td {
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: middle;
+      font-size: 13px;
+    }
+
+    thead th {
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    tbody tr:hover { background: var(--surface); }
+
+    .rate-history-card {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .rate-history-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .rate-history-entry {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 12px;
+      padding: 10px 12px;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: var(--surface);
+    }
+
+    .rate-history-entry.current {
+      border-color: var(--accent);
+      background: var(--accent-weak);
+    }
+
+    .rate-history-entry .rate {
+      font-weight: 700;
+      font-size: 16px;
+    }
+
+    .rate-history-entry .date {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .form-group {
+      margin-bottom: 16px;
+    }
+
+    .form-label {
+      display: block;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--muted);
+      margin-bottom: 6px;
+    }
+
     .form-input {
-      width: 100%; padding: 10px 14px; border-radius: 8px; border: 1px solid var(--line);
-      background: var(--surface); font-size: 14px;
+      width: 100%;
+      padding: 10px 14px;
+      border-radius: 10px;
+      border: 1px solid var(--line);
+      background: var(--card);
+      font-size: 14px;
     }
-    .form-input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-weak); }
-    hr.divider { border: none; border-top: 1px solid var(--line); margin: 24px 0; }
 
-    .setup-container {
-        text-align: center;
-        padding: 60px 20px;
+    hr.divider {
+      border: none;
+      border-top: 1px solid var(--line);
+      margin: 20px 0;
     }
-    .setup-icon { font-size: 48px; margin-bottom: 16px; }
+
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(15, 23, 42, 0.6);
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      padding-top: 5vh;
+      z-index: 1000;
+      backdrop-filter: blur(8px);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s ease-out;
+      overflow-y: auto;
+    }
+
+    .modal-overlay.visible {
+      opacity: 1;
+      pointer-events: all;
+    }
+
+    .modal-card {
+      background: var(--card);
+      padding: 0;
+      border-radius: 16px;
+      box-shadow: var(--shadow-lg);
+      max-width: 520px;
+      width: 92%;
+      transform: scale(0.96);
+      transition: transform 0.2s ease;
+      border: 1px solid var(--line);
+      overflow: hidden;
+      margin-bottom: 5vh;
+    }
+
+    .modal-overlay.visible .modal-card {
+      transform: scale(1);
+    }
+
+    .modal-header {
+      padding: 20px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .modal-title {
+      font-size: 18px;
+      font-weight: 700;
+      margin: 0;
+    }
+
+    .modal-body {
+      padding: 20px;
+    }
+
+    .modal-footer {
+      padding: 16px 20px;
+      border-top: 1px solid var(--line);
+      background: var(--surface);
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
+    }
   </style>
 </head>
-<body>
+<body data-page="loan">
 
-  <div class="wrap">
-    <header class="page-header">
-      <div class="page-title-group">
-        <a href="index.html" class="back-link">← Powrót</a>
-        <h1 class="page-title">Monitor kredytu</h1>
-        <p class="page-subtitle">Śledź saldo, nadpłaty i harmonogram spłat w jednym miejscu.</p>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Główna nawigacja">
+      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
+        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
+        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
+        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
+        <a class="nav-link active" href="loan.html" aria-current="page"><span class="icon">🏦</span><span>Kredyt</span></a>
+        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
+        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
+        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      </nav>
+      <div class="sidebar-footer">
+        <strong>Twój cyfrowy dom</strong>
+        Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
-      <div class="page-actions">
-        <button class="btn primary" id="add-payment-btn" style="display: none;">+ Dodaj spłatę</button>
-        <button class="btn" id="settings-btn" style="display: none;">⚙️ Ustawienia</button>
-      </div>
-    </header>
+    </aside>
 
-    <main id="app-container">
-      
-      <div id="setup-container" class="card setup-container" style="display: none;">
-        <div class="setup-icon">📊</div>
-        <h2 class="title">Witaj w module kredytowym!</h2>
-        <p class="muted" style="max-width: 400px; margin: 0 auto 24px;">Aby rozpocząć, wprowadź podstawowe informacje o swoim kredycie. Te dane posłużą do wszystkich dalszych obliczeń.</p>
-        <button class="btn primary" id="setup-loan-btn">Skonfiguruj kredyt</button>
-      </div>
-
-      <div id="dashboard-container" class="grid" style="display: none;">
-        
-        <div class="grid g-3">
-          <div class="card kpi-card">
-            <div class="kpi-label">Pozostało kapitału</div>
-            <div id="capital-remaining" class="kpi-value"></div>
-          </div>
-          <div class="card kpi-card">
-            <div class="kpi-label">Spłacono kapitału</div>
-            <div id="capital-paid" class="kpi-value"></div>
-          </div>
-          <div class="card kpi-card">
-            <div class="kpi-label">Suma nadpłat</div>
-            <div id="overpayments-total" class="kpi-value"></div>
-          </div>
-          <div class="card kpi-card">
-            <div class="kpi-label">Zapłacone odsetki</div>
-            <div id="interest-paid" class="kpi-value"></div>
-          </div>
-          <div class="card kpi-card">
-            <div class="kpi-label">Liczba rat</div>
-            <div id="payments-count" class="kpi-value"></div>
-            <div id="payments-sub" class="kpi-sub"></div>
-          </div>
-           <div class="card kpi-card">
-           <div class="kpi-label">Kredyt skrócony o</div>
-           <div id="time-saved" class="kpi-value"></div>
-          </div>
+    <div class="main">
+      <header class="topbar">
+        <div class="topbar-info">
+          <p class="topbar-eyebrow">Finanse</p>
+          <h1 class="topbar-title">Kredyt</h1>
         </div>
-
-        <div class="card" id="loan-insights-card" style="display:none;">
-            <h3 class="title">Najbliższe kroki</h3>
-            <div id="loan-insights-grid" class="insights-grid"></div>
+        <div class="topbar-actions">
+          <button class="btn soft" id="settings-btn" style="display: none;">⚙️ Ustawienia</button>
+          <button class="btn primary" id="add-payment-btn" style="display: none;">+ Dodaj spłatę</button>
         </div>
+      </header>
 
-        <div class="card">
-            <h3 class="title">Postęp spłaty kapitału</h3>
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
+      <div class="content">
+        <main class="stack tight">
+          <div id="app-container" class="stack tight">
+
+            <section id="setup-container" class="card loan-setup-card" style="display: none;">
+              <div class="setup-icon">📊</div>
+              <h2 class="title">Witaj w module kredytowym!</h2>
+              <p class="muted" style="max-width: 420px; margin: 0 auto;">Aby rozpocząć, wprowadź podstawowe informacje o swoim kredycie. Te dane posłużą do wszystkich dalszych obliczeń.</p>
+              <button class="btn primary" id="setup-loan-btn">Skonfiguruj kredyt</button>
+            </section>
+
+            <div id="dashboard-container" class="stack tight" style="display: none;">
+              <section class="card loan-progress-card">
+                <div class="loan-progress-header">
+                  <h2 class="title">Postęp spłaty kapitału</h2>
+                  <span id="progress-percent" class="loan-progress-percent">0%</span>
+                </div>
                 <span id="progress-text" class="tiny muted"></span>
-                <span id="progress-percent" style="font-weight: 700;">0%</span>
-            </div>
-            <div class="progress-bar">
-                <div id="progress-bar-inner" class="progress-bar-inner" style="width: 0%;"></div>
-            </div>
-        </div>
+                <div class="loan-progress-bar">
+                  <div id="progress-bar-inner" class="loan-progress-fill" style="width: 0%;"></div>
+                </div>
+                <div class="loan-progress-stats">
+                  <div class="loan-progress-stat">
+                    <span class="label">Suma nadpłat</span>
+                    <span id="overpayments-total" class="value"></span>
+                  </div>
+                  <div class="loan-progress-stat">
+                    <span class="label">Raty wykonane</span>
+                    <span id="payments-count" class="value"></span>
+                    <span id="payments-sub" class="note"></span>
+                  </div>
+                  <div class="loan-progress-stat">
+                    <span class="label">Kredyt skrócony o</span>
+                    <span id="time-saved" class="value"></span>
+                  </div>
+                </div>
+                <div id="loan-insights-card" class="loan-insights-panel" style="display: none;">
+                  <p class="panel-title">Najbliższe kroki</p>
+                  <div id="loan-insights-grid" class="insights-grid"></div>
+                </div>
+              </section>
 
-        <div class="grid g-2">
-            <div class="card">
-                <h3 class="title">Rata i oprocentowanie</h3>
-                <canvas id="capital-chart" style="max-height: 300px;"></canvas>
-            </div>
-            <div class="card">
-                <h3 class="title">Struktura spłat</h3>
-                <canvas id="structure-chart" style="max-height: 300px;"></canvas>
-            </div>
-        </div>
+              <section class="card loan-charts-card">
+                <div class="section-heading">
+                  <h2 class="title">Kapitał i odsetki</h2>
+                  <span class="tiny muted">Śledź jak zmienia się struktura każdej raty</span>
+                </div>
+                <div class="loan-chart-grid">
+                  <div class="loan-chart-area">
+                    <canvas id="capital-chart"></canvas>
+                  </div>
+                  <div class="loan-donut-area">
+                    <canvas id="structure-chart"></canvas>
+                  </div>
+                </div>
+              </section>
 
-        <div class="card" id="rate-history-card">
-            <h3 class="title">Historia oprocentowania</h3>
-            <ul id="rate-history-list" class="rate-history-list list-clean"></ul>
-        </div>
-
-        <div class="card">
-            <h3 class="title">Historia spłat</h3>
-            <div class="table-wrapper">
-                <table>
+              <section class="card loan-table-card">
+                <div class="section-heading">
+                  <h2 class="title">Historia spłat</h2>
+                  <span class="tiny muted">Edytuj dowolny wpis, aby zaktualizować harmonogram</span>
+                </div>
+                <div class="table-wrapper scrollable">
+                  <table>
                     <thead>
-                        <tr>
-                            <th>Data</th>
-                            <th>Kapitał</th>
-                            <th>Odsetki</th>
-                            <th>Nadpłata</th>
-                            <th>Suma raty</th>
-                            <th>Akcje</th>
-                        </tr>
+                      <tr>
+                        <th>Data</th>
+                        <th>Kapitał</th>
+                        <th>Odsetki</th>
+                        <th>Nadpłata</th>
+                        <th>Suma raty</th>
+                        <th>Akcje</th>
+                      </tr>
                     </thead>
-                    <tbody id="history-tbody">
-                    </tbody>
-                </table>
+                    <tbody id="history-tbody"></tbody>
+                  </table>
+                </div>
+              </section>
+
+              <section class="card rate-history-card" id="rate-history-card">
+                <div class="section-heading">
+                  <h2 class="title">Historia oprocentowania</h2>
+                  <span class="tiny muted">Aktualne stawki wpływają na kolejne raty</span>
+                </div>
+                <ul id="rate-history-list" class="rate-history-list"></ul>
+              </section>
             </div>
-        </div>
+          </div>
+        </main>
 
+        <aside class="right-rail">
+          <div class="kpi-compact">
+            <span class="kpi-emoji">💰</span>
+            <div>
+              <span class="kpi-label">Kapitał pozostały</span>
+              <span class="kpi-value" id="capital-remaining">—</span>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <span class="kpi-emoji">📉</span>
+            <div>
+              <span class="kpi-label">Kapitał spłacony</span>
+              <span class="kpi-value" id="capital-paid">—</span>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <span class="kpi-emoji">📈</span>
+            <div>
+              <span class="kpi-label">Odsetki spłacone</span>
+              <span class="kpi-value" id="interest-paid">—</span>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <span class="kpi-emoji">💸</span>
+            <div>
+              <span class="kpi-label">Śr. rata</span>
+              <span class="kpi-value" id="avg-installment">—</span>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <span class="kpi-emoji">⏳</span>
+            <div>
+              <span class="kpi-label">Następna rata</span>
+              <span class="kpi-value" id="next-payment">—</span>
+              <span class="tiny muted" id="next-payment-note"></span>
+            </div>
+          </div>
+        </aside>
       </div>
-
-    </main>
+    </div>
   </div>
-  
+
   <div id="modal-overlay" class="modal-overlay" role="dialog">
     <div class="modal-card" id="modal-card">
       <div class="modal-header">
@@ -475,7 +746,7 @@ function render() {
     $('#settings-btn').style.display = 'none';
   } else {
     $('#setup-container').style.display = 'none';
-    $('#dashboard-container').style.display = 'grid';
+    $('#dashboard-container').style.display = 'flex';
     $('#add-payment-btn').style.display = 'inline-flex';
     $('#settings-btn').style.display = 'inline-flex';
     renderDashboard();
@@ -504,6 +775,11 @@ function renderDashboard() {
     const avgInstallment = monthsPaid > 0 ? payments.reduce((s, p) => s + p.capital + p.interest + (p.overpayment || 0), 0) / monthsPaid : 0;
     const projectedMonthsRemaining = avgMonthlyPrincipal > 0 ? capitalRemaining / avgMonthlyPrincipal : Infinity;
     const monthsSaved = originalMonths - monthsPaid - projectedMonthsRemaining;
+
+    const avgInstallmentEl = $('#avg-installment');
+    if (avgInstallmentEl) {
+        avgInstallmentEl.textContent = monthsPaid > 0 ? fmt(avgInstallment) : '—';
+    }
 
     if (monthsSaved > 0) {
         const years = Math.floor(monthsSaved / 12);
@@ -613,19 +889,29 @@ function getNextPaymentMonth(payments, loanDetails) {
 function updateLoanInsights(metrics) {
     const card = $('#loan-insights-card');
     const grid = $('#loan-insights-grid');
+    const nextPaymentEl = $('#next-payment');
+    const nextNoteEl = $('#next-payment-note');
     if (!card || !grid) return;
 
     if (!metrics || !metrics.loanDetails) {
         card.style.display = 'none';
+        if (nextPaymentEl) nextPaymentEl.textContent = '—';
+        if (nextNoteEl) nextNoteEl.textContent = '';
         return;
     }
 
-    card.style.display = 'block';
+    card.style.display = 'flex';
     const { loanDetails, payments, capitalRemaining, totalCapitalPaid, totalOverpayments, avgMonthlyPrincipal, avgInstallment, projectedMonthsRemaining, nextPaymentMonth } = metrics;
     const paymentsList = payments || [];
     const avgInterestPortion = paymentsList.length ? paymentsList.reduce((sum, p) => sum + p.interest, 0) / paymentsList.length : 0;
     const nextRate = getRateForDate(nextPaymentMonth, loanDetails.interestRateHistory || []);
     const nextLabel = new Date(`${nextPaymentMonth}-01`).toLocaleDateString('pl-PL', { month: 'long', year: 'numeric' });
+
+    if (nextPaymentEl) nextPaymentEl.textContent = nextLabel || '—';
+    if (nextNoteEl) {
+        const hasRateHistory = (loanDetails.interestRateHistory || []).length > 0;
+        nextNoteEl.textContent = hasRateHistory ? `Oprocentowanie ${Number(nextRate || 0).toFixed(2)}%` : '';
+    }
 
     const recommendedOverpayment = (avgMonthlyPrincipal > 0 && projectedMonthsRemaining && isFinite(projectedMonthsRemaining) && projectedMonthsRemaining > 6)
         ? Math.max(0, (capitalRemaining / Math.max(projectedMonthsRemaining - 6, 1)) - avgMonthlyPrincipal)

--- a/loan.html
+++ b/loan.html
@@ -782,7 +782,55 @@ function fmt(n) {
 }
 
 function fmtPlain(n) {
-  return fmt(n).replace(/\s*zł/i, '').trim();
+  try {
+    const value = Number(n || 0);
+    const formatter = new Intl.NumberFormat('pl-PL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    return formatter.format(value).replace(/\u00a0/g, ' ');
+  } catch {
+    return Number(n || 0).toFixed(2);
+  }
+}
+
+function formatThousands(value, fractionDigits = 1) {
+  const formatter = new Intl.NumberFormat('pl-PL', {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+  return formatter.format(value).replace(/\u00a0/g, ' ');
+}
+
+function fmtChartValue(n) {
+  try {
+    const value = Number(n || 0);
+    if (!Number.isFinite(value)) return '0 zł';
+    if (Math.abs(value) >= 1000) {
+      return `${formatThousands(value / 1000, 1)} k zł`;
+    }
+    return fmt(value);
+  } catch {
+    const numeric = Number(n || 0);
+    if (Math.abs(numeric) >= 1000) {
+      return `${(numeric / 1000).toFixed(1)} k zł`;
+    }
+    return fmt(numeric);
+  }
+}
+
+function fmtChartTick(n) {
+  try {
+    const value = Number(n || 0);
+    if (!Number.isFinite(value)) return '0 zł';
+    if (Math.abs(value) >= 1000) {
+      return `${formatThousands(value / 1000, 1)} k zł`;
+    }
+    return `${fmtPlain(value)} zł`;
+  } catch {
+    const numeric = Number(n || 0);
+    if (Math.abs(numeric) >= 1000) {
+      return `${(numeric / 1000).toFixed(1)} k zł`;
+    }
+    return `${Number(numeric || 0).toFixed(2)} zł`;
+  }
 }
 
 function formatRateValue(value) {
@@ -1470,7 +1518,7 @@ function renderChartForPanel(panelType) {
                     const index = context.dataIndex;
                     const principalValue = context.chart.data.datasets[1].data[index] || 0;
                     const total = (value || 0) + principalValue;
-                    return total ? fmt(total) : '';
+                    return total ? fmtChartValue(total) : '';
                   }
                 }
               },
@@ -1483,7 +1531,7 @@ function renderChartForPanel(panelType) {
             maintainAspectRatio: false,
             scales: {
               x: { stacked: true, grid: { display: false } },
-              y: { stacked: true, grid: { color: palette.line }, ticks: { callback: (value) => fmtPlain(value) } },
+              y: { stacked: true, grid: { color: palette.line }, ticks: { callback: (value) => fmtChartTick(value) } },
               yRate: { type: 'linear', position: 'right', grid: { display: false }, min: yRateMin, max: yRateMax, ticks: { callback: (value) => `${value}%` } }
             },
             plugins: {
@@ -1494,7 +1542,7 @@ function renderChartForPanel(panelType) {
                     if (context.dataset.yAxisID === 'yRate') {
                       return `${context.dataset.label}: ${context.raw}%`;
                     }
-                    return `${context.dataset.label}: ${fmt(context.raw)}`;
+                    return `${context.dataset.label}: ${fmtChartValue(context.raw)}`;
                   }
                 }
               }
@@ -1522,7 +1570,7 @@ function renderChartForPanel(panelType) {
           const value = context.raw || 0;
           const sum = totals.principal + totals.interest;
           const percentage = sum > 0 ? ((value / sum) * 100).toFixed(2) : 0;
-          return `${label}: ${fmt(value)} (${percentage}%)`;
+          return `${label}: ${fmtChartValue(value)} (${percentage}%)`;
         };
         charts.structure.update();
       } else {
@@ -1554,7 +1602,7 @@ function renderChartForPanel(panelType) {
                     const label = context.label || '';
                     const value = context.raw || 0;
                     const percentage = totalPaid > 0 ? ((value / totalPaid) * 100).toFixed(2) : 0;
-                    return `${label}: ${fmt(value)} (${percentage}%)`;
+                    return `${label}: ${fmtChartValue(value)} (${percentage}%)`;
                   }
                 }
               }
@@ -1594,7 +1642,7 @@ function renderChartForPanel(panelType) {
               legend: { position: 'bottom' },
               tooltip: {
                 callbacks: {
-                  label: (context) => `${context.dataset.label}: ${fmt(context.raw)}`
+                  label: (context) => `${context.dataset.label}: ${fmtChartValue(context.raw)}`
                 }
               },
               datalabels: {
@@ -1603,13 +1651,13 @@ function renderChartForPanel(panelType) {
                 anchor: (context) => (context.datasetIndex === 0 ? 'end' : 'start'),
                 color: (context) => context.dataset.borderColor || palette.ink,
                 font: { weight: 600, size: 10 },
-                formatter: (value) => fmt(value)
+                formatter: (value) => fmtChartValue(value)
               }
             },
             scales: {
               y: {
                 grid: { color: palette.line },
-                ticks: { callback: (value) => fmtPlain(value) }
+                ticks: { callback: (value) => fmtChartTick(value) }
               }
             }
           }
@@ -1634,7 +1682,9 @@ function renderChartForPanel(panelType) {
         const element = meta.data[dataIndex];
         const target = datasetIndex === 0 ? 10 : 80;
         const targetPixel = yScale.getPixelForValue(target);
-        return targetPixel - element.y;
+        const baseOffset = targetPixel - element.y;
+        const separation = datasetIndex === 0 ? -14 : 14;
+        return baseOffset + separation;
       };
       const shareLabelColor = (context) => (context.datasetIndex === 0 ? palette.green : palette.orange);
       if (charts.shareArea) {
@@ -1644,6 +1694,11 @@ function renderChartForPanel(panelType) {
         charts.shareArea.options.plugins.datalabels.display = (ctx) => chartLabelState.share && !ctx.dataset.hidden;
         charts.shareArea.options.plugins.datalabels.offset = shareLabelOffset;
         charts.shareArea.options.plugins.datalabels.color = shareLabelColor;
+        charts.shareArea.options.plugins.datalabels.align = (ctx) => (ctx.datasetIndex === 0 ? 'end' : 'start');
+        charts.shareArea.options.plugins.datalabels.anchor = (ctx) => (ctx.datasetIndex === 0 ? 'end' : 'start');
+        charts.shareArea.options.plugins.datalabels.backgroundColor = 'rgba(255, 255, 255, 0.9)';
+        charts.shareArea.options.plugins.datalabels.borderRadius = 6;
+        charts.shareArea.options.plugins.datalabels.padding = { top: 2, bottom: 2, left: 6, right: 6 };
         charts.shareArea.options.plugins.datalabels.formatter = shareLabelFormatter;
         charts.shareArea.update();
       } else {
@@ -1669,10 +1724,13 @@ function renderChartForPanel(panelType) {
               },
               datalabels: {
                 display: (ctx) => chartLabelState.share && !ctx.dataset.hidden,
-                align: 'center',
-                anchor: 'center',
+                align: (ctx) => (ctx.datasetIndex === 0 ? 'end' : 'start'),
+                anchor: (ctx) => (ctx.datasetIndex === 0 ? 'end' : 'start'),
                 clip: false,
                 offset: shareLabelOffset,
+                backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                borderRadius: 6,
+                padding: { top: 2, bottom: 2, left: 6, right: 6 },
                 color: shareLabelColor,
                 font: { weight: 600, size: 10 },
                 formatter: shareLabelFormatter
@@ -1706,6 +1764,19 @@ function renderChartForPanel(panelType) {
         charts.cumulative.data.datasets[1].data = cumulativeInterest;
         charts.cumulative.data.datasets[2].data = cumulativePrincipal.map((value, index) => value + cumulativeInterest[index]);
         charts.cumulative.options.plugins.datalabels.display = chartLabelState.cumulative;
+        charts.cumulative.options.plugins.datalabels.align = (context) => {
+          if (context.datasetIndex === 2) return 'end';
+          return context.datasetIndex === 1 ? 'bottom' : 'top';
+        };
+        charts.cumulative.options.plugins.datalabels.anchor = (context) => {
+          if (context.datasetIndex === 2) return 'end';
+          return context.datasetIndex === 1 ? 'start' : 'end';
+        };
+        charts.cumulative.options.plugins.datalabels.backgroundColor = 'rgba(255, 255, 255, 0.9)';
+        charts.cumulative.options.plugins.datalabels.borderRadius = 6;
+        charts.cumulative.options.plugins.datalabels.padding = { top: 2, bottom: 2, left: 6, right: 6 };
+        charts.cumulative.options.plugins.datalabels.clamp = true;
+        charts.cumulative.options.plugins.datalabels.formatter = (value) => fmtChartValue(value);
         charts.cumulative.update();
       } else {
         charts.cumulative = new Chart(cumulativeCtx, {
@@ -1727,22 +1798,32 @@ function renderChartForPanel(panelType) {
               legend: { position: 'bottom' },
               tooltip: {
                 callbacks: {
-                  label: (context) => `${context.dataset.label}: ${fmt(context.raw)}`
+                  label: (context) => `${context.dataset.label}: ${fmtChartValue(context.raw)}`
                 }
               },
               datalabels: {
                 display: chartLabelState.cumulative,
-                align: (context) => (context.datasetIndex === 1 ? 'bottom' : 'top'),
-                anchor: (context) => (context.datasetIndex === 1 ? 'start' : 'end'),
+                align: (context) => {
+                  if (context.datasetIndex === 2) return 'end';
+                  return context.datasetIndex === 1 ? 'bottom' : 'top';
+                },
+                anchor: (context) => {
+                  if (context.datasetIndex === 2) return 'end';
+                  return context.datasetIndex === 1 ? 'start' : 'end';
+                },
                 color: (context) => context.dataset.borderColor || palette.ink,
+                backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                borderRadius: 6,
+                padding: { top: 2, bottom: 2, left: 6, right: 6 },
                 font: { weight: 600, size: 10 },
-                formatter: (value) => fmt(value)
+                clamp: true,
+                formatter: (value) => fmtChartValue(value)
               }
             },
             scales: {
               y: {
                 grid: { color: palette.line },
-                ticks: { callback: (value) => fmtPlain(value) }
+                ticks: { callback: (value) => fmtChartTick(value) }
               }
             }
           }
@@ -1786,7 +1867,7 @@ function renderChartForPanel(panelType) {
               legend: { display: false },
               tooltip: {
                 callbacks: {
-                  label: (context) => `Saldo: ${fmt(context.raw)}`
+                  label: (context) => `Saldo: ${fmtChartValue(context.raw)}`
                 }
               },
               datalabels: {
@@ -1796,14 +1877,14 @@ function renderChartForPanel(panelType) {
                 font: { weight: 700, size: 11 },
                 formatter: (value, context) => {
                   const dataset = context.dataset.data || [];
-                  return context.dataIndex === dataset.length - 1 ? fmt(value) : '';
+                  return context.dataIndex === dataset.length - 1 ? fmtChartValue(value) : '';
                 }
               }
             },
             scales: {
               y: {
                 grid: { color: palette.line },
-                ticks: { callback: (value) => fmtPlain(value) }
+                ticks: { callback: (value) => fmtChartTick(value) }
               }
             }
           }
@@ -1887,7 +1968,7 @@ function renderChartForPanel(panelType) {
                 position: 'left',
                 display: showValue,
                 grid: { color: palette.line },
-                ticks: { callback: (value) => fmtPlain(value) }
+                ticks: { callback: (value) => fmtChartTick(value) }
               },
               yPercent: {
                 type: 'linear',
@@ -1909,7 +1990,7 @@ function renderChartForPanel(panelType) {
                       const sign = numeric > 0 ? '+' : '';
                       return `${context.dataset.label}: ${sign}${numeric.toFixed(2)}%`;
                     }
-                    return `${context.dataset.label}: ${fmt(context.raw)}`;
+                    return `${context.dataset.label}: ${fmtChartValue(context.raw)}`;
                   }
                 }
               },
@@ -1938,7 +2019,7 @@ function renderChartForPanel(panelType) {
                     const sign = numeric > 0 ? '+' : '';
                     return `${sign}${numeric.toFixed(2)}%`;
                   }
-                  return fmt(value);
+                  return fmtChartValue(value);
                 }
               }
             }

--- a/loan.html
+++ b/loan.html
@@ -496,6 +496,7 @@
             <div class="kpi-body">
               <span class="kpi-label">Kapitał pozostały</span>
               <span class="kpi-value" id="capital-remaining">—</span>
+              <span class="tiny muted" id="capital-remaining-note"></span>
             </div>
           </div>
           <div class="kpi-compact">
@@ -503,6 +504,7 @@
             <div class="kpi-body">
               <span class="kpi-label">Kapitał spłacony</span>
               <span class="kpi-value" id="capital-paid">—</span>
+              <span class="tiny muted" id="capital-paid-note"></span>
             </div>
           </div>
           <div class="kpi-compact">
@@ -510,6 +512,7 @@
             <div class="kpi-body">
               <span class="kpi-label">Odsetki spłacone</span>
               <span class="kpi-value" id="interest-paid">—</span>
+              <span class="tiny muted" id="interest-paid-note"></span>
             </div>
           </div>
           <div class="kpi-compact">
@@ -517,6 +520,7 @@
             <div class="kpi-body">
               <span class="kpi-label">Śr. rata</span>
               <span class="kpi-value" id="avg-installment">—</span>
+              <span class="tiny muted" id="avg-installment-note"></span>
             </div>
           </div>
           <div class="kpi-compact">
@@ -775,6 +779,51 @@ function renderDashboard() {
     const avgInstallment = monthsPaid > 0 ? payments.reduce((s, p) => s + p.capital + p.interest + (p.overpayment || 0), 0) / monthsPaid : 0;
     const projectedMonthsRemaining = avgMonthlyPrincipal > 0 ? capitalRemaining / avgMonthlyPrincipal : Infinity;
     const monthsSaved = originalMonths - monthsPaid - projectedMonthsRemaining;
+
+    const capitalRemainingNoteEl = $('#capital-remaining-note');
+    const capitalPaidNoteEl = $('#capital-paid-note');
+    const interestPaidNoteEl = $('#interest-paid-note');
+    const avgInstallmentNoteEl = $('#avg-installment-note');
+
+    if (capitalRemainingNoteEl) {
+        if (payments.length && projectedMonthsRemaining && isFinite(projectedMonthsRemaining)) {
+            const monthsLeft = Math.max(0, Math.round(projectedMonthsRemaining));
+            const label = monthsLeft > 0 ? `~${monthsLeft} rat do końca` : 'Finisz w zasięgu ręki';
+            capitalRemainingNoteEl.textContent = label;
+        } else if (loanDetails.totalCapital) {
+            capitalRemainingNoteEl.textContent = 'Dodaj raty, by wyliczyć prognozę';
+        } else {
+            capitalRemainingNoteEl.textContent = '';
+        }
+    }
+
+    if (capitalPaidNoteEl) {
+        if (payments.length) {
+            capitalPaidNoteEl.textContent = totalOverpayments > 0 ? `Nadpłaty ${fmt(totalOverpayments)}` : "Standardowe raty bez nadpłat";
+        } else {
+            capitalPaidNoteEl.textContent = 'Dodaj pierwszą ratę';
+        }
+    }
+
+    if (interestPaidNoteEl) {
+        const totalOutflow = payments.reduce((sum, p) => sum + p.capital + p.interest + (p.overpayment || 0), 0);
+        if (totalOutflow > 0) {
+            const share = ((totalInterestPaid / totalOutflow) * 100).toFixed(1);
+            interestPaidNoteEl.textContent = `To ${share}% wszystkich wpłat`;
+        } else {
+            interestPaidNoteEl.textContent = 'Brak danych o odsetkach';
+        }
+    }
+
+    if (avgInstallmentNoteEl) {
+        if (payments.length) {
+            const latestPayment = [...payments].sort((a, b) => (a.date || '').localeCompare(b.date || '')).pop();
+            const latestTotal = latestPayment ? latestPayment.capital + latestPayment.interest + (latestPayment.overpayment || 0) : 0;
+            avgInstallmentNoteEl.textContent = latestPayment ? `Ostatnia rata ${fmt(latestTotal)}` : '';
+        } else {
+            avgInstallmentNoteEl.textContent = 'Brak danych o ratach';
+        }
+    }
 
     const avgInstallmentEl = $('#avg-installment');
     if (avgInstallmentEl) {

--- a/loan.html
+++ b/loan.html
@@ -182,6 +182,53 @@
       gap: 18px;
     }
 
+    .loan-analytics-hub {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .loan-tab-nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .loan-tab-btn {
+      border: 1px solid var(--line);
+      background: var(--surface);
+      color: var(--muted);
+      padding: 8px 14px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    }
+
+    .loan-tab-btn.active {
+      background: var(--ink);
+      color: var(--card);
+      border-color: transparent;
+    }
+
+    .loan-tab-panels {
+      position: relative;
+      min-height: 320px;
+    }
+
+    .loan-tab-panel {
+      display: none;
+      flex-direction: column;
+      gap: 18px;
+    }
+
+    .loan-tab-panel.active {
+      display: flex;
+    }
+
     .loan-chart-grid {
       display: grid;
       grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
@@ -199,6 +246,19 @@
     @media (max-width: 1200px) {
       .loan-chart-grid { grid-template-columns: 1fr; }
       .loan-donut-area { min-height: 240px; }
+    }
+
+    .loan-chart-placeholder {
+      display: none;
+      border: 1px dashed var(--line);
+      border-radius: 14px;
+      padding: 32px;
+      text-align: center;
+      font-size: 14px;
+      color: var(--muted);
+      align-items: center;
+      justify-content: center;
+      min-height: 220px;
     }
 
     .loan-table-card {
@@ -442,17 +502,47 @@
                 </div>
               </section>
 
-              <section class="card loan-charts-card">
+              <section class="card loan-charts-card" id="loan-analytics-card">
                 <div class="section-heading">
-                  <h2 class="title">Kapitał i odsetki</h2>
-                  <span class="tiny muted">Śledź jak zmienia się struktura każdej raty</span>
+                  <h2 class="title">Hub analityczny</h2>
+                  <span class="tiny muted">Przełącz zakładki, aby porównać strukturę rat i postępy spłaty</span>
                 </div>
-                <div class="loan-chart-grid">
-                  <div class="loan-chart-area">
-                    <canvas id="capital-chart"></canvas>
+                <div class="loan-analytics-hub">
+                  <div class="loan-tab-nav" id="loan-tab-nav">
+                    <button class="loan-tab-btn active" data-chart="mix">Struktura raty</button>
+                    <button class="loan-tab-btn" data-chart="line">Kapitał vs odsetki</button>
+                    <button class="loan-tab-btn" data-chart="share">Udziały w czasie</button>
+                    <button class="loan-tab-btn" data-chart="cumulative">Kumulacja spłat</button>
                   </div>
-                  <div class="loan-donut-area">
-                    <canvas id="structure-chart"></canvas>
+                  <div id="loan-chart-placeholder" class="loan-chart-placeholder">
+                    Dodaj raty, aby zobaczyć analizy spłaty kredytu.
+                  </div>
+                  <div class="loan-tab-panels" id="loan-tab-panels">
+                    <div class="loan-tab-panel active" data-chart="mix">
+                      <div class="loan-chart-grid">
+                        <div class="loan-chart-area">
+                          <canvas id="capital-chart"></canvas>
+                        </div>
+                        <div class="loan-donut-area">
+                          <canvas id="structure-chart"></canvas>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="loan-tab-panel" data-chart="line">
+                      <div class="loan-chart-area" style="min-height:320px;">
+                        <canvas id="monthly-line-chart"></canvas>
+                      </div>
+                    </div>
+                    <div class="loan-tab-panel" data-chart="share">
+                      <div class="loan-chart-area" style="min-height:320px;">
+                        <canvas id="share-area-chart"></canvas>
+                      </div>
+                    </div>
+                    <div class="loan-tab-panel" data-chart="cumulative">
+                      <div class="loan-chart-area" style="min-height:320px;">
+                        <canvas id="cumulative-chart"></canvas>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </section>
@@ -556,6 +646,7 @@ const defaultState = {
 
 let state = {};
 let charts = {};
+let chartDataCache = null;
 
 function $(selector) { return document.querySelector(selector); }
 function $$(selector) { return document.querySelectorAll(selector); }
@@ -1035,84 +1126,371 @@ function renderRateHistory(loanDetails, nextPaymentMonth) {
 }
 
 function renderCharts() {
-  const capitalCtx = $('#capital-chart').getContext('2d');
-  const structureCtx = $('#structure-chart').getContext('2d');
-  if (charts.capital) charts.capital.destroy();
-  if (charts.structure) charts.structure.destroy();
+  const placeholder = $('#loan-chart-placeholder');
+  const panels = $('#loan-tab-panels');
+  const tabNav = $('#loan-tab-nav');
+  const payments = state.payments || [];
+  const loanDetails = state.loanDetails || { interestRateHistory: [] };
+  const hasPayments = payments.length > 0;
+
+  if (placeholder) {
+    placeholder.style.display = hasPayments ? 'none' : 'flex';
+  }
+  if (panels) {
+    panels.style.display = hasPayments ? 'block' : 'none';
+  }
+  if (tabNav) {
+    tabNav.style.display = hasPayments ? 'flex' : 'none';
+  }
+
+  if (!hasPayments) {
+    destroyAllLoanCharts();
+    chartDataCache = null;
+    return;
+  }
 
   Chart.defaults.font.family = "'Inter', sans-serif";
   Chart.defaults.color = getComputedStyle(document.body).getPropertyValue('--muted').trim();
 
-  const { payments, loanDetails } = state;
-  const paymentLabels = payments.map(p => new Date(p.date+'-02').toLocaleDateString('pl-PL', {month:'short', year:'2-digit'}));
-  
-  const interestRateData = payments.map(p => getRateForDate(p.date, loanDetails.interestRateHistory));
+  const paymentLabels = payments.map(p => new Date(p.date + '-02').toLocaleDateString('pl-PL', { month: 'short', year: '2-digit' }));
+  const principalSeries = payments.map(p => p.capital + (p.overpayment || 0));
+  const interestSeries = payments.map(p => p.interest);
+  const totalSeries = principalSeries.map((value, index) => value + interestSeries[index]);
+  const cumulativePrincipal = [];
+  const cumulativeInterest = [];
+  let principalRunning = 0;
+  let interestRunning = 0;
+  principalSeries.forEach((value, index) => {
+    principalRunning += value;
+    interestRunning += interestSeries[index];
+    cumulativePrincipal.push(principalRunning);
+    cumulativeInterest.push(interestRunning);
+  });
 
-  const greenColor = getComputedStyle(document.body).getPropertyValue('--green').trim();
-  const orangeColor = getComputedStyle(document.body).getPropertyValue('--orange').trim();
-  const blueColor = getComputedStyle(document.body).getPropertyValue('--blue').trim();
-
-  charts.capital = new Chart(capitalCtx, {
-    type: 'bar',
-    data: {
-      labels: paymentLabels,
-      datasets: [
-        { type: 'line', label: 'Oprocentowanie', data: interestRateData, borderColor: blueColor, yAxisID: 'yRate', tension: 0.1, pointRadius: 3, pointBackgroundColor: blueColor },
-        { label: 'Kapitał', data: payments.map(p => p.capital + (p.overpayment || 0)), backgroundColor: greenColor, borderRadius: 4, order: 2 },
-        { label: 'Odsetki', data: payments.map(p => p.interest), backgroundColor: orangeColor, borderRadius: 4, order: 3 },
-      ]
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      scales: {
-        x: { stacked: true, grid: { display: false } },
-        y: { stacked: true, grid: { color: getComputedStyle(document.body).getPropertyValue('--line').trim() }, ticks: { callback: (value) => fmt(value).replace(/\sPLN/,'') } },
-        yRate: { type: 'linear', position: 'right', grid: { display: false }, ticks: { callback: (value) => `${value}%` } }
-      },
-      plugins: {
-        legend: { position: 'bottom' },
-        tooltip: { callbacks: { label: (context) => `${context.dataset.label}: ${context.dataset.type === 'line' ? context.raw+'%' : fmt(context.raw)}` } }
-      }
+  const sharePrincipal = [];
+  const shareInterest = [];
+  totalSeries.forEach((total, index) => {
+    if (total > 0) {
+      const principalShare = Number(((principalSeries[index] / total) * 100).toFixed(1));
+      const interestShare = Math.max(0, Number((100 - principalShare).toFixed(1)));
+      sharePrincipal.push(principalShare);
+      shareInterest.push(interestShare);
+    } else {
+      sharePrincipal.push(0);
+      shareInterest.push(0);
     }
   });
 
-  const totalCapitalPaid = payments.reduce((sum, p) => sum + p.capital + (p.overpayment || 0), 0);
-  const totalInterestPaid = payments.reduce((sum, p) => sum + p.interest, 0);
-  const totalPaid = totalCapitalPaid + totalInterestPaid;
+  const rateHistory = loanDetails.interestRateHistory || [];
+  const interestRateData = payments.map(p => getRateForDate(p.date, rateHistory));
+  const totalCapitalPaid = principalSeries.reduce((sum, value) => sum + value, 0);
+  const totalInterestPaid = interestSeries.reduce((sum, value) => sum + value, 0);
 
-  charts.structure = new Chart(structureCtx, {
-    type: 'doughnut',
-    data: {
-      labels: ['Spłacony kapitał', 'Zapłacone odsetki'],
-      datasets: [{ data: [totalCapitalPaid, totalInterestPaid], backgroundColor: [greenColor, orangeColor], borderColor: getComputedStyle(document.body).getPropertyValue('--card').trim(), borderWidth: 5, hoverOffset: 8 }]
-    },
-    plugins: [ChartDataLabels, doughnutCenterText],
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      cutout: '65%',
-      plugins: {
-        datalabels: {
-          formatter: (value, ctx) => {
-            if (totalPaid === 0) return '0%';
-            const percentage = ((value / totalPaid) * 100).toFixed(1) + '%';
-            return ctx.dataset.data[ctx.dataIndex] > 0 ? percentage : '';
+  chartDataCache = {
+    labels: paymentLabels,
+    principalSeries,
+    interestSeries,
+    totalSeries,
+    cumulativePrincipal,
+    cumulativeInterest,
+    sharePrincipal,
+    shareInterest,
+    interestRateData,
+    totals: { principal: totalCapitalPaid, interest: totalInterestPaid }
+  };
+
+  const activePanel = document.querySelector('.loan-tab-panel.active');
+  const activeChart = activePanel ? activePanel.dataset.chart : 'mix';
+  renderChartForPanel(activeChart);
+}
+
+function destroyAllLoanCharts() {
+  Object.keys(charts).forEach(key => {
+    if (charts[key]) {
+      charts[key].destroy();
+      delete charts[key];
+    }
+  });
+}
+
+function getLoanPalette() {
+  const styles = getComputedStyle(document.body);
+  return {
+    green: styles.getPropertyValue('--green').trim(),
+    greenSoft: styles.getPropertyValue('--green-soft').trim(),
+    orange: styles.getPropertyValue('--orange').trim(),
+    orangeSoft: styles.getPropertyValue('--orange-soft').trim(),
+    blue: styles.getPropertyValue('--blue').trim(),
+    blueSoft: styles.getPropertyValue('--blue-soft').trim(),
+    line: styles.getPropertyValue('--line').trim(),
+    card: styles.getPropertyValue('--card').trim(),
+    ink: styles.getPropertyValue('--ink').trim()
+  };
+}
+
+function renderChartForPanel(panelType) {
+  if (!chartDataCache) return;
+  const palette = getLoanPalette();
+  const { labels, principalSeries, interestSeries, interestRateData, totals, sharePrincipal, shareInterest, cumulativePrincipal, cumulativeInterest } = chartDataCache;
+
+  if (panelType === 'mix') {
+    const capitalCanvas = $('#capital-chart');
+    if (capitalCanvas) {
+      const capitalCtx = capitalCanvas.getContext('2d');
+      if (charts.capital) {
+        charts.capital.data.labels = labels;
+        charts.capital.data.datasets[0].data = interestRateData;
+        charts.capital.data.datasets[1].data = principalSeries;
+        charts.capital.data.datasets[2].data = interestSeries;
+        charts.capital.update();
+      } else {
+        charts.capital = new Chart(capitalCtx, {
+          type: 'bar',
+          data: {
+            labels,
+            datasets: [
+              { type: 'line', label: 'Oprocentowanie', data: interestRateData, borderColor: palette.blue, yAxisID: 'yRate', tension: 0.2, pointRadius: 3, pointBackgroundColor: palette.blue, borderWidth: 2 },
+              { label: 'Kapitał', data: principalSeries, backgroundColor: palette.green, borderRadius: 4, order: 2 },
+              { label: 'Odsetki', data: interestSeries, backgroundColor: palette.orange, borderRadius: 4, order: 3 }
+            ]
           },
-          color: '#fff',
-          font: { weight: 'bold', size: 12 },
-        },
-        legend: { display: false },
-        tooltip: {
-          callbacks: {
-            label: (context) => {
-                const label = context.label || '';
-                const value = context.raw || 0;
-                const percentage = totalPaid > 0 ? ((value / totalPaid) * 100).toFixed(2) : 0;
-                return `${label}: ${fmt(value)} (${percentage}%)`;
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: { stacked: true, grid: { display: false } },
+              y: { stacked: true, grid: { color: palette.line }, ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') } },
+              yRate: { type: 'linear', position: 'right', grid: { display: false }, ticks: { callback: (value) => `${value}%` } }
+            },
+            plugins: {
+              legend: { position: 'bottom' },
+              tooltip: {
+                callbacks: {
+                  label: (context) => {
+                    if (context.dataset.type === 'line') {
+                      return `${context.dataset.label}: ${context.raw}%`;
+                    }
+                    return `${context.dataset.label}: ${fmt(context.raw)}`;
+                  }
+                }
+              }
             }
           }
-        },
+        });
       }
+      setTimeout(() => charts.capital && charts.capital.resize(), 30);
     }
+
+    const structureCanvas = $('#structure-chart');
+    if (structureCanvas) {
+      const structureCtx = structureCanvas.getContext('2d');
+      const totalPaid = totals.principal + totals.interest;
+      if (charts.structure) {
+        charts.structure.data.datasets[0].data = [totals.principal, totals.interest];
+        charts.structure.options.plugins.datalabels.formatter = (value, ctx) => {
+          const sum = totals.principal + totals.interest;
+          if (sum === 0) return '0%';
+          const percentage = ((value / sum) * 100).toFixed(1) + '%';
+          return ctx.dataset.data[ctx.dataIndex] > 0 ? percentage : '';
+        };
+        charts.structure.options.plugins.tooltip.callbacks.label = (context) => {
+          const label = context.label || '';
+          const value = context.raw || 0;
+          const sum = totals.principal + totals.interest;
+          const percentage = sum > 0 ? ((value / sum) * 100).toFixed(2) : 0;
+          return `${label}: ${fmt(value)} (${percentage}%)`;
+        };
+        charts.structure.update();
+      } else {
+        charts.structure = new Chart(structureCtx, {
+          type: 'doughnut',
+          data: {
+            labels: ['Spłacony kapitał', 'Zapłacone odsetki'],
+            datasets: [{ data: [totals.principal, totals.interest], backgroundColor: [palette.green, palette.orange], borderColor: palette.card, borderWidth: 5, hoverOffset: 8 }]
+          },
+          plugins: [ChartDataLabels, doughnutCenterText],
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            cutout: '65%',
+            plugins: {
+              datalabels: {
+                formatter: (value, ctx) => {
+                  if (totalPaid === 0) return '0%';
+                  const percentage = ((value / totalPaid) * 100).toFixed(1) + '%';
+                  return ctx.dataset.data[ctx.dataIndex] > 0 ? percentage : '';
+                },
+                color: '#fff',
+                font: { weight: 'bold', size: 12 }
+              },
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: (context) => {
+                    const label = context.label || '';
+                    const value = context.raw || 0;
+                    const percentage = totalPaid > 0 ? ((value / totalPaid) * 100).toFixed(2) : 0;
+                    return `${label}: ${fmt(value)} (${percentage}%)`;
+                  }
+                }
+              }
+            }
+          }
+        });
+      }
+      setTimeout(() => charts.structure && charts.structure.resize(), 30);
+    }
+  }
+
+  if (panelType === 'line') {
+    const lineCanvas = $('#monthly-line-chart');
+    if (lineCanvas) {
+      const lineCtx = lineCanvas.getContext('2d');
+      if (charts.monthlyLine) {
+        charts.monthlyLine.data.labels = labels;
+        charts.monthlyLine.data.datasets[0].data = principalSeries;
+        charts.monthlyLine.data.datasets[1].data = interestSeries;
+        charts.monthlyLine.update();
+      } else {
+        charts.monthlyLine = new Chart(lineCtx, {
+          type: 'line',
+          data: {
+            labels,
+            datasets: [
+              { label: 'Kapitał', data: principalSeries, borderColor: palette.green, backgroundColor: palette.greenSoft, fill: false, tension: 0.25, pointRadius: 3, pointBackgroundColor: palette.green },
+              { label: 'Odsetki', data: interestSeries, borderColor: palette.orange, backgroundColor: palette.orangeSoft, fill: false, tension: 0.25, pointRadius: 3, pointBackgroundColor: palette.orange }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { position: 'bottom' },
+              tooltip: {
+                callbacks: {
+                  label: (context) => `${context.dataset.label}: ${fmt(context.raw)}`
+                }
+              }
+            },
+            scales: {
+              y: {
+                grid: { color: palette.line },
+                ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') }
+              }
+            }
+          }
+        });
+      }
+      setTimeout(() => charts.monthlyLine && charts.monthlyLine.resize(), 30);
+    }
+  }
+
+  if (panelType === 'share') {
+    const shareCanvas = $('#share-area-chart');
+    if (shareCanvas) {
+      const shareCtx = shareCanvas.getContext('2d');
+      if (charts.shareArea) {
+        charts.shareArea.data.labels = labels;
+        charts.shareArea.data.datasets[0].data = sharePrincipal;
+        charts.shareArea.data.datasets[1].data = shareInterest;
+        charts.shareArea.update();
+      } else {
+        charts.shareArea = new Chart(shareCtx, {
+          type: 'line',
+          data: {
+            labels,
+            datasets: [
+              { label: 'Kapitał %', data: sharePrincipal, borderColor: palette.green, backgroundColor: palette.greenSoft, fill: 'origin', tension: 0.25, pointRadius: 0, stack: 'shares' },
+              { label: 'Odsetki %', data: shareInterest, borderColor: palette.orange, backgroundColor: palette.orangeSoft, fill: '-1', tension: 0.25, pointRadius: 0, stack: 'shares' }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { position: 'bottom' },
+              tooltip: {
+                callbacks: {
+                  label: (context) => `${context.dataset.label}: ${context.raw.toFixed(1)}%`
+                }
+              }
+            },
+            scales: {
+              x: {
+                grid: { color: palette.line, drawOnChartArea: false }
+              },
+              y: {
+                stacked: true,
+                min: 0,
+                max: 100,
+                ticks: { callback: (value) => `${value}%` },
+                grid: { color: palette.line }
+              }
+            }
+          }
+        });
+      }
+      setTimeout(() => charts.shareArea && charts.shareArea.resize(), 30);
+    }
+  }
+
+  if (panelType === 'cumulative') {
+    const cumulativeCanvas = $('#cumulative-chart');
+    if (cumulativeCanvas) {
+      const cumulativeCtx = cumulativeCanvas.getContext('2d');
+      if (charts.cumulative) {
+        charts.cumulative.data.labels = labels;
+        charts.cumulative.data.datasets[0].data = cumulativePrincipal;
+        charts.cumulative.data.datasets[1].data = cumulativeInterest;
+        charts.cumulative.data.datasets[2].data = cumulativePrincipal.map((value, index) => value + cumulativeInterest[index]);
+        charts.cumulative.update();
+      } else {
+        charts.cumulative = new Chart(cumulativeCtx, {
+          type: 'line',
+          data: {
+            labels,
+            datasets: [
+              { label: 'Kapitał skumulowany', data: cumulativePrincipal, borderColor: palette.green, backgroundColor: palette.greenSoft, fill: false, tension: 0.25, pointRadius: 0 },
+              { label: 'Odsetki skumulowane', data: cumulativeInterest, borderColor: palette.orange, backgroundColor: palette.orangeSoft, fill: false, tension: 0.25, pointRadius: 0 },
+              { label: 'Łącznie', data: cumulativePrincipal.map((value, index) => value + cumulativeInterest[index]), borderColor: palette.blue, backgroundColor: palette.blueSoft, fill: false, borderDash: [6, 4], tension: 0.25, pointRadius: 0 }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { position: 'bottom' },
+              tooltip: {
+                callbacks: {
+                  label: (context) => `${context.dataset.label}: ${fmt(context.raw)}`
+                }
+              }
+            },
+            scales: {
+              y: {
+                grid: { color: palette.line },
+                ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') }
+              }
+            }
+          }
+        });
+      }
+      setTimeout(() => charts.cumulative && charts.cumulative.resize(), 30);
+    }
+  }
+}
+
+function setupLoanChartTabs() {
+  document.querySelectorAll('.loan-tab-btn').forEach(button => {
+    button.addEventListener('click', () => {
+      const target = button.dataset.chart;
+      if (button.classList.contains('active')) {
+        return;
+      }
+      document.querySelectorAll('.loan-tab-btn').forEach(btn => btn.classList.toggle('active', btn === button));
+      document.querySelectorAll('.loan-tab-panel').forEach(panel => panel.classList.toggle('active', panel.dataset.chart === target));
+      renderChartForPanel(target);
+    });
   });
 }
 
@@ -1120,6 +1498,7 @@ function renderCharts() {
 function init() {
   loadState();
   render();
+  setupLoanChartTabs();
   $('#setup-loan-btn').addEventListener('click', openSetupModal);
   $('#settings-btn').addEventListener('click', openSetupModal);
   $('#add-payment-btn').addEventListener('click', () => openPaymentModal(null));

--- a/loan.html
+++ b/loan.html
@@ -763,10 +763,10 @@ function renderDashboard() {
     const capitalRemaining = loanDetails.totalCapital - totalCapitalPaid;
     const progress = (totalCapitalPaid / loanDetails.totalCapital) * 100;
 
-    $('#capital-remaining').innerHTML = `${fmt(capitalRemaining)}<span class="currency">PLN</span>`;
-    $('#capital-paid').innerHTML = `${fmt(totalCapitalPaid)}<span class="currency">PLN</span>`;
-    $('#overpayments-total').innerHTML = `${fmt(totalOverpayments)}<span class="currency">PLN</span>`;
-    $('#interest-paid').innerHTML = `${fmt(totalInterestPaid)}<span class="currency">PLN</span>`;
+    $('#capital-remaining').textContent = fmt(capitalRemaining);
+    $('#capital-paid').textContent = fmt(totalCapitalPaid);
+    $('#overpayments-total').textContent = fmt(totalOverpayments);
+    $('#interest-paid').textContent = fmt(totalInterestPaid);
     $('#payments-count').innerHTML = `${payments.length}<span class="currency">z ${loanDetails.loanTerm * 12}</span>`;
 
     const originalMonths = loanDetails.loanTerm * 12;

--- a/loan.html
+++ b/loan.html
@@ -232,8 +232,13 @@
     .loan-chart-actions {
       display: flex;
       justify-content: flex-end;
+      align-items: center;
       margin-bottom: 8px;
       gap: 8px;
+    }
+
+    .loan-chart-actions.with-switch {
+      justify-content: space-between;
     }
 
     .loan-chart-toggle {
@@ -245,6 +250,39 @@
       color: var(--ink);
       cursor: pointer;
       transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    .loan-chart-switch {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: var(--surface);
+    }
+
+    .loan-chart-mode-btn {
+      border: none;
+      background: transparent;
+      padding: 4px 12px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--muted);
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    .loan-chart-mode-btn.active {
+      background: var(--blue-soft);
+      color: var(--blue);
+      box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.06);
+    }
+
+    .loan-chart-mode-btn:focus-visible {
+      outline: 2px solid var(--blue);
+      outline-offset: 2px;
     }
 
     .loan-chart-toggle:hover,
@@ -591,7 +629,11 @@
                       </div>
                     </div>
                     <div class="loan-tab-panel" data-chart="change">
-                      <div class="loan-chart-actions">
+                      <div class="loan-chart-actions with-switch">
+                        <div class="loan-chart-switch" role="group" aria-label="Tryb zmian raty">
+                          <button class="loan-chart-mode-btn active" type="button" data-change-mode="value">Kwotowo</button>
+                          <button class="loan-chart-mode-btn" type="button" data-change-mode="percent">Procentowo</button>
+                        </div>
                         <button class="loan-chart-toggle" type="button" data-chart-toggle="change">Pokaż dane</button>
                       </div>
                       <div class="loan-chart-area" style="min-height:320px;">
@@ -709,6 +751,8 @@ const chartLabelState = {
   change: false
 };
 
+let paymentChangeMode = 'value';
+
 function $(selector) { return document.querySelector(selector); }
 function $$(selector) { return document.querySelectorAll(selector); }
 
@@ -723,8 +767,22 @@ function saveState() {
 }
 
 function fmt(n) {
-  try { return new Intl.NumberFormat('pl-PL', { style: 'currency', currency: 'PLN' }).format(n || 0); }
-  catch { return `${(n || 0).toFixed(2)} PLN`; }
+  try {
+    const value = Number(n || 0);
+    const formatter = new Intl.NumberFormat('pl-PL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    const formatted = formatter.format(value).replace(/\u00a0/g, ' ');
+    if (Math.abs(value) < 10000) {
+      const compact = formatted.replace(/\s(?=\d)/g, '');
+      return `${compact} zł`;
+    }
+    return `${formatted} zł`;
+  } catch {
+    return `${(n || 0).toFixed(2)} zł`;
+  }
+}
+
+function fmtPlain(n) {
+  return fmt(n).replace(/\s*zł/i, '').trim();
 }
 
 function formatRateValue(value) {
@@ -1259,14 +1317,8 @@ function renderCharts() {
     return Math.max(runningBalance, 0);
   });
 
-  const sortedRateHistory = [...rateHistory].sort((a, b) => a.date.localeCompare(b.date));
-  const rateHistoryLabels = sortedRateHistory.length
-    ? sortedRateHistory.map(entry => new Date(`${entry.date}-02`).toLocaleDateString('pl-PL', { month: 'short', year: '2-digit' }))
-    : paymentLabels;
-  const rateHistoryValuesRaw = sortedRateHistory.length
-    ? sortedRateHistory.map(entry => entry.rate)
-    : interestRateData;
-  const rateHistoryValues = rateHistoryValuesRaw.map(rate => formatRateValue(rate));
+  const rateHistoryLabels = paymentLabels;
+  const rateHistoryValues = interestRateData;
   const rateHistoryDiffs = rateHistoryValues.map((value, index) => {
     if (index === 0) return 0;
     const previous = rateHistoryValues[index - 1];
@@ -1275,6 +1327,9 @@ function renderCharts() {
   });
   const totalCapitalPaid = principalSeries.reduce((sum, value) => sum + value, 0);
   const totalInterestPaid = interestSeries.reduce((sum, value) => sum + value, 0);
+  const averageInstallment = totalSeries.length
+    ? Number((totalSeries.reduce((sum, value) => sum + value, 0) / totalSeries.length).toFixed(2))
+    : 0;
 
   const paymentChangeValues = totalSeries.map((value, index) => {
     if (index === 0) return 0;
@@ -1306,6 +1361,7 @@ function renderCharts() {
     rateHistoryDiffs,
     paymentChangeValues,
     paymentChangePercentages,
+    averageInstallment,
     totals: { principal: totalCapitalPaid, interest: totalInterestPaid }
   };
 
@@ -1359,18 +1415,37 @@ function renderChartForPanel(panelType) {
     rateHistoryValues,
     rateHistoryDiffs,
     paymentChangeValues,
-    paymentChangePercentages
+    paymentChangePercentages,
+    averageInstallment
   } = chartDataCache;
 
   if (panelType === 'mix') {
     const capitalCanvas = $('#capital-chart');
     if (capitalCanvas) {
       const capitalCtx = capitalCanvas.getContext('2d');
+      const minRateValue = interestRateData.length ? Math.min(...interestRateData) : 0;
+      const maxRateValue = interestRateData.length ? Math.max(...interestRateData) : 0;
+      const ratePadding = 0.4;
+      const suggestedRateMin = Number.isFinite(minRateValue) ? Math.min(minRateValue - ratePadding, 4) : 0;
+      const yRateMin = Math.max(0, Number.isFinite(suggestedRateMin) ? suggestedRateMin : 0);
+      const yRateMax = Number.isFinite(maxRateValue) ? maxRateValue + ratePadding : undefined;
       if (charts.capital) {
         charts.capital.data.labels = labels;
-        charts.capital.data.datasets[0].data = interestRateData;
-        charts.capital.data.datasets[1].data = principalSeries;
-        charts.capital.data.datasets[2].data = interestSeries;
+        const rateDataset = charts.capital.data.datasets.find(ds => ds.label === 'Oprocentowanie');
+        const principalDataset = charts.capital.data.datasets.find(ds => ds.label === 'Kapitał');
+        const interestDataset = charts.capital.data.datasets.find(ds => ds.label === 'Odsetki');
+        const averageDataset = charts.capital.data.datasets.find(ds => ds.label === 'Średnia rata');
+        if (rateDataset) rateDataset.data = interestRateData;
+        if (principalDataset) principalDataset.data = principalSeries;
+        if (interestDataset) interestDataset.data = interestSeries;
+        if (averageDataset) {
+          averageDataset.data = labels.map(() => averageInstallment);
+          averageDataset.hidden = !averageInstallment;
+        }
+        if (charts.capital.options?.scales?.yRate) {
+          charts.capital.options.scales.yRate.min = yRateMin;
+          charts.capital.options.scales.yRate.max = yRateMax;
+        }
         charts.capital.update();
       } else {
         charts.capital = new Chart(capitalCtx, {
@@ -1398,7 +1473,8 @@ function renderChartForPanel(panelType) {
                     return total ? fmt(total) : '';
                   }
                 }
-              }
+              },
+              { type: 'line', label: 'Średnia rata', data: labels.map(() => averageInstallment), borderColor: palette.ink, borderDash: [6, 4], borderWidth: 1.5, yAxisID: 'y', pointRadius: 0, tension: 0, datalabels: { display: false }, hidden: !averageInstallment }
             ]
           },
           plugins: [ChartDataLabels],
@@ -1407,15 +1483,15 @@ function renderChartForPanel(panelType) {
             maintainAspectRatio: false,
             scales: {
               x: { stacked: true, grid: { display: false } },
-              y: { stacked: true, grid: { color: palette.line }, ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') } },
-              yRate: { type: 'linear', position: 'right', grid: { display: false }, ticks: { callback: (value) => `${value}%` } }
+              y: { stacked: true, grid: { color: palette.line }, ticks: { callback: (value) => fmtPlain(value) } },
+              yRate: { type: 'linear', position: 'right', grid: { display: false }, min: yRateMin, max: yRateMax, ticks: { callback: (value) => `${value}%` } }
             },
             plugins: {
-              legend: { position: 'bottom' },
+              legend: { position: 'bottom', labels: { usePointStyle: true } },
               tooltip: {
                 callbacks: {
                   label: (context) => {
-                    if (context.dataset.type === 'line') {
+                    if (context.dataset.yAxisID === 'yRate') {
                       return `${context.dataset.label}: ${context.raw}%`;
                     }
                     return `${context.dataset.label}: ${fmt(context.raw)}`;
@@ -1533,7 +1609,7 @@ function renderChartForPanel(panelType) {
             scales: {
               y: {
                 grid: { color: palette.line },
-                ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') }
+                ticks: { callback: (value) => fmtPlain(value) }
               }
             }
           }
@@ -1546,11 +1622,29 @@ function renderChartForPanel(panelType) {
     const shareCanvas = $('#share-area-chart');
     if (shareCanvas) {
       const shareCtx = shareCanvas.getContext('2d');
+      const shareLabelFormatter = (value) => `${Number(value).toFixed(1)}%`;
+      const shareLabelOffset = (context) => {
+        const chart = context.chart;
+        const datasetIndex = context.datasetIndex;
+        const dataIndex = context.dataIndex;
+        const yScale = chart.scales.y;
+        if (!yScale) return 0;
+        const meta = chart.getDatasetMeta(datasetIndex);
+        if (!meta || !meta.data || !meta.data[dataIndex]) return 0;
+        const element = meta.data[dataIndex];
+        const target = datasetIndex === 0 ? 10 : 80;
+        const targetPixel = yScale.getPixelForValue(target);
+        return targetPixel - element.y;
+      };
+      const shareLabelColor = (context) => (context.datasetIndex === 0 ? palette.green : palette.orange);
       if (charts.shareArea) {
         charts.shareArea.data.labels = labels;
         charts.shareArea.data.datasets[0].data = sharePrincipal;
         charts.shareArea.data.datasets[1].data = shareInterest;
-        charts.shareArea.options.plugins.datalabels.display = chartLabelState.share;
+        charts.shareArea.options.plugins.datalabels.display = (ctx) => chartLabelState.share && !ctx.dataset.hidden;
+        charts.shareArea.options.plugins.datalabels.offset = shareLabelOffset;
+        charts.shareArea.options.plugins.datalabels.color = shareLabelColor;
+        charts.shareArea.options.plugins.datalabels.formatter = shareLabelFormatter;
         charts.shareArea.update();
       } else {
         charts.shareArea = new Chart(shareCtx, {
@@ -1567,19 +1661,21 @@ function renderChartForPanel(panelType) {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-              legend: { position: 'bottom' },
+              legend: { position: 'bottom', labels: { usePointStyle: true } },
               tooltip: {
                 callbacks: {
                   label: (context) => `${context.dataset.label}: ${context.raw.toFixed(1)}%`
                 }
               },
               datalabels: {
-                display: chartLabelState.share,
-                align: (context) => (context.datasetIndex === 0 ? 'top' : 'bottom'),
-                anchor: (context) => (context.datasetIndex === 0 ? 'end' : 'start'),
-                color: (context) => context.dataset.borderColor || palette.ink,
+                display: (ctx) => chartLabelState.share && !ctx.dataset.hidden,
+                align: 'center',
+                anchor: 'center',
+                clip: false,
+                offset: shareLabelOffset,
+                color: shareLabelColor,
                 font: { weight: 600, size: 10 },
-                formatter: (value) => `${Number(value).toFixed(1)}%`
+                formatter: shareLabelFormatter
               }
             },
             scales: {
@@ -1646,7 +1742,7 @@ function renderChartForPanel(panelType) {
             scales: {
               y: {
                 grid: { color: palette.line },
-                ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') }
+                ticks: { callback: (value) => fmtPlain(value) }
               }
             }
           }
@@ -1707,7 +1803,7 @@ function renderChartForPanel(panelType) {
             scales: {
               y: {
                 grid: { color: palette.line },
-                ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') }
+                ticks: { callback: (value) => fmtPlain(value) }
               }
             }
           }
@@ -1720,18 +1816,35 @@ function renderChartForPanel(panelType) {
   if (panelType === 'change') {
     const changeCanvas = $('#payment-change-chart');
     if (changeCanvas) {
+      updateChangeModeButtons();
       const changeCtx = changeCanvas.getContext('2d');
       const barColors = paymentChangeValues.map(value => {
         if (value < 0) return palette.green;
         if (value > 0) return palette.orange;
         return palette.line;
       });
+      const showValue = paymentChangeMode === 'value';
+      const showPercent = paymentChangeMode === 'percent';
       if (charts.paymentChange) {
         charts.paymentChange.data.labels = labels;
-        charts.paymentChange.data.datasets[0].data = paymentChangeValues;
-        charts.paymentChange.data.datasets[0].backgroundColor = barColors;
-        charts.paymentChange.data.datasets[1].data = paymentChangePercentages;
-        charts.paymentChange.options.plugins.datalabels.display = chartLabelState.change;
+        const valueDataset = charts.paymentChange.data.datasets.find(ds => ds.label === 'Zmiana kwotowa');
+        const percentDataset = charts.paymentChange.data.datasets.find(ds => ds.label === 'Zmiana %');
+        if (valueDataset) {
+          valueDataset.data = paymentChangeValues;
+          valueDataset.backgroundColor = barColors;
+          valueDataset.hidden = !showValue;
+        }
+        if (percentDataset) {
+          percentDataset.data = paymentChangePercentages;
+          percentDataset.hidden = !showPercent;
+        }
+        if (charts.paymentChange.options?.scales?.yValue) {
+          charts.paymentChange.options.scales.yValue.display = showValue;
+        }
+        if (charts.paymentChange.options?.scales?.yPercent) {
+          charts.paymentChange.options.scales.yPercent.display = showPercent;
+        }
+        charts.paymentChange.options.plugins.datalabels.display = (ctx) => chartLabelState.change && !ctx.dataset.hidden;
         charts.paymentChange.update();
       } else {
         charts.paymentChange = new Chart(changeCtx, {
@@ -1745,7 +1858,8 @@ function renderChartForPanel(panelType) {
                 data: paymentChangeValues,
                 backgroundColor: barColors,
                 borderRadius: 4,
-                yAxisID: 'yValue'
+                yAxisID: 'yValue',
+                hidden: !showValue
               },
               {
                 type: 'line',
@@ -1756,7 +1870,8 @@ function renderChartForPanel(panelType) {
                 fill: false,
                 tension: 0.25,
                 pointRadius: 3,
-                yAxisID: 'yPercent'
+                yAxisID: 'yPercent',
+                hidden: !showPercent
               }
             ]
           },
@@ -1770,12 +1885,14 @@ function renderChartForPanel(panelType) {
               yValue: {
                 type: 'linear',
                 position: 'left',
+                display: showValue,
                 grid: { color: palette.line },
-                ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') }
+                ticks: { callback: (value) => fmtPlain(value) }
               },
               yPercent: {
                 type: 'linear',
                 position: 'right',
+                display: showPercent,
                 grid: { display: false },
                 ticks: {
                   callback: (value) => `${value}%`
@@ -1797,7 +1914,7 @@ function renderChartForPanel(panelType) {
                 }
               },
               datalabels: {
-                display: chartLabelState.change,
+                display: (ctx) => chartLabelState.change && !ctx.dataset.hidden,
                 align: (context) => {
                   if (context.dataset.type === 'line') return 'bottom';
                   return Number(context.raw || 0) >= 0 ? 'top' : 'bottom';
@@ -1836,15 +1953,35 @@ function renderChartForPanel(panelType) {
     const rateCanvas = $('#rate-trend-chart');
     if (rateCanvas) {
       const rateCtx = rateCanvas.getContext('2d');
+      const minRateValue = rateHistoryValues.length ? Math.min(...rateHistoryValues) : 0;
+      const maxRateValue = rateHistoryValues.length ? Math.max(...rateHistoryValues) : 0;
+      const ratePadding = 0.25;
+      const yRateMin = Math.max(0, Math.min(minRateValue - ratePadding, 4));
+      const yRateMax = maxRateValue + ratePadding;
+      const pointColor = (index) => {
+        const diff = rateHistoryDiffs[index] || 0;
+        if (diff > 0.01) return palette.orange;
+        if (diff < -0.01) return palette.green;
+        return palette.line;
+      };
+      const pointRadius = (index) => (Math.abs(rateHistoryDiffs[index] || 0) >= 0.01 ? 4 : 2);
       if (charts.rateTrend) {
         charts.rateTrend.data.labels = rateHistoryLabels;
         charts.rateTrend.data.datasets[0].data = rateHistoryValues;
+        charts.rateTrend.data.datasets[0].pointBackgroundColor = (ctx) => pointColor(ctx.dataIndex);
+        charts.rateTrend.data.datasets[0].pointBorderColor = (ctx) => pointColor(ctx.dataIndex);
+        charts.rateTrend.data.datasets[0].pointRadius = (ctx) => pointRadius(ctx.dataIndex);
+        charts.rateTrend.data.datasets[0].pointHoverRadius = (ctx) => Math.max(5, pointRadius(ctx.dataIndex) + 1);
+        charts.rateTrend.data.datasets[0].segment = {
+          borderDash: (ctx) => (ctx.p0.parsed.y === ctx.p1.parsed.y ? [4, 4] : undefined),
+          borderColor: (ctx) => (ctx.p0.parsed.y === ctx.p1.parsed.y ? palette.line : palette.orange)
+        };
         charts.rateTrend.options.plugins.tooltip.callbacks.label = (context) => {
           const value = Number(context.raw || 0);
           const diff = rateHistoryDiffs[context.dataIndex] || 0;
           const base = `${context.dataset.label}: ${value.toFixed(2)}%`;
           if (context.dataIndex === 0 || Math.abs(diff) < 0.01) {
-            return base;
+            return `${base} (bez zmian)`;
           }
           const sign = diff > 0 ? '+' : '';
           return `${base} (${sign}${diff.toFixed(2)} pp)`;
@@ -1862,6 +1999,10 @@ function renderChartForPanel(panelType) {
           const sign = diff > 0 ? '+' : '';
           return `${sign}${diff.toFixed(2)} pp`;
         };
+        if (charts.rateTrend.options?.scales?.y) {
+          charts.rateTrend.options.scales.y.min = yRateMin;
+          charts.rateTrend.options.scales.y.max = yRateMax;
+        }
         charts.rateTrend.update();
       } else {
         charts.rateTrend = new Chart(rateCtx, {
@@ -1876,8 +2017,14 @@ function renderChartForPanel(panelType) {
                 backgroundColor: palette.orangeSoft,
                 fill: 'start',
                 tension: 0.25,
-                pointRadius: 4,
-                pointHoverRadius: 6
+                pointRadius: (ctx) => pointRadius(ctx.dataIndex),
+                pointHoverRadius: (ctx) => Math.max(5, pointRadius(ctx.dataIndex) + 1),
+                pointBackgroundColor: (ctx) => pointColor(ctx.dataIndex),
+                pointBorderColor: (ctx) => pointColor(ctx.dataIndex),
+                segment: {
+                  borderDash: (ctx) => (ctx.p0.parsed.y === ctx.p1.parsed.y ? [4, 4] : undefined),
+                  borderColor: (ctx) => (ctx.p0.parsed.y === ctx.p1.parsed.y ? palette.line : palette.orange)
+                }
               }
             ]
           },
@@ -1895,7 +2042,7 @@ function renderChartForPanel(panelType) {
                     const diff = rateHistoryDiffs[context.dataIndex] || 0;
                     const base = `${context.dataset.label}: ${value.toFixed(2)}%`;
                     if (context.dataIndex === 0 || Math.abs(diff) < 0.01) {
-                      return base;
+                      return `${base} (bez zmian)`;
                     }
                     const sign = diff > 0 ? '+' : '';
                     return `${base} (${sign}${diff.toFixed(2)} pp)`;
@@ -1925,7 +2072,9 @@ function renderChartForPanel(panelType) {
             scales: {
               y: {
                 grid: { color: palette.line },
-                ticks: { callback: (value) => `${value}%` }
+                ticks: { callback: (value) => `${value}%` },
+                min: yRateMin,
+                max: yRateMax
               }
             }
           }
@@ -1959,6 +2108,29 @@ function setupLoanChartToggles() {
   updateChartToggleLabels();
 }
 
+function updateChangeModeButtons() {
+  document.querySelectorAll('.loan-chart-mode-btn').forEach(button => {
+    const mode = button.dataset.changeMode;
+    button.classList.toggle('active', mode === paymentChangeMode);
+  });
+}
+
+function setupChangeModeSwitch() {
+  document.querySelectorAll('.loan-chart-mode-btn').forEach(button => {
+    button.addEventListener('click', () => {
+      const mode = button.dataset.changeMode;
+      if (!mode || mode === paymentChangeMode) return;
+      paymentChangeMode = mode;
+      updateChangeModeButtons();
+      const activePanel = document.querySelector('.loan-tab-panel.active');
+      if (activePanel && activePanel.dataset.chart === 'change') {
+        renderChartForPanel('change');
+      }
+    });
+  });
+  updateChangeModeButtons();
+}
+
 function setupLoanChartTabs() {
   document.querySelectorAll('.loan-tab-btn').forEach(button => {
     button.addEventListener('click', () => {
@@ -1979,6 +2151,7 @@ function init() {
   render();
   setupLoanChartTabs();
   setupLoanChartToggles();
+  setupChangeModeSwitch();
   $('#setup-loan-btn').addEventListener('click', openSetupModal);
   $('#settings-btn').addEventListener('click', openSetupModal);
   $('#add-payment-btn').addEventListener('click', () => openPaymentModal(null));

--- a/loan.html
+++ b/loan.html
@@ -493,35 +493,35 @@
         <aside class="right-rail">
           <div class="kpi-compact">
             <span class="kpi-emoji">💰</span>
-            <div>
+            <div class="kpi-body">
               <span class="kpi-label">Kapitał pozostały</span>
               <span class="kpi-value" id="capital-remaining">—</span>
             </div>
           </div>
           <div class="kpi-compact">
             <span class="kpi-emoji">📉</span>
-            <div>
+            <div class="kpi-body">
               <span class="kpi-label">Kapitał spłacony</span>
               <span class="kpi-value" id="capital-paid">—</span>
             </div>
           </div>
           <div class="kpi-compact">
             <span class="kpi-emoji">📈</span>
-            <div>
+            <div class="kpi-body">
               <span class="kpi-label">Odsetki spłacone</span>
               <span class="kpi-value" id="interest-paid">—</span>
             </div>
           </div>
           <div class="kpi-compact">
             <span class="kpi-emoji">💸</span>
-            <div>
+            <div class="kpi-body">
               <span class="kpi-label">Śr. rata</span>
               <span class="kpi-value" id="avg-installment">—</span>
             </div>
           </div>
           <div class="kpi-compact">
             <span class="kpi-emoji">⏳</span>
-            <div>
+            <div class="kpi-body">
               <span class="kpi-label">Następna rata</span>
               <span class="kpi-value" id="next-payment">—</span>
               <span class="tiny muted" id="next-payment-note"></span>

--- a/loan.html
+++ b/loan.html
@@ -229,6 +229,31 @@
       display: flex;
     }
 
+    .loan-chart-actions {
+      display: flex;
+      justify-content: flex-end;
+      margin-bottom: 8px;
+      gap: 8px;
+    }
+
+    .loan-chart-toggle {
+      font-size: 12px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: var(--surface);
+      color: var(--ink);
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    .loan-chart-toggle:hover,
+    .loan-chart-toggle:focus {
+      background: var(--card);
+      color: var(--ink);
+      outline: none;
+    }
+
     .loan-chart-grid {
       display: grid;
       grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
@@ -514,8 +539,8 @@
                     <button class="loan-tab-btn" data-chart="share">Udziały w czasie</button>
                     <button class="loan-tab-btn" data-chart="cumulative">Kumulacja spłat</button>
                     <button class="loan-tab-btn" data-chart="balance">Saldo kredytu</button>
-                    <button class="loan-tab-btn" data-chart="overpay">Nadpłaty</button>
                     <button class="loan-tab-btn" data-chart="rate">Trend oprocentowania</button>
+                    <button class="loan-tab-btn" data-chart="change">Zmiana raty</button>
                   </div>
                   <div id="loan-chart-placeholder" class="loan-chart-placeholder">
                     Dodaj raty, aby zobaczyć analizy spłaty kredytu.
@@ -532,16 +557,25 @@
                       </div>
                     </div>
                     <div class="loan-tab-panel" data-chart="line">
+                      <div class="loan-chart-actions">
+                        <button class="loan-chart-toggle" type="button" data-chart-toggle="line">Pokaż dane</button>
+                      </div>
                       <div class="loan-chart-area" style="min-height:320px;">
                         <canvas id="monthly-line-chart"></canvas>
                       </div>
                     </div>
                     <div class="loan-tab-panel" data-chart="share">
+                      <div class="loan-chart-actions">
+                        <button class="loan-chart-toggle" type="button" data-chart-toggle="share">Pokaż dane</button>
+                      </div>
                       <div class="loan-chart-area" style="min-height:320px;">
                         <canvas id="share-area-chart"></canvas>
                       </div>
                     </div>
                     <div class="loan-tab-panel" data-chart="cumulative">
+                      <div class="loan-chart-actions">
+                        <button class="loan-chart-toggle" type="button" data-chart-toggle="cumulative">Pokaż dane</button>
+                      </div>
                       <div class="loan-chart-area" style="min-height:320px;">
                         <canvas id="cumulative-chart"></canvas>
                       </div>
@@ -551,14 +585,17 @@
                         <canvas id="balance-chart"></canvas>
                       </div>
                     </div>
-                    <div class="loan-tab-panel" data-chart="overpay">
-                      <div class="loan-chart-area" style="min-height:320px;">
-                        <canvas id="overpayment-chart"></canvas>
-                      </div>
-                    </div>
                     <div class="loan-tab-panel" data-chart="rate">
                       <div class="loan-chart-area" style="min-height:320px;">
                         <canvas id="rate-trend-chart"></canvas>
+                      </div>
+                    </div>
+                    <div class="loan-tab-panel" data-chart="change">
+                      <div class="loan-chart-actions">
+                        <button class="loan-chart-toggle" type="button" data-chart-toggle="change">Pokaż dane</button>
+                      </div>
+                      <div class="loan-chart-area" style="min-height:320px;">
+                        <canvas id="payment-change-chart"></canvas>
                       </div>
                     </div>
                   </div>
@@ -665,6 +702,12 @@ const defaultState = {
 let state = {};
 let charts = {};
 let chartDataCache = null;
+const chartLabelState = {
+  line: false,
+  share: false,
+  cumulative: false,
+  change: false
+};
 
 function $(selector) { return document.querySelector(selector); }
 function $$(selector) { return document.querySelectorAll(selector); }
@@ -680,8 +723,14 @@ function saveState() {
 }
 
 function fmt(n) {
-  try { return new Intl.NumberFormat('pl-PL', { style: 'currency', currency: 'PLN' }).format(n || 0); } 
+  try { return new Intl.NumberFormat('pl-PL', { style: 'currency', currency: 'PLN' }).format(n || 0); }
   catch { return `${(n || 0).toFixed(2)} PLN`; }
+}
+
+function formatRateValue(value) {
+  const numeric = Number.parseFloat(value || 0);
+  if (Number.isNaN(numeric)) return 0;
+  return Number(numeric.toFixed(2));
 }
 
 /* === Modal Logic === */
@@ -1022,7 +1071,7 @@ function getRateForDate(paymentDate, history) {
             break;
         }
     }
-    return currentRate;
+    return formatRateValue(currentRate);
 }
 
 function getNextPaymentMonth(payments, loanDetails) {
@@ -1202,7 +1251,7 @@ function renderCharts() {
   });
 
   const rateHistory = loanDetails.interestRateHistory || [];
-  const interestRateData = payments.map(p => getRateForDate(p.date, rateHistory));
+  const interestRateData = payments.map(p => formatRateValue(getRateForDate(p.date, rateHistory)));
   const totalCapitalAmount = Number(loanDetails.totalCapital || 0);
   let runningBalance = totalCapitalAmount;
   const remainingBalances = payments.map((p, index) => {
@@ -1214,11 +1263,30 @@ function renderCharts() {
   const rateHistoryLabels = sortedRateHistory.length
     ? sortedRateHistory.map(entry => new Date(`${entry.date}-02`).toLocaleDateString('pl-PL', { month: 'short', year: '2-digit' }))
     : paymentLabels;
-  const rateHistoryValues = sortedRateHistory.length
-    ? sortedRateHistory.map(entry => Number(entry.rate || 0))
-    : interestRateData.map(rate => Number(rate || 0));
+  const rateHistoryValuesRaw = sortedRateHistory.length
+    ? sortedRateHistory.map(entry => entry.rate)
+    : interestRateData;
+  const rateHistoryValues = rateHistoryValuesRaw.map(rate => formatRateValue(rate));
+  const rateHistoryDiffs = rateHistoryValues.map((value, index) => {
+    if (index === 0) return 0;
+    const previous = rateHistoryValues[index - 1];
+    const diff = value - previous;
+    return formatRateValue(diff);
+  });
   const totalCapitalPaid = principalSeries.reduce((sum, value) => sum + value, 0);
   const totalInterestPaid = interestSeries.reduce((sum, value) => sum + value, 0);
+
+  const paymentChangeValues = totalSeries.map((value, index) => {
+    if (index === 0) return 0;
+    return value - totalSeries[index - 1];
+  });
+
+  const paymentChangePercentages = totalSeries.map((value, index) => {
+    if (index === 0) return 0;
+    const previous = totalSeries[index - 1];
+    if (!previous) return 0;
+    return Number(((value - previous) / previous * 100).toFixed(2));
+  });
 
   chartDataCache = {
     labels: paymentLabels,
@@ -1235,6 +1303,9 @@ function renderCharts() {
     remainingBalances,
     rateHistoryLabels,
     rateHistoryValues,
+    rateHistoryDiffs,
+    paymentChangeValues,
+    paymentChangePercentages,
     totals: { principal: totalCapitalPaid, interest: totalInterestPaid }
   };
 
@@ -1276,6 +1347,7 @@ function renderChartForPanel(panelType) {
     basePrincipalSeries,
     overpaymentSeries,
     interestSeries,
+    totalSeries,
     interestRateData,
     totals,
     sharePrincipal,
@@ -1284,7 +1356,10 @@ function renderChartForPanel(panelType) {
     cumulativeInterest,
     remainingBalances,
     rateHistoryLabels,
-    rateHistoryValues
+    rateHistoryValues,
+    rateHistoryDiffs,
+    paymentChangeValues,
+    paymentChangePercentages
   } = chartDataCache;
 
   if (panelType === 'mix') {
@@ -1303,11 +1378,30 @@ function renderChartForPanel(panelType) {
           data: {
             labels,
             datasets: [
-              { type: 'line', label: 'Oprocentowanie', data: interestRateData, borderColor: palette.blue, yAxisID: 'yRate', tension: 0.2, pointRadius: 3, pointBackgroundColor: palette.blue, borderWidth: 2 },
-              { label: 'Kapitał', data: principalSeries, backgroundColor: palette.green, borderRadius: 4, order: 2 },
-              { label: 'Odsetki', data: interestSeries, backgroundColor: palette.orange, borderRadius: 4, order: 3 }
+              { type: 'line', label: 'Oprocentowanie', data: interestRateData, borderColor: palette.blue, yAxisID: 'yRate', tension: 0.2, pointRadius: 3, pointBackgroundColor: palette.blue, borderWidth: 2, datalabels: { display: false } },
+              { label: 'Kapitał', data: principalSeries, backgroundColor: palette.green, borderRadius: 4, order: 2, datalabels: { display: false } },
+              {
+                label: 'Odsetki',
+                data: interestSeries,
+                backgroundColor: palette.orange,
+                borderRadius: 4,
+                order: 3,
+                datalabels: {
+                  anchor: 'end',
+                  align: 'top',
+                  color: palette.ink,
+                  font: { weight: 700, size: 11 },
+                  formatter: (value, context) => {
+                    const index = context.dataIndex;
+                    const principalValue = context.chart.data.datasets[1].data[index] || 0;
+                    const total = (value || 0) + principalValue;
+                    return total ? fmt(total) : '';
+                  }
+                }
+              }
             ]
           },
+          plugins: [ChartDataLabels],
           options: {
             responsive: true,
             maintainAspectRatio: false,
@@ -1404,6 +1498,7 @@ function renderChartForPanel(panelType) {
         charts.monthlyLine.data.labels = labels;
         charts.monthlyLine.data.datasets[0].data = principalSeries;
         charts.monthlyLine.data.datasets[1].data = interestSeries;
+        charts.monthlyLine.options.plugins.datalabels.display = chartLabelState.line;
         charts.monthlyLine.update();
       } else {
         charts.monthlyLine = new Chart(lineCtx, {
@@ -1415,6 +1510,7 @@ function renderChartForPanel(panelType) {
               { label: 'Odsetki', data: interestSeries, borderColor: palette.orange, backgroundColor: palette.orangeSoft, fill: false, tension: 0.25, pointRadius: 3, pointBackgroundColor: palette.orange }
             ]
           },
+          plugins: [ChartDataLabels],
           options: {
             responsive: true,
             maintainAspectRatio: false,
@@ -1424,6 +1520,14 @@ function renderChartForPanel(panelType) {
                 callbacks: {
                   label: (context) => `${context.dataset.label}: ${fmt(context.raw)}`
                 }
+              },
+              datalabels: {
+                display: chartLabelState.line,
+                align: (context) => (context.datasetIndex === 0 ? 'top' : 'bottom'),
+                anchor: (context) => (context.datasetIndex === 0 ? 'end' : 'start'),
+                color: (context) => context.dataset.borderColor || palette.ink,
+                font: { weight: 600, size: 10 },
+                formatter: (value) => fmt(value)
               }
             },
             scales: {
@@ -1438,7 +1542,6 @@ function renderChartForPanel(panelType) {
       setTimeout(() => charts.monthlyLine && charts.monthlyLine.resize(), 30);
     }
   }
-
   if (panelType === 'share') {
     const shareCanvas = $('#share-area-chart');
     if (shareCanvas) {
@@ -1447,6 +1550,7 @@ function renderChartForPanel(panelType) {
         charts.shareArea.data.labels = labels;
         charts.shareArea.data.datasets[0].data = sharePrincipal;
         charts.shareArea.data.datasets[1].data = shareInterest;
+        charts.shareArea.options.plugins.datalabels.display = chartLabelState.share;
         charts.shareArea.update();
       } else {
         charts.shareArea = new Chart(shareCtx, {
@@ -1458,6 +1562,7 @@ function renderChartForPanel(panelType) {
               { label: 'Odsetki %', data: shareInterest, borderColor: palette.orange, backgroundColor: palette.orangeSoft, fill: '-1', tension: 0.25, pointRadius: 0, stack: 'shares' }
             ]
           },
+          plugins: [ChartDataLabels],
           options: {
             responsive: true,
             maintainAspectRatio: false,
@@ -1467,6 +1572,14 @@ function renderChartForPanel(panelType) {
                 callbacks: {
                   label: (context) => `${context.dataset.label}: ${context.raw.toFixed(1)}%`
                 }
+              },
+              datalabels: {
+                display: chartLabelState.share,
+                align: (context) => (context.datasetIndex === 0 ? 'top' : 'bottom'),
+                anchor: (context) => (context.datasetIndex === 0 ? 'end' : 'start'),
+                color: (context) => context.dataset.borderColor || palette.ink,
+                font: { weight: 600, size: 10 },
+                formatter: (value) => `${Number(value).toFixed(1)}%`
               }
             },
             scales: {
@@ -1487,7 +1600,6 @@ function renderChartForPanel(panelType) {
       setTimeout(() => charts.shareArea && charts.shareArea.resize(), 30);
     }
   }
-
   if (panelType === 'cumulative') {
     const cumulativeCanvas = $('#cumulative-chart');
     if (cumulativeCanvas) {
@@ -1497,6 +1609,7 @@ function renderChartForPanel(panelType) {
         charts.cumulative.data.datasets[0].data = cumulativePrincipal;
         charts.cumulative.data.datasets[1].data = cumulativeInterest;
         charts.cumulative.data.datasets[2].data = cumulativePrincipal.map((value, index) => value + cumulativeInterest[index]);
+        charts.cumulative.options.plugins.datalabels.display = chartLabelState.cumulative;
         charts.cumulative.update();
       } else {
         charts.cumulative = new Chart(cumulativeCtx, {
@@ -1509,6 +1622,7 @@ function renderChartForPanel(panelType) {
               { label: 'Łącznie', data: cumulativePrincipal.map((value, index) => value + cumulativeInterest[index]), borderColor: palette.blue, backgroundColor: palette.blueSoft, fill: false, borderDash: [6, 4], tension: 0.25, pointRadius: 0 }
             ]
           },
+          plugins: [ChartDataLabels],
           options: {
             responsive: true,
             maintainAspectRatio: false,
@@ -1519,6 +1633,14 @@ function renderChartForPanel(panelType) {
                 callbacks: {
                   label: (context) => `${context.dataset.label}: ${fmt(context.raw)}`
                 }
+              },
+              datalabels: {
+                display: chartLabelState.cumulative,
+                align: (context) => (context.datasetIndex === 1 ? 'bottom' : 'top'),
+                anchor: (context) => (context.datasetIndex === 1 ? 'start' : 'end'),
+                color: (context) => context.dataset.borderColor || palette.ink,
+                font: { weight: 600, size: 10 },
+                formatter: (value) => fmt(value)
               }
             },
             scales: {
@@ -1533,7 +1655,6 @@ function renderChartForPanel(panelType) {
       setTimeout(() => charts.cumulative && charts.cumulative.resize(), 30);
     }
   }
-
   if (panelType === 'balance') {
     const balanceCanvas = $('#balance-chart');
     if (balanceCanvas) {
@@ -1596,23 +1717,47 @@ function renderChartForPanel(panelType) {
     }
   }
 
-  if (panelType === 'overpay') {
-    const overpaymentCanvas = $('#overpayment-chart');
-    if (overpaymentCanvas) {
-      const overpaymentCtx = overpaymentCanvas.getContext('2d');
-      if (charts.overpayment) {
-        charts.overpayment.data.labels = labels;
-        charts.overpayment.data.datasets[0].data = basePrincipalSeries;
-        charts.overpayment.data.datasets[1].data = overpaymentSeries;
-        charts.overpayment.update();
+  if (panelType === 'change') {
+    const changeCanvas = $('#payment-change-chart');
+    if (changeCanvas) {
+      const changeCtx = changeCanvas.getContext('2d');
+      const barColors = paymentChangeValues.map(value => {
+        if (value < 0) return palette.green;
+        if (value > 0) return palette.orange;
+        return palette.line;
+      });
+      if (charts.paymentChange) {
+        charts.paymentChange.data.labels = labels;
+        charts.paymentChange.data.datasets[0].data = paymentChangeValues;
+        charts.paymentChange.data.datasets[0].backgroundColor = barColors;
+        charts.paymentChange.data.datasets[1].data = paymentChangePercentages;
+        charts.paymentChange.options.plugins.datalabels.display = chartLabelState.change;
+        charts.paymentChange.update();
       } else {
-        charts.overpayment = new Chart(overpaymentCtx, {
+        charts.paymentChange = new Chart(changeCtx, {
           type: 'bar',
           data: {
             labels,
             datasets: [
-              { label: 'Kapitał planowy', data: basePrincipalSeries, backgroundColor: palette.green, borderRadius: 4, stack: 'stacked' },
-              { label: 'Nadpłata', data: overpaymentSeries, backgroundColor: palette.blue, borderRadius: 4, stack: 'stacked' }
+              {
+                type: 'bar',
+                label: 'Zmiana kwotowa',
+                data: paymentChangeValues,
+                backgroundColor: barColors,
+                borderRadius: 4,
+                yAxisID: 'yValue'
+              },
+              {
+                type: 'line',
+                label: 'Zmiana %',
+                data: paymentChangePercentages,
+                borderColor: palette.blue,
+                backgroundColor: palette.blueSoft,
+                fill: false,
+                tension: 0.25,
+                pointRadius: 3,
+                yAxisID: 'yPercent'
+              }
             ]
           },
           plugins: [ChartDataLabels],
@@ -1621,23 +1766,61 @@ function renderChartForPanel(panelType) {
             maintainAspectRatio: false,
             interaction: { mode: 'index', intersect: false },
             scales: {
-              x: { stacked: true, grid: { display: false } },
-              y: { stacked: true, grid: { color: palette.line }, ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') } }
+              x: { grid: { display: false } },
+              yValue: {
+                type: 'linear',
+                position: 'left',
+                grid: { color: palette.line },
+                ticks: { callback: (value) => fmt(value).replace(/\sPLN/, '') }
+              },
+              yPercent: {
+                type: 'linear',
+                position: 'right',
+                grid: { display: false },
+                ticks: {
+                  callback: (value) => `${value}%`
+                }
+              }
             },
             plugins: {
               legend: { position: 'bottom' },
               tooltip: {
                 callbacks: {
-                  label: (context) => `${context.dataset.label}: ${fmt(context.raw)}`
+                  label: (context) => {
+                    if (context.dataset.type === 'line') {
+                      const numeric = Number(context.raw || 0);
+                      const sign = numeric > 0 ? '+' : '';
+                      return `${context.dataset.label}: ${sign}${numeric.toFixed(2)}%`;
+                    }
+                    return `${context.dataset.label}: ${fmt(context.raw)}`;
+                  }
                 }
               },
               datalabels: {
-                color: palette.ink,
-                anchor: 'end',
-                align: 'top',
+                display: chartLabelState.change,
+                align: (context) => {
+                  if (context.dataset.type === 'line') return 'bottom';
+                  return Number(context.raw || 0) >= 0 ? 'top' : 'bottom';
+                },
+                anchor: (context) => {
+                  if (context.dataset.type === 'line') return 'start';
+                  return Number(context.raw || 0) >= 0 ? 'end' : 'start';
+                },
+                color: (context) => {
+                  if (context.dataset.type === 'line') return palette.blue;
+                  const numeric = Number(context.raw || 0);
+                  if (numeric < 0) return palette.green;
+                  if (numeric > 0) return palette.orange;
+                  return palette.ink;
+                },
                 font: { weight: 600, size: 10 },
                 formatter: (value, context) => {
-                  if (context.dataset.label !== 'Nadpłata' || !value) return '';
+                  if (context.dataset.type === 'line') {
+                    const numeric = Number(value || 0);
+                    if (!numeric) return '0.00%';
+                    const sign = numeric > 0 ? '+' : '';
+                    return `${sign}${numeric.toFixed(2)}%`;
+                  }
                   return fmt(value);
                 }
               }
@@ -1645,7 +1828,7 @@ function renderChartForPanel(panelType) {
           }
         });
       }
-      setTimeout(() => charts.overpayment && charts.overpayment.resize(), 30);
+      setTimeout(() => charts.paymentChange && charts.paymentChange.resize(), 30);
     }
   }
 
@@ -1656,6 +1839,29 @@ function renderChartForPanel(panelType) {
       if (charts.rateTrend) {
         charts.rateTrend.data.labels = rateHistoryLabels;
         charts.rateTrend.data.datasets[0].data = rateHistoryValues;
+        charts.rateTrend.options.plugins.tooltip.callbacks.label = (context) => {
+          const value = Number(context.raw || 0);
+          const diff = rateHistoryDiffs[context.dataIndex] || 0;
+          const base = `${context.dataset.label}: ${value.toFixed(2)}%`;
+          if (context.dataIndex === 0 || Math.abs(diff) < 0.01) {
+            return base;
+          }
+          const sign = diff > 0 ? '+' : '';
+          return `${base} (${sign}${diff.toFixed(2)} pp)`;
+        };
+        charts.rateTrend.options.plugins.datalabels.formatter = (value, context) => {
+          const idx = context.dataIndex;
+          const numeric = Number(value || 0);
+          if (idx === 0) {
+            return `${numeric.toFixed(2)}%`;
+          }
+          const diff = rateHistoryDiffs[idx] || 0;
+          if (Math.abs(diff) < 0.01) {
+            return '';
+          }
+          const sign = diff > 0 ? '+' : '';
+          return `${sign}${diff.toFixed(2)} pp`;
+        };
         charts.rateTrend.update();
       } else {
         charts.rateTrend = new Chart(rateCtx, {
@@ -1684,7 +1890,16 @@ function renderChartForPanel(panelType) {
               legend: { display: false },
               tooltip: {
                 callbacks: {
-                  label: (context) => `${context.dataset.label}: ${Number(context.raw || 0).toFixed(2)}%`
+                  label: (context) => {
+                    const value = Number(context.raw || 0);
+                    const diff = rateHistoryDiffs[context.dataIndex] || 0;
+                    const base = `${context.dataset.label}: ${value.toFixed(2)}%`;
+                    if (context.dataIndex === 0 || Math.abs(diff) < 0.01) {
+                      return base;
+                    }
+                    const sign = diff > 0 ? '+' : '';
+                    return `${base} (${sign}${diff.toFixed(2)} pp)`;
+                  }
                 }
               },
               datalabels: {
@@ -1693,8 +1908,17 @@ function renderChartForPanel(panelType) {
                 color: palette.orange,
                 font: { weight: 700, size: 11 },
                 formatter: (value, context) => {
-                  const dataset = context.dataset.data || [];
-                  return context.dataIndex === dataset.length - 1 ? `${Number(value || 0).toFixed(2)}%` : '';
+                  const idx = context.dataIndex;
+                  const numeric = Number(value || 0);
+                  if (idx === 0) {
+                    return `${numeric.toFixed(2)}%`;
+                  }
+                  const diff = rateHistoryDiffs[idx] || 0;
+                  if (Math.abs(diff) < 0.01) {
+                    return '';
+                  }
+                  const sign = diff > 0 ? '+' : '';
+                  return `${sign}${diff.toFixed(2)} pp`;
                 }
               }
             },
@@ -1710,6 +1934,29 @@ function renderChartForPanel(panelType) {
       setTimeout(() => charts.rateTrend && charts.rateTrend.resize(), 30);
     }
   }
+}
+
+function updateChartToggleLabels() {
+  document.querySelectorAll('.loan-chart-toggle').forEach(button => {
+    const target = button.dataset.chartToggle;
+    if (!target) return;
+    button.textContent = chartLabelState[target] ? 'Ukryj dane' : 'Pokaż dane';
+  });
+}
+
+function setupLoanChartToggles() {
+  document.querySelectorAll('.loan-chart-toggle').forEach(button => {
+    button.addEventListener('click', () => {
+      const target = button.dataset.chartToggle;
+      if (!target) return;
+      chartLabelState[target] = !chartLabelState[target];
+      updateChartToggleLabels();
+      const activePanel = document.querySelector('.loan-tab-panel.active');
+      const activeType = activePanel ? activePanel.dataset.chart : 'mix';
+      renderChartForPanel(activeType);
+    });
+  });
+  updateChartToggleLabels();
 }
 
 function setupLoanChartTabs() {
@@ -1731,6 +1978,7 @@ function init() {
   loadState();
   render();
   setupLoanChartTabs();
+  setupLoanChartToggles();
   $('#setup-loan-btn').addEventListener('click', openSetupModal);
   $('#settings-btn').addEventListener('click', openSetupModal);
   $('#add-payment-btn').addEventListener('click', () => openPaymentModal(null));

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,7 @@
   --shadow: 0 12px 30px -24px rgb(15 23 42 / 0.2);
   --shadow-md: 0 16px 40px -24px rgb(15 23 42 / 0.24);
   --shadow-lg: 0 28px 60px -32px rgb(15 23 42 / 0.24);
+  --topbar-height: 80px;
   --green: #059669;
   --green-soft: #dcfce7;
   --red: #dc2626;
@@ -46,7 +47,12 @@
   --info: var(--blue);
   --info-light: var(--blue-soft);
   --bg-secondary: var(--surface);
-  --sidebar-bg: #101727;
+  --sidebar-bg: #0f172a;
+  --sidebar-text: #e2e8f0;
+  --sidebar-accent: hsl(var(--accent-h) 85% 68%);
+  --sidebar-hover: rgba(148, 163, 184, 0.12);
+  --topbar-bg: #ffffff;
+  --topbar-border: rgba(15, 23, 42, 0.08);
   --text-primary: var(--ink);
   --text-secondary: var(--muted);
   --text-tertiary: #94a3b8;
@@ -76,41 +82,253 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid hsl(var(--accent-h) 90% 70% / 0.6);
+  outline-offset: 2px;
+}
+
 img {
   max-width: 100%;
   display: block;
 }
 
 a {
-  color: var(--blue);
+  color: inherit;
   text-decoration: none;
-  transition: color var(--transition);
+  transition: color var(--transition), background-color var(--transition);
 }
 
 a:hover {
-  color: hsl(var(--accent-h) var(--accent-s) calc(var(--accent-l) + 6%));
+  color: hsl(var(--accent-h) var(--accent-s) calc(var(--accent-l) + 8%));
 }
 
 .wrap {
-  max-width: 1280px;
+  width: 100%;
+  max-width: 1320px;
   margin: 0 auto;
-  padding: 32px 20px 48px;
+  padding: 0;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 20px;
+  background: var(--card);
+  border-bottom: 1px solid var(--line);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  min-height: var(--topbar-height);
+}
+
+.topbar-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.topbar-eyebrow {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.topbar-title {
+  margin: 0;
+  font-size: clamp(22px, 3vw, 30px);
+  font-weight: 800;
+}
+
+.topbar-subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.topbar-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.page-content {
+  flex: 1;
+  padding: 20px 28px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.page-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 24px;
+  align-items: start;
+}
+
+.page-columns > * {
+  min-width: 0;
+}
+
+.page-columns.narrow {
+  grid-template-columns: minmax(0, 1fr) 280px;
+}
+
+.layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+.content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 20px;
+  padding: 20px;
+}
+
+.content > * {
+  min-width: 0;
+}
+
+.right-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: sticky;
+  top: calc(var(--topbar-height) + 20px);
+  align-self: start;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.stack.tight {
+  gap: 16px;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px 20px;
+  width: 240px;
+  background: var(--sidebar-bg);
+  color: #fff;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: 0.04em;
+}
+
+.sidebar-header .emoji {
+  font-size: 20px;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  color: inherit;
+  font-weight: 600;
+  font-size: 13px;
+  transition: background-color var(--transition), color var(--transition), transform var(--transition);
+}
+
+.nav-link .icon {
+  font-size: 16px;
+  width: 20px;
+  text-align: center;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  background: var(--sidebar-hover);
+  color: #f8fafc;
+}
+
+.nav-link.active,
+.nav-link[aria-current="page"] {
+  background: rgba(148, 163, 184, 0.18);
+  color: #fff;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.3);
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  font-size: 12px;
+  color: rgba(226, 232, 240, 0.7);
+  line-height: 1.5;
+}
+
+.sidebar-footer strong {
+  display: block;
+  color: #fff;
+  margin-bottom: 4px;
 }
 
 .card {
   background: var(--card);
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  padding: 20px;
-  box-shadow: var(--shadow);
+  padding: 18px;
+  box-shadow: 0 10px 30px -20px rgb(15 23 42 / 0.4);
   position: relative;
   transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
 }
 
 .card:hover {
-  transform: translateY(-1px);
+  transform: translateY(-2px);
   box-shadow: var(--shadow-md);
-  border-color: hsl(var(--accent-h) 40% 80% / 0.6);
+  border-color: hsl(var(--accent-h) 50% 80% / 0.6);
 }
 
 .card-header {
@@ -196,6 +414,91 @@ a:hover {
   background: var(--bg);
 }
 
+@media (max-width: 1280px) {
+  .page-columns {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .content {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 1024px) {
+  .topbar {
+    padding: 14px 18px;
+  }
+
+  .page-content {
+    padding: 18px;
+  }
+
+  .content {
+    padding: 18px;
+  }
+}
+
+@media (max-width: 920px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+    flex-direction: column;
+    gap: 16px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    width: 100%;
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .nav-link {
+    flex: 1 1 140px;
+    justify-content: flex-start;
+  }
+
+  .topbar {
+    position: static;
+  }
+
+  .content {
+    padding: 18px;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .topbar-actions {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .page-content {
+    padding: 18px;
+  }
+
+  .nav-link {
+    flex: 1 1 120px;
+  }
+
+  .content {
+    grid-template-columns: 1fr;
+    padding: 16px;
+    gap: 16px;
+  }
+}
+
 .module-hero {
   background: var(--gradient-hero);
   border-bottom: 1px solid var(--line);
@@ -203,8 +506,7 @@ a:hover {
 }
 
 .module-hero .wrap {
-  padding-top: 0;
-  padding-bottom: 0;
+  padding: 0 32px;
 }
 
 .module-hero-inner {
@@ -434,7 +736,9 @@ textarea:focus {
 @media (max-width: 900px) {
   .g-2,
   .g-3,
-  .g-4 {
+  .g-4,
+  .grid-2,
+  .grid-3 {
     grid-template-columns: 1fr;
   }
 }
@@ -466,6 +770,54 @@ textarea:focus {
 .stat-card .note {
   font-size: 12px;
   color: var(--muted);
+}
+
+.kpi-compact {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.kpi-emoji {
+  font-size: 18px;
+}
+
+.kpi-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.05em;
+}
+
+.kpi-value {
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.insight-bubble {
+  font-size: 12px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: var(--blue-soft);
+  color: var(--ink);
+  border: 1px solid var(--line);
+}
+
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 20px;
 }
 
 .chart-card {
@@ -608,6 +960,10 @@ thead th {
 @media (max-width: 768px) {
   .module-hero {
     padding: 28px 0 22px;
+  }
+
+  .module-hero .wrap {
+    padding: 0 20px;
   }
 
   .module-hero-top {

--- a/styles.css
+++ b/styles.css
@@ -778,12 +778,24 @@ textarea:focus {
   border-radius: 14px;
   padding: 12px;
   display: flex;
-  gap: 8px;
+  gap: 10px;
   align-items: flex-start;
+  min-height: 110px;
 }
 
 .kpi-emoji {
   font-size: 18px;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.kpi-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  flex: 1;
 }
 
 .kpi-label {
@@ -791,11 +803,25 @@ textarea:focus {
   text-transform: uppercase;
   color: var(--muted);
   letter-spacing: 0.05em;
+  font-weight: 600;
+  display: block;
 }
 
 .kpi-value {
   font-size: 22px;
   font-weight: 800;
+  line-height: 1.2;
+  display: block;
+  word-break: break-word;
+}
+
+.kpi-value--sm {
+  font-size: 18px;
+}
+
+.kpi-body .tiny,
+.kpi-body .muted {
+  display: block;
   line-height: 1.2;
 }
 

--- a/tasks.html
+++ b/tasks.html
@@ -208,50 +208,51 @@
 
       <div class="content">
         <main class="page-content stack">
-    <section class="card insights-card" aria-live="polite">
-      <div class="insights-header">
-        <div>
-          <h2 class="title" style="margin-bottom:4px;">Szybkie wnioski</h2>
-          <p class="muted tiny">Inteligentne podpowiedzi pomagają zaplanować kolejny krok.</p>
-        </div>
-      </div>
-      <div class="insights-grid" id="insights-grid" role="list"></div>
-      <p class="muted tiny" id="insights-empty" style="margin-top:12px; display:none;">Dodaj pierwsze zadanie, aby zobaczyć proponowane działania.</p>
-    </section>
-
-    <div class="card" id="task-form-card" style="margin-top:12px;">
-      <h3 class="title" id="form-title" style="margin-bottom: 16px;">Nowe zadanie</h3>
-      <input type="hidden" id="task-id">
-      <div class="grid" style="grid-template-columns: 1fr; gap: 12px; margin-bottom: 16px;">
-        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Tytuł zadania</label><input type="text" id="task-title" placeholder="Np. Przygotować raport kwartalny"></div>
-        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Notatki</label><textarea id="task-notes" placeholder="Szczegóły, linki, wymagania..."></textarea></div>
-      </div>
-      <div class="grid g-3">
-        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Kategoria</label>
-          <div id="task-category-selector" class="segmented-control">
-              <div class="segment active" data-value="work">Praca</div>
-              <div class="segment" data-value="private">Prywatne</div>
+        <div class="grid" style="grid-template-columns:minmax(0,2fr) minmax(0,1fr); gap:12px; align-items:flex-start; margin-top:12px;">
+          <div class="card" id="task-form-card">
+            <h3 class="title" id="form-title" style="margin-bottom: 16px;">Nowe zadanie</h3>
+            <input type="hidden" id="task-id">
+            <div class="grid" style="grid-template-columns: 1fr; gap: 12px; margin-bottom: 16px;">
+              <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Tytuł zadania</label><input type="text" id="task-title" placeholder="Np. Przygotować raport kwartalny"></div>
+              <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Notatki</label><textarea id="task-notes" placeholder="Szczegóły, linki, wymagania..."></textarea></div>
+            </div>
+            <div class="grid g-3">
+              <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Kategoria</label>
+                <div id="task-category-selector" class="segmented-control">
+                    <div class="segment active" data-value="work">Praca</div>
+                    <div class="segment" data-value="private">Prywatne</div>
+                </div>
+              </div>
+              <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Priorytet</label><select id="task-priority"><option value="low">Niski</option><option value="medium">Średni</option><option value="high">Wysoki</option></select></div>
+              <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Termin</label><input type="date" id="task-due-date"></div>
+              <div style="grid-column: 1 / -1;"><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Tagi (oddzielone przecinkiem)</label><input type="text" id="task-tags" placeholder="np. praca, pilne, projekt-x"></div>
+              <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Powtarzalność</label><select id="task-recurrence"><option value="none">Nigdy</option><option value="daily">Codziennie</option><option value="weekly">Co tydzień</option><option value="monthly">Co miesiąc</option></select></div>
+              <div style="grid-column: 2 / -1;">
+                   <label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Podzadania</label>
+                   <div style="display:flex; gap: 8px;">
+                       <input type="text" id="subtask-input" placeholder="Dodaj krok do wykonania...">
+                       <button id="add-subtask-btn" class="btn" style="white-space:nowrap;">Dodaj</button>
+                   </div>
+                   <ul id="subtask-list-form" style="list-style:none; padding: 0; margin: 8px 0 0 0; display:flex; flex-direction:column; gap: 4px;"></ul>
+              </div>
+            </div>
+            <div style="display:flex; gap: 8px; justify-content:flex-end; margin-top: 16px;">
+               <button id="cancel-edit-btn" class="btn" style="display:none;">Anuluj</button>
+               <button id="add-task-btn" class="btn primary"><span id="add-task-btn-text">Dodaj zadanie</span></button>
+            </div>
           </div>
+          <section class="card insights-card" aria-live="polite">
+            <div class="insights-header">
+              <div>
+                <h2 class="title" style="margin-bottom:4px;">Szybkie wnioski</h2>
+                <p class="muted tiny">Inteligentne podpowiedzi pomagają zaplanować kolejny krok.</p>
+              </div>
+            </div>
+            <div class="insights-grid" id="insights-grid" role="list" style="display:flex; flex-direction:column; gap:12px;"></div>
+            <p class="muted tiny" id="insights-empty" style="margin-top:12px; display:none;">Dodaj pierwsze zadanie, aby zobaczyć proponowane działania.</p>
+          </section>
         </div>
-        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Priorytet</label><select id="task-priority"><option value="low">Niski</option><option value="medium">Średni</option><option value="high">Wysoki</option></select></div>
-        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Termin</label><input type="date" id="task-due-date"></div>
-        <div style="grid-column: 1 / -1;"><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Tagi (oddzielone przecinkiem)</label><input type="text" id="task-tags" placeholder="np. praca, pilne, projekt-x"></div>
-        <div><label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Powtarzalność</label><select id="task-recurrence"><option value="none">Nigdy</option><option value="daily">Codziennie</option><option value="weekly">Co tydzień</option><option value="monthly">Co miesiąc</option></select></div>
-        <div style="grid-column: 2 / -1;">
-             <label class="muted" style="font-size:11px; display:block; margin-bottom: 4px;">Podzadania</label>
-             <div style="display:flex; gap: 8px;">
-                 <input type="text" id="subtask-input" placeholder="Dodaj krok do wykonania...">
-                 <button id="add-subtask-btn" class="btn" style="white-space:nowrap;">Dodaj</button>
-             </div>
-             <ul id="subtask-list-form" style="list-style:none; padding: 0; margin: 8px 0 0 0; display:flex; flex-direction:column; gap: 4px;"></ul>
-        </div>
-      </div>
-       <div style="display:flex; gap: 8px; justify-content:flex-end; margin-top: 16px;">
-          <button id="cancel-edit-btn" class="btn" style="display:none;">Anuluj</button>
-          <button id="add-task-btn" class="btn primary"><span id="add-task-btn-text">Dodaj zadanie</span></button>
-       </div>
-    </div>
-    
+
     <div class="tabs" style="margin-top: 24px;">
         <div class="tab active" data-tab="list">Lista Zadań</div>
         <div class="tab" data-tab="calendar">Kalendarz</div>

--- a/tasks.html
+++ b/tasks.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>LifeOS — Zadania Pro</title>
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -32,7 +32,7 @@
     .task-exit { animation: fadeOut 0.3s ease-in forwards; }
     *{box-sizing:border-box}
     body{margin:0;background:var(--bg);color:var(--ink);font-family: 'Inter', system-ui,-apple-system,Segoe UI,Roboto; font-size: 12px; line-height: 1.5;}
-    .wrap{max-width:1200px;margin:0 auto;padding:32px 24px}
+    .wrap{max-width:1320px;margin:0 auto;padding:0}
     .card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:24px;box-shadow: var(--shadow); transition: all .3s ease;}
     .row{display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap}
     .muted{color:var(--muted)}
@@ -174,19 +174,40 @@
 
   </style>
 </head>
-<body>
-  <div class="wrap">
-    <header class="page-header">
-      <div class="page-title-group">
-        <a href="./index.html" class="back-link">← Powrót</a>
-        <h1 class="page-title">Zadania Pro</h1>
-        <p class="page-subtitle">Zarządzaj wszystkimi obowiązkami w jednym miejscu i miej kontrolę nad priorytetami.</p>
+<body data-page="tasks">
+  <div class="app-shell">
+    <aside class="sidebar" aria-label="Główna nawigacja">
+      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
+        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
+        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
+        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
+        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
+        <a class="nav-link active" href="tasks.html" aria-current="page"><span class="icon">✅</span><span>Zadania</span></a>
+        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
+        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      </nav>
+      <div class="sidebar-footer">
+        <strong>Twój cyfrowy dom</strong>
+        Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
-      <div class="page-actions">
-        <button id="clear-all-btn" class="btn danger">Wyczyść wszystko</button>
-      </div>
-    </header>
+    </aside>
 
+    <div class="app-main">
+      <header class="topbar">
+        <div class="topbar-info">
+          <p class="topbar-eyebrow">Organizacja</p>
+          <h1 class="topbar-title">Zadania Pro</h1>
+          <p class="topbar-subtitle">Zarządzaj wszystkimi obowiązkami w jednym miejscu i miej kontrolę nad priorytetami.</p>
+        </div>
+        <div class="topbar-actions">
+          <button id="clear-all-btn" class="btn danger">Wyczyść wszystko</button>
+        </div>
+      </header>
+
+      <main class="page-content">
+        <div class="wrap stack">
     <section class="card insights-card" aria-live="polite">
       <div class="insights-header">
         <div>
@@ -319,6 +340,8 @@
                 <div class="chart-container"><canvas id="completion-progress-chart"></canvas></div>
             </div>
         </div>
+        </div>
+      </main>
     </div>
   </div>
 

--- a/tasks.html
+++ b/tasks.html
@@ -175,7 +175,7 @@
   </style>
 </head>
 <body data-page="tasks">
-  <div class="app-shell">
+  <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
       <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
       <nav class="sidebar-nav">
@@ -194,20 +194,20 @@
       </div>
     </aside>
 
-    <div class="app-main">
+    <div class="main">
       <header class="topbar">
-        <div class="topbar-info">
-          <p class="topbar-eyebrow">Organizacja</p>
-          <h1 class="topbar-title">Zadania Pro</h1>
-          <p class="topbar-subtitle">Zarządzaj wszystkimi obowiązkami w jednym miejscu i miej kontrolę nad priorytetami.</p>
+        <div>
+          <h1 class="topbar-title">Zadania</h1>
         </div>
-        <div class="topbar-actions">
-          <button id="clear-all-btn" class="btn danger">Wyczyść wszystko</button>
+        <div class="topbar-actions" style="gap:8px">
+          <a class="btn primary" href="#task-form-card">➕ Dodaj</a>
+          <button class="btn" id="tasks-import-btn" type="button">⬆️ Import</button>
+          <button class="btn" id="tasks-export-btn" type="button">⬇️ Eksport</button>
         </div>
       </header>
 
-      <main class="page-content">
-        <div class="wrap stack">
+      <div class="content">
+        <main class="page-content stack">
     <section class="card insights-card" aria-live="polite">
       <div class="insights-header">
         <div>
@@ -219,7 +219,7 @@
       <p class="muted tiny" id="insights-empty" style="margin-top:12px; display:none;">Dodaj pierwsze zadanie, aby zobaczyć proponowane działania.</p>
     </section>
 
-    <div class="card" style="margin-top:16px;">
+    <div class="card" id="task-form-card" style="margin-top:12px;">
       <h3 class="title" id="form-title" style="margin-bottom: 16px;">Nowe zadanie</h3>
       <input type="hidden" id="task-id">
       <div class="grid" style="grid-template-columns: 1fr; gap: 12px; margin-bottom: 16px;">
@@ -259,17 +259,18 @@
     </div>
 
     <div id="tab-content-list" class="card">
-        <div class="row" style="gap: 8px; padding-bottom: 12px;">
-            <div class="row" style="gap: 8px; flex-grow: 1;">
+        <div class="grid-2" style="gap:12px; align-items:flex-start; margin-bottom:12px;">
+            <div class="row" style="gap: 8px; flex-wrap: wrap;">
               <select id="category-filter" style="width:auto;"></select>
               <select id="date-filter" style="width:auto;"></select>
               <select id="task-priority-filter" style="width:auto;"></select>
-              <input type="text" id="tag-filter" placeholder="Filtruj po tagach..." style="width: 150px; flex-grow: 1;">
+              <input type="text" id="tag-filter" placeholder="Filtruj po tagach..." style="min-width:180px; flex:1 1 160px;">
             </div>
-            <div class="row" style="gap: 8px;">
+            <div class="row" style="gap: 8px; justify-content:flex-end; flex-wrap: wrap;">
               <select id="sort-by" style="width:auto;"></select>
               <button id="sort-direction" class="btn" style="padding: 10px;">↑</button>
               <label style="display:flex; align-items:center; gap: 6px; font-size: 11px; white-space: nowrap;"><input type="checkbox" id="hide-completed-filter" checked style="width: 16px; height: 16px;"> Ukryj wykonane</label>
+              <button id="clear-all-btn" class="btn danger" style="white-space: nowrap;">Wyczyść wszystko</button>
             </div>
         </div>
         <table class="task-table">
@@ -342,7 +343,44 @@
         </div>
         </div>
       </main>
+      <aside class="right-rail">
+        <div class="kpi-compact">
+          <div class="kpi-emoji">📌</div>
+          <div class="kpi-body">
+            <div class="kpi-label">Wszystkie zadania</div>
+            <div class="kpi-value" id="kpi-total-tasks">0</div>
+            <div class="muted tiny" id="kpi-total-note">—</div>
+          </div>
+        </div>
+        <div class="kpi-compact">
+          <div class="kpi-emoji">✅</div>
+          <div class="kpi-body">
+            <div class="kpi-label">Ukończone</div>
+            <div class="kpi-value" id="kpi-completed-tasks">0</div>
+            <div class="muted tiny" id="kpi-completed-note">—</div>
+          </div>
+        </div>
+        <div class="kpi-compact">
+          <div class="kpi-emoji">⏱</div>
+          <div class="kpi-body">
+            <div class="kpi-label">Przeterminowane</div>
+            <div class="kpi-value" id="kpi-overdue-tasks">0</div>
+            <div class="muted tiny" id="kpi-overdue-note">Brak zaległości</div>
+          </div>
+        </div>
+        <div class="kpi-compact">
+          <div class="kpi-emoji">📅</div>
+          <div class="kpi-body">
+            <div class="kpi-label">Nadchodzące</div>
+            <div class="kpi-value" id="kpi-upcoming-tasks">0</div>
+            <div class="muted tiny" id="kpi-upcoming-note">—</div>
+          </div>
+        </div>
+        <div class="insight-bubble" id="tasks-progress-bubble">Postęp tygodnia: —</div>
+        <div class="insight-bubble" id="tasks-focus-bubble">Najbliższe kroki: —</div>
+      </aside>
     </div>
+  </div>
   </div>
 
 <div id="modal-overlay" class="modal-overlay" style="display: none;">
@@ -436,11 +474,22 @@ const statsRangeControl = getEl('stats-range-control');
 const statsCategoryControl = getEl('stats-category-control');
 const insightsGrid = getEl('insights-grid');
 const insightsEmpty = getEl('insights-empty');
+const kpiTotalTasksEl = getEl('kpi-total-tasks');
+const kpiCompletedTasksEl = getEl('kpi-completed-tasks');
+const kpiOverdueTasksEl = getEl('kpi-overdue-tasks');
+const kpiUpcomingTasksEl = getEl('kpi-upcoming-tasks');
+const kpiTotalNoteEl = getEl('kpi-total-note');
+const kpiCompletedNoteEl = getEl('kpi-completed-note');
+const kpiOverdueNoteEl = getEl('kpi-overdue-note');
+const kpiUpcomingNoteEl = getEl('kpi-upcoming-note');
+const tasksProgressBubble = getEl('tasks-progress-bubble');
+const tasksFocusBubble = getEl('tasks-focus-bubble');
 
 const cssVar = (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 
 // --- GŁÓWNE FUNKCJE ---
 function render() {
+    renderKpis();
     renderInsights();
     renderTaskList();
     const activeTabEl = document.querySelector('.tab.active');
@@ -461,6 +510,102 @@ function describeRelativeDate(target, base) {
     const label = pluralize(Math.abs(diffDays), ['dzień', 'dni', 'dni']);
     if (diffDays > 1) return `za ${diffDays} ${label}`;
     return `${Math.abs(diffDays)} ${label} temu`;
+}
+
+function renderKpis() {
+    if (!kpiTotalTasksEl) return;
+    const tasks = state.tasks;
+    const total = tasks.length;
+    const completed = tasks.filter(task => task.status === 'done');
+    const active = tasks.filter(task => task.status !== 'done');
+    const completionRate = total ? Math.round((completed.length / total) * 100) : 0;
+
+    kpiTotalTasksEl.textContent = total;
+    if (kpiTotalNoteEl) {
+        kpiTotalNoteEl.textContent = total
+            ? `${active.length} aktywnych • ${completed.length} ukończonych`
+            : 'Brak zadań w bazie';
+    }
+
+    if (kpiCompletedTasksEl) kpiCompletedTasksEl.textContent = completed.length;
+    if (kpiCompletedNoteEl) {
+        kpiCompletedNoteEl.textContent = total ? `${completionRate}% realizacji` : 'Dodaj zadania';
+    }
+
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    const horizon = new Date(today);
+    horizon.setUTCDate(horizon.getUTCDate() + 7);
+
+    const activeWithDue = active
+        .filter(task => task.dueDate)
+        .map(task => ({ task, due: parseDate(task.dueDate) }))
+        .filter(entry => entry.due && !Number.isNaN(entry.due.getTime()));
+
+    const overdueEntries = activeWithDue.filter(entry => entry.due < today);
+    const overdueSorted = [...overdueEntries].sort((a, b) => a.due - b.due);
+    if (kpiOverdueTasksEl) kpiOverdueTasksEl.textContent = overdueEntries.length;
+    if (kpiOverdueNoteEl) {
+        if (overdueSorted.length) {
+            const oldest = overdueSorted[0];
+            const relative = describeRelativeDate(oldest.due, today);
+            kpiOverdueNoteEl.textContent = `${formatDateShort(oldest.due)} • ${relative}`;
+        } else {
+            kpiOverdueNoteEl.textContent = 'Brak zaległości';
+        }
+    }
+
+    const upcomingEntries = activeWithDue
+        .filter(entry => entry.due >= today && entry.due <= horizon)
+        .sort((a, b) => {
+            const diff = a.due - b.due;
+            if (diff !== 0) return diff;
+            return priorityWeight(a.task.priority) - priorityWeight(b.task.priority);
+        });
+    if (kpiUpcomingTasksEl) kpiUpcomingTasksEl.textContent = upcomingEntries.length;
+    if (kpiUpcomingNoteEl) {
+        if (upcomingEntries.length) {
+            const { task, due } = upcomingEntries[0];
+            const relative = describeRelativeDate(due, today);
+            const priorityLabel = { high: 'wysoki', medium: 'średni', low: 'niski' }[task.priority] || 'średni';
+            kpiUpcomingNoteEl.textContent = `${task.title} • ${formatDateShort(due)} (${relative}, ${priorityLabel})`;
+        } else {
+            kpiUpcomingNoteEl.textContent = 'Dodaj terminy na tydzień';
+        }
+    }
+
+    const lastSevenStart = new Date(today);
+    lastSevenStart.setUTCDate(lastSevenStart.getUTCDate() - 6);
+    const completedRecent = completed.filter(task => {
+        if (!task.dueDate) return false;
+        const due = parseDate(task.dueDate);
+        return due && due >= lastSevenStart && due <= today;
+    }).length;
+    const plannedWeek = upcomingEntries.length;
+    const denominator = completedRecent + plannedWeek;
+    const progressRate = denominator ? Math.round((completedRecent / denominator) * 100) : 0;
+    if (tasksProgressBubble) {
+        tasksProgressBubble.textContent = denominator
+            ? `Postęp tygodnia: ${progressRate}% (✓ ${completedRecent} / ${denominator})`
+            : 'Postęp tygodnia: Brak zaplanowanych zadań — dodaj priorytety.';
+    }
+
+    if (tasksFocusBubble) {
+        if (overdueSorted.length) {
+            const { task, due } = overdueSorted[0];
+            const relative = describeRelativeDate(due, today);
+            tasksFocusBubble.textContent = `Najbliższe kroki: nadrób „${task.title}” (termin ${formatDateShort(due)}, ${relative}).`;
+        } else if (upcomingEntries.length) {
+            const { task, due } = upcomingEntries[0];
+            const relative = describeRelativeDate(due, today);
+            const priorityLabel = { high: 'wysoki', medium: 'średni', low: 'niski' }[task.priority] || 'średni';
+            tasksFocusBubble.textContent = `Najbliższe kroki: „${task.title}” (${priorityLabel}) — ${relative}.`;
+        } else if (active.length) {
+            tasksFocusBubble.textContent = 'Najbliższe kroki: przypisz terminy otwartym zadaniom.';
+        } else {
+            tasksFocusBubble.textContent = 'Najbliższe kroki: dodaj nowe zadania.';
+        }
+    }
 }
 
 function priorityWeight(priority) {

--- a/trainings.html
+++ b/trainings.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>LifeOS – Trainings</title>
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -38,7 +38,7 @@
 .page-content {
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 24px;
 }
 
 .module-title-row {
@@ -119,6 +119,255 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.plan-overview {
+  align-items: flex-start;
+}
+
+.grid-2.plan-overview {
+  grid-template-columns: minmax(260px, 0.85fr) minmax(560px, 1.75fr);
+  gap: 18px;
+  align-items: stretch;
+}
+
+.plan-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  height: 100%;
+  min-height: 0;
+}
+
+.plan-card--slim {
+  gap: 10px;
+  padding: 16px;
+}
+
+.plan-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.plan-card-title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.plan-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.plan-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.plan-card--board {
+  padding: 18px;
+}
+
+.plan-card-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.plan-summary {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(148, 163, 184, 0.12);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.plan-summary-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.plan-summary-title {
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.35;
+  margin: 0;
+}
+
+.plan-summary .vacation-note {
+  margin: 0;
+}
+
+.plan-panel-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.plan-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.plan-panel {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.plan-panel.is-empty:not([open]) {
+  border-style: dashed;
+  color: var(--muted);
+}
+
+.plan-panel summary {
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.plan-panel summary::-webkit-details-marker {
+  display: none;
+}
+
+.plan-panel[open] summary {
+  border-bottom: 1px solid var(--line);
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.plan-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px 14px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.panel-main {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.panel-title {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.panel-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--accent);
+}
+
+.plan-panel.is-empty .panel-count {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--muted);
+}
+
+.panel-meta {
+  font-size: 11px;
+  color: var(--muted);
+  font-weight: 500;
+  text-align: right;
+}
+
+.plan-panel.is-empty .panel-meta {
+  color: var(--muted);
+}
+
+.plan-panel .detail-list {
+  max-height: none;
+  overflow: visible;
+  padding-right: 0;
+}
+
+.plan-panel .empty-state {
+  font-size: 11px;
+  color: var(--muted);
+  margin: 0;
+}
+
+
+.plan-card-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.plan-card-actions .btn {
+  flex: 1 1 140px;
+}
+
+.plan-card-actions--compact {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+  margin-top: 0;
+}
+
+.plan-card-actions--compact .btn {
+  padding: 10px 12px;
+  font-size: 13px;
+}
+
+.plan-card-actions--stacked {
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.plan-card-actions--stacked .btn {
+  justify-content: flex-start;
+}
+
+.focus-card--compact {
+  gap: 14px;
+}
+
+.focus-card--compact .focus-columns {
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+
+.focus-card--compact .detail-actions {
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.focus-card--compact .detail-actions .btn {
+  flex: 1 1 160px;
+  min-width: 140px;
 }
 
 .focus-header {
@@ -311,6 +560,17 @@
   height: 24px;
 }
 
+.metric-visual--compact {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+}
+
+.metric-visual--compact .icon {
+  width: 20px;
+  height: 20px;
+}
+
 .metric-card--visual[data-activity-type="gym"] .metric-visual {
   background: rgba(91, 33, 182, 0.12);
   color: var(--gym-color);
@@ -336,6 +596,49 @@
   color: var(--muted);
 }
 
+.kpi-value--sm {
+  font-size: 18px;
+}
+
+.kpi-progress-card {
+  align-items: stretch;
+}
+
+.kpi-progress-card > span {
+  align-self: flex-start;
+}
+
+.kpi-progress-card > div {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.kpi-next-activity {
+  gap: 12px;
+  align-items: center;
+}
+
+.kpi-next-activity .kpi-value--sm {
+  margin-top: 2px;
+}
+
+.goal-progress-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.goal-progress-item {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.goal-progress-item .goal-progress-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
 
 .card-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 16px; }
 .card-header p { margin-top: 4px; }
@@ -356,33 +659,61 @@
 
 .calendar-weekdays span {
   display: flex;
-  justify-content: center;
-  padding-bottom: 4px;
+  justify-content: flex-start;
+  padding-bottom: 2px;
+  padding-left: 4px;
+}
+
+
+.calendar-card--compact {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px 18px;
+  height: 100%;
+  min-height: 0;
+}
+
+.calendar-card .card-header {
+  margin-bottom: 0;
+  align-items: flex-start;
+}
+.calendar-card .card-header p {
+  margin-top: 2px;
+}
+
+.calendar-card--compact .calendar-grid {
+  flex: 1;
+  overflow: auto;
+  padding-right: 2px;
 }
 
 .calendar-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 12px;
+  gap: 8px;
+  grid-auto-rows: minmax(140px, 1fr);
 }
 
 .calendar-day {
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  padding: 10px 12px;
-  min-height: 104px;
+  background: var(--surface);
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  padding: 12px;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
   cursor: pointer;
   transition: var(--transition);
   position: relative;
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.04);
+  overflow: hidden;
 }
 
-.calendar-day:hover { border-color: var(--primary); box-shadow: var(--shadow-sm); transform: translateY(-2px); }
-.calendar-day--other-month { opacity: 0.55; }
-.calendar-day--selected { border-color: var(--primary); box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.12); }
+.calendar-day:hover { border-color: var(--primary); box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12); transform: translateY(-2px); }
+.calendar-day--other-month { opacity: 0.45; }
+.calendar-day--selected { border-color: var(--primary); box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.14); }
 .calendar-day--today { border-color: var(--success); }
 .calendar-day--empty { background: var(--day-empty); border-color: var(--day-empty-border); }
 .calendar-day--planned { background: var(--day-planned); border-color: var(--day-planned-border); }
@@ -397,51 +728,174 @@
   outline-offset: 3px;
 }
 
-.calendar-day-header { display: flex; justify-content: space-between; align-items: center; }
-.calendar-date-number { font-weight: 700; font-size: 14px; }
-.calendar-day-badges { display: flex; gap: 6px; align-items: center; }
-.calendar-badge {
-  background: #fff;
-  border-radius: 999px;
-  padding: 2px 8px;
+.calendar-day-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+.calendar-day-title {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+.calendar-day-weekday {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+  font-weight: 600;
+}
+.calendar-date-number {
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 26px;
+  height: 28px;
+  border-radius: 9px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--ink);
+  box-shadow: inset 0 -1px 0 rgba(15, 23, 42, 0.06);
+}
+.calendar-day-status {
   font-size: 10px;
   font-weight: 600;
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+.calendar-day-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.calendar-day-status[data-state="planned"] { color: var(--warning); }
+.calendar-day-status[data-state="progress"] { color: var(--accent); }
+.calendar-day-status[data-state="done"] { color: var(--success); }
+.calendar-day-status[data-state="vacation"] { color: rgba(30, 41, 59, 0.6); }
+.calendar-day-status[data-state="empty"] { color: var(--muted); }
+.calendar-day-badges {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.calendar-badge {
+  background: rgba(148, 163, 184, 0.16);
+  border-radius: 999px;
+  padding: 2px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  border: 1px solid rgba(148, 163, 184, 0.3);
   color: var(--muted);
 }
 
-.calendar-day-tags { display: flex; flex-wrap: wrap; gap: 4px; min-height: 32px; }
+.calendar-day-tags {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+}
 .activity-tag {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--ink);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  max-width: 100%;
+  white-space: normal;
+  line-height: 1.35;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+.activity-tag::before {
+  content: '•';
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1;
+  transform: translateY(2px);
+}
+.activity-tag[draggable="true"] { cursor: grab; }
+.activity-tag.dragging { opacity: 0.6; cursor: grabbing; }
+.activity-tag.gym { background: rgba(91, 33, 182, 0.08); color: var(--gym-color); border-color: rgba(91, 33, 182, 0.18); }
+.activity-tag.gym::before { content: '🏋️'; }
+.activity-tag.running { background: rgba(4, 120, 87, 0.08); color: var(--run-color); border-color: rgba(4, 120, 87, 0.18); }
+.activity-tag.running::before { content: '🏃'; }
+.activity-tag.reading { background: rgba(29, 78, 216, 0.08); color: var(--read-color); border-color: rgba(29, 78, 216, 0.18); }
+.activity-tag.reading::before { content: '📚'; }
+.activity-tag.extra { background: rgba(14, 165, 233, 0.1); color: var(--extra-color); border-color: rgba(14, 165, 233, 0.18); }
+.activity-tag.extra::before { content: '✨'; }
+.activity-tag.vacation { background: rgba(148, 163, 184, 0.18); color: var(--muted); border-color: rgba(148, 163, 184, 0.32); font-weight: 700; }
+.activity-tag.vacation::before { content: '🌴'; }
+.activity-tag.more { background: rgba(148, 163, 184, 0.12); color: var(--muted); border-style: dashed; }
+.activity-tag.more::before { content: '➕'; color: var(--muted); }
+
+.calendar-progress {
+  height: 4px;
+  background: rgba(148, 163, 184, 0.16);
+  border-radius: 999px;
+  overflow: hidden;
+  margin-top: 2px;
+}
+.calendar-progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  transition: width 0.25s ease;
+}
+.calendar-progress-fill[data-state="empty"] { background: rgba(248, 113, 113, 0.65); }
+.calendar-progress-fill[data-state="planned"] { background: rgba(251, 191, 36, 0.8); }
+.calendar-progress-fill[data-state="progress"] { background: rgba(59, 130, 246, 0.85); }
+.calendar-progress-fill[data-state="done"] { background: rgba(34, 197, 94, 0.85); }
+.calendar-progress-fill[data-state="vacation"] { background: rgba(148, 163, 184, 0.6); }
+
+.calendar-day-footer {
+  margin-top: auto;
+  font-size: 10px;
+  color: var(--muted);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+}
+.calendar-footer-label {
+  font-weight: 600;
   display: inline-flex;
   align-items: center;
   gap: 4px;
   padding: 2px 6px;
   border-radius: 999px;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  background: rgba(148, 163, 184, 0.18);
-  color: var(--ink);
-  border: 1px solid transparent;
-  max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--muted);
 }
-.activity-tag[draggable="true"] { cursor: grab; }
-.activity-tag.dragging { opacity: 0.6; cursor: grabbing; }
-.activity-tag.gym { background: rgba(91, 33, 182, 0.12); color: var(--gym-color); border-color: rgba(91, 33, 182, 0.16); }
-.activity-tag.running { background: rgba(4, 120, 87, 0.12); color: var(--run-color); border-color: rgba(4, 120, 87, 0.18); }
-.activity-tag.reading { background: rgba(29, 78, 216, 0.12); color: var(--read-color); border-color: rgba(29, 78, 216, 0.18); }
-.activity-tag.extra { background: rgba(14, 165, 233, 0.12); color: var(--extra-color); border-color: rgba(14, 165, 233, 0.18); }
-.activity-tag.vacation { background: rgba(148, 163, 184, 0.22); color: var(--muted); border-color: rgba(148, 163, 184, 0.32); font-weight: 700; }
-.activity-tag.more { background: rgba(148, 163, 184, 0.14); color: var(--muted); border-style: dashed; }
-
-.calendar-day-footer { margin-top: auto; font-size: 11px; color: var(--muted); display: flex; justify-content: space-between; align-items: center; }
-.calendar-footer-label { font-weight: 600; color: var(--muted); }
-.calendar-day--empty .calendar-footer-label { color: var(--danger); }
-.calendar-day--planned .calendar-footer-label { color: var(--warning); }
-.calendar-day--completed .calendar-footer-label { color: var(--success); }
+.calendar-footer-label::before {
+  content: '✓';
+  font-size: 10px;
+}
+.calendar-day--empty .calendar-footer-label { color: var(--danger); background: rgba(248, 113, 113, 0.12); }
+.calendar-day--empty .calendar-footer-label::before { content: '○'; }
+.calendar-day--planned .calendar-footer-label { color: var(--warning); background: rgba(251, 191, 36, 0.18); }
+.calendar-day--planned .calendar-footer-label::before { content: '•'; }
+.calendar-day--completed .calendar-footer-label { color: var(--success); background: rgba(34, 197, 94, 0.16); }
+.calendar-footer-remaining {
+  font-size: 10px;
+  color: var(--muted);
+}
 
 .calendar-legend { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; font-size: 11px; color: var(--muted); }
 .calendar-legend span { display: inline-flex; align-items: center; gap: 6px; }
@@ -463,23 +917,26 @@
 .legend-tag.vacation { background: rgba(148, 163, 184, 0.22); color: var(--muted); }
 
 .planning-banner {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  display: none;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
-  background: rgba(37, 99, 235, 0.05);
-  border: 1px dashed rgba(37, 99, 235, 0.25);
-  border-radius: 14px;
-  padding: 12px 14px;
+  background: rgba(37, 99, 235, 0.04);
+  border: 1px dashed rgba(37, 99, 235, 0.2);
+  border-radius: 12px;
+  padding: 10px 12px;
+  margin-top: 4px;
 }
 
 .planning-banner.active {
+  display: flex;
   border-style: solid;
   background: rgba(37, 99, 235, 0.1);
   box-shadow: var(--shadow-sm);
 }
 .planning-banner:not(.active) #stop-planning-btn { display: none; }
-.planning-banner-info { display: flex; align-items: flex-start; gap: 10px; }
+.planning-banner-info { display: flex; align-items: flex-start; gap: 8px; }
 .planning-banner-info strong { display: block; font-size: 12px; font-weight: 700; color: var(--ink); }
 .planning-banner-info span { display: block; font-size: 11px; color: var(--muted); }
 .planning-banner .icon { color: var(--primary); }
@@ -493,8 +950,8 @@
   font-size: 12px;
   color: var(--muted);
   text-align: center;
-  padding: 18px 12px;
-  border-radius: 12px;
+  padding: 12px 10px;
+  border-radius: 10px;
   background: rgba(248, 250, 252, 0.7);
   border: 1px dashed rgba(148, 163, 184, 0.4);
 }
@@ -505,24 +962,24 @@
 .detail-item {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.32);
-  background: rgba(248, 250, 252, 0.8);
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: rgba(248, 250, 252, 0.85);
   transition: var(--transition);
 }
 .detail-item[draggable="true"] { cursor: grab; }
 .detail-item.dragging { opacity: 0.6; cursor: grabbing; }
 .detail-item:hover { border-color: var(--primary-border); box-shadow: var(--shadow-sm); background: #fff; }
 .detail-item.completed { background: var(--success-soft); border-color: var(--success-border); }
-.detail-info { display: flex; gap: 12px; }
-.detail-icon { width: 38px; height: 38px; border-radius: 12px; display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 600; font-size: 14px; }
+.detail-info { display: flex; gap: 8px; }
+.detail-icon { width: 34px; height: 34px; border-radius: 12px; display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 600; font-size: 13px; }
 .detail-icon.gym { background: rgba(91, 33, 182, 0.2); color: var(--gym-color); }
 .detail-icon.running { background: rgba(4, 120, 87, 0.18); color: var(--run-color); }
 .detail-icon.reading { background: rgba(29, 78, 216, 0.18); color: var(--read-color); }
 .detail-icon.extra { background: rgba(14, 165, 233, 0.18); color: var(--extra-color); }
-.detail-title { font-weight: 600; font-size: 13px; }
+.detail-title { font-weight: 600; font-size: 12.5px; }
 .detail-meta { font-size: 11px; color: var(--muted); }
 .detail-actions-inline { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
 
@@ -545,13 +1002,7 @@
 
 .detail-actions { display: flex; gap: 10px; margin-top: 18px; flex-wrap: wrap; }
 
-.goal-progress-list { display: flex; flex-direction: column; gap: 14px; }
-.goal-progress-item { display: flex; flex-direction: column; gap: 8px; }
-.goal-progress-label { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
-.goal-progress-label strong { font-size: 13px; }
-.goal-progress-value { font-size: 11px; font-weight: 600; color: var(--muted); }
-.goal-progress-bar { width: 100%; height: 10px; border-radius: 999px; background: var(--line); overflow: hidden; }
-.goal-progress-bar span { display: block; height: 100%; border-radius: 999px; transition: width .3s ease; }
+
 
 .heatmap-card { display: flex; flex-direction: column; gap: 16px; }
 .heatmap { display: flex; gap: 3px; overflow-x: auto; padding-bottom: 8px; flex-wrap: nowrap; }
@@ -631,6 +1082,8 @@
   .top-grid { grid-template-columns: 1fr; }
   .focus-columns { grid-template-columns: 1fr; }
   .bottom-grid { grid-template-columns: 1fr; }
+  .grid-2.plan-overview { grid-template-columns: 1fr; }
+  .plan-card-layout { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 720px) {
@@ -647,20 +1100,36 @@
 }
   </style>
 </head>
-<body class="module-shell">
-  <section class="module-hero">
-    <div class="wrap module-hero-inner">
-      <div class="module-hero-top">
-        <div class="module-title-group">
-          <a href="./index.html" class="back-link">← Powrót</a>
-          <div class="module-eyebrow">Program treningowy</div>
+<body data-page="trainings">
+  <div class="layout">
+    <aside class="sidebar" aria-label="Główna nawigacja">
+      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
+      <nav class="sidebar-nav">
+        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
+        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
+        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
+        <a class="nav-link active" href="trainings.html" aria-current="page"><span class="icon">💪</span><span>Treningi</span></a>
+        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
+        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
+        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
+        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      </nav>
+      <div class="sidebar-footer">
+        <strong>Twój cyfrowy dom</strong>
+        Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
+      </div>
+    </aside>
+
+    <div class="main">
+      <header class="topbar">
+        <div>
+          <p class="topbar-eyebrow">Program treningowy</p>
           <div class="module-title-row">
-            <h1 class="module-title">Panel treningów</h1>
+            <h1 class="topbar-title">Treningi</h1>
             <span class="chip" id="header-month-chip">--</span>
           </div>
-          <p class="module-subtitle">Zarządzaj planem aktywności, dniami urlopu i monitoruj realizację celów.</p>
         </div>
-        <div class="module-hero-actions month-switcher">
+        <div class="topbar-actions month-switcher">
           <button id="prev-month-btn" class="btn ghost icon-btn" aria-label="Poprzedni miesiąc"><i data-lucide="chevron-left" class="icon"></i></button>
           <div class="month-labels">
             <span class="month-label" id="current-month-label">--</span>
@@ -669,189 +1138,167 @@
           <button id="next-month-btn" class="btn ghost icon-btn" aria-label="Następny miesiąc"><i data-lucide="chevron-right" class="icon"></i></button>
           <button id="today-month-btn" class="btn soft"><i data-lucide="calendar" class="icon"></i>Dzisiaj</button>
         </div>
-      </div>
-      <div class="module-hero-stats">
-        <div class="module-hero-stat">
-          <div class="label">Realizacja celów</div>
-          <div class="value" id="hero-goal-progress">0%</div>
-          <div class="note" id="hero-goal-progress-note">Cele tygodniowe — --</div>
-        </div>
-        <div class="module-hero-stat">
-          <div class="label">Zaliczone tygodnie</div>
-          <div class="value" id="hero-weekly-complete-count">0/0</div>
-          <div class="note" id="hero-weekly-complete-note">0%</div>
-        </div>
-        <div class="module-hero-stat">
-          <div class="label">Aktywne dni</div>
-          <div class="value" id="hero-active-days">0/0</div>
-          <div class="note" id="hero-active-days-note">W tym miesiącu</div>
-        </div>
-      </div>
-    </div>
-  </section>
+      </header>
 
-  <main class="module-content">
-    <div class="wrap page-content">
-    <div class="top-grid">
-      <section class="card metrics-card">
-        <div class="metrics-header">
-          <h3>Wskaźniki</h3>
-          <p class="muted tiny">Szybki podgląd Twojego miesiąca</p>
-        </div>
-        <div class="metrics-grid">
-          <div class="metric-card">
-            <div class="metric-text">
-              <span class="metric-label">Realizacja celów</span>
-              <span class="metric-value" id="metric-goal-progress">0%</span>
-              <div class="metric-sub metric-sub--stacked" id="metric-goal-progress-sub">
-                <span class="metric-subline">Cele tygodniowe</span>
-                <span class="metric-subline">--</span>
-              </div>
-            </div>
-          </div>
-          <div class="metric-card metric-card--donut">
-            <div class="metric-donut">
-              <svg viewBox="0 0 36 36" aria-hidden="true">
-                <circle class="donut-bg" cx="18" cy="18" r="16"></circle>
-                <circle class="donut-value" id="metric-weekly-complete-circle" cx="18" cy="18" r="16"></circle>
-              </svg>
-              <span id="metric-weekly-complete-percent">0%</span>
-            </div>
-            <div class="metric-text">
-              <span class="metric-label">Zaliczone tygodnie</span>
-              <span class="metric-value" id="metric-weekly-complete-count">0/0</span>
-              <div class="metric-sub metric-sub--stacked" id="metric-weekly-complete-sub">
-                <span class="metric-subline">Rok --</span>
-                <span class="metric-subline">--</span>
-              </div>
-            </div>
-          </div>
-          <div class="metric-card">
-            <div class="metric-text">
-              <span class="metric-label">Zamknięte działania</span>
-              <span class="metric-value" id="metric-plan-completion">0/0</span>
-              <span class="metric-sub">Ukończone vs zaplanowane</span>
-            </div>
-          </div>
-          <div class="metric-card">
-            <div class="metric-text">
-              <span class="metric-label">Aktywne dni</span>
-              <span class="metric-value" id="metric-active-days">0/0</span>
-              <span class="metric-sub">Dni z planem w miesiącu</span>
-            </div>
-          </div>
-          <div class="metric-card metric-card--visual" id="metric-next-activity-card" data-activity-type="none">
-            <div class="metric-visual" id="metric-next-activity-visual"><i data-lucide="calendar" class="icon"></i></div>
-            <div class="metric-text">
-              <span class="metric-label">Najbliższa aktywność</span>
-              <div class="metric-sub metric-sub--stacked">
-                <span class="metric-subline" id="metric-next-activity-date">Brak terminu</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="card focus-card">
-        <div class="focus-header">
-          <div class="focus-title">
-            <span class="tiny muted">Plan na dziś</span>
-            <h3 id="selected-day-title">--</h3>
-          </div>
-          <div class="focus-meta">
-            <span class="month-chip" id="selected-day-chip">--</span>
-            <button id="toggle-vacation-btn" class="btn ghost small"><i data-lucide="plane" class="icon"></i>Urlop</button>
-          </div>
-        </div>
-        <p class="muted tiny" id="selected-day-summary">Wybierz dzień z kalendarza, aby zarządzać planem.</p>
-        <div id="vacation-note" class="vacation-note">Dzień oznaczony jako urlop — bez oczekiwań treningowych.</div>
-        <div class="focus-columns">
-          <div class="focus-column">
-            <div class="detail-block">
-              <div class="detail-block-header">
-                <span>Plan treningowy</span>
-              </div>
-              <div id="day-plan-list" class="detail-list"></div>
-              <p id="day-plan-empty" class="empty-state">Brak zaplanowanych treningów na ten dzień.</p>
-            </div>
-            <div class="detail-block">
-              <div class="detail-block-header">
-                <span>Aktywności dodatkowe</span>
-              </div>
-              <div id="day-extra-list" class="detail-list"></div>
-              <p id="day-extra-empty" class="empty-state">Dodaj krótkie działania lub przypomnienia.</p>
-            </div>
-          </div>
-          <div class="focus-column">
-            <div class="planning-banner" id="planning-banner" aria-live="polite">
-              <div class="planning-banner-info">
-                <i data-lucide="mouse-pointer" class="icon"></i>
-                <div>
-                  <strong id="planning-banner-title">Tryb planowania</strong>
-                  <span id="planning-banner-meta">Wybierz typ treningu, aby rozpocząć tryb planowania wielu dni.</span>
+      <div class="content">
+        <main class="page-content content-main stack">
+          <div class="grid-2 plan-overview">
+            <section class="card focus-card focus-card--compact plan-card plan-card--slim plan-card--board">
+              <header class="plan-card-header">
+                <div class="plan-card-title">
+                  <span class="tiny muted">Plan na dziś</span>
+                  <h3>Twoja dzisiejsza ścieżka</h3>
+                </div>
+                <div class="plan-card-meta">
+                  <span class="month-chip" id="selected-day-chip">--</span>
+                  <button id="toggle-vacation-btn" class="btn ghost small"><i data-lucide="plane" class="icon"></i>Urlop</button>
+                </div>
+              </header>
+              <div class="plan-card-body">
+                <div class="plan-card-layout">
+                  <div class="plan-summary">
+                    <div class="plan-summary-head">
+                      <h4 id="selected-day-title" class="plan-summary-title">--</h4>
+                    </div>
+                    <p class="muted tiny" id="selected-day-summary">Wybierz dzień z kalendarza, aby zarządzać planem.</p>
+                    <div id="vacation-note" class="vacation-note">Dzień oznaczony jako urlop — bez oczekiwań treningowych.</div>
+                    <div class="plan-card-actions plan-card-actions--compact plan-card-actions--stacked">
+                      <button id="add-training-btn" class="btn"><i data-lucide="plus" class="icon"></i>Zaplanuj treningi</button>
+                      <button id="add-extra-btn" class="btn ghost"><i data-lucide="sparkles" class="icon"></i>Dodaj aktywność</button>
+                      <button id="plan-vacation-range-btn" class="btn ghost"><i data-lucide="calendar-range" class="icon"></i>Zaplanuj urlop</button>
+                    </div>
+                    <div class="planning-banner" id="planning-banner" aria-live="polite">
+                      <div class="planning-banner-info">
+                        <i data-lucide="mouse-pointer" class="icon"></i>
+                        <div>
+                          <strong id="planning-banner-title">Tryb planowania</strong>
+                          <span id="planning-banner-meta">Wybierz typ treningu, aby rozpocząć tryb planowania wielu dni.</span>
+                        </div>
+                      </div>
+                      <button id="stop-planning-btn" class="btn soft small"><i data-lucide="check" class="icon"></i>Zakończ</button>
+                    </div>
+                  </div>
+                  <div class="plan-panel-stack">
+                    <div class="plan-panels">
+                      <details id="plan-training-panel" class="plan-panel" open>
+                        <summary>
+                          <div class="panel-main">
+                            <span class="panel-title">Plan treningowy</span>
+                            <span class="panel-count" id="day-plan-count">0</span>
+                          </div>
+                          <span class="panel-meta" id="day-plan-meta">Brak zaplanowanych treningów</span>
+                        </summary>
+                        <div class="plan-panel-body">
+                          <div id="day-plan-list" class="detail-list"></div>
+                          <p id="day-plan-empty" class="empty-state">Brak zaplanowanych treningów na ten dzień.</p>
+                        </div>
+                      </details>
+                      <details id="plan-extra-panel" class="plan-panel">
+                        <summary>
+                          <div class="panel-main">
+                            <span class="panel-title">Aktywności dodatkowe</span>
+                            <span class="panel-count" id="day-extra-count">0</span>
+                          </div>
+                          <span class="panel-meta" id="day-extra-meta">Nic zaplanowanego</span>
+                        </summary>
+                        <div class="plan-panel-body">
+                          <div id="day-extra-list" class="detail-list"></div>
+                          <p id="day-extra-empty" class="empty-state">Dodaj krótkie działania lub przypomnienia.</p>
+                        </div>
+                      </details>
+                    </div>
+                  </div>
                 </div>
               </div>
-              <button id="stop-planning-btn" class="btn soft small"><i data-lucide="check" class="icon"></i>Zakończ</button>
-            </div>
-            <div class="focus-goals">
-              <div class="detail-block-header">
-                <span>Postęp tygodnia</span>
+            </section>
+
+            <section class="card calendar-card calendar-card--compact">
+              <div class="card-header">
+                <div>
+                  <h3>Dziennik aktywności</h3>
+                  <p class="muted tiny">Pełny miesiąc w jednym widoku</p>
+                </div>
+                <div class="calendar-legend">
+                  <span class="legend-tag gym">Siłownia</span>
+                  <span class="legend-tag running">Bieganie</span>
+                  <span class="legend-tag reading">Czytanie</span>
+                  <span class="legend-tag extra">Dodatkowe</span>
+                  <span class="legend-tag vacation">Urlop</span>
+                </div>
               </div>
-              <div id="goal-progress-list" class="goal-progress-list"></div>
+              <div class="calendar-weekdays">
+                <span>Pon</span><span>Wt</span><span>Śr</span><span>Czw</span><span>Pt</span><span>Sob</span><span>Niedz</span>
+              </div>
+              <div id="calendar-grid" class="calendar-grid"></div>
+            </section>
+          </div>
+
+          <section class="card heatmap-card">
+            <div class="card-header">
+              <div>
+                <h3>Historia aktywności</h3>
+                <p class="muted tiny">Podsumowanie ukończonych zadań w ciągu roku</p>
+              </div>
+              <span class="month-chip" id="heatmap-year-label">--</span>
+            </div>
+            <div id="heatmap" class="heatmap"></div>
+            <div class="heatmap-legend">
+              <span>Brak</span>
+              <div class="heatmap-legend-scale">
+                <span data-level="0"></span>
+                <span data-level="1"></span>
+                <span data-level="2"></span>
+                <span data-level="3"></span>
+                <span data-level="4"></span>
+              </div>
+              <span>Intensywnie</span>
+            </div>
+          </section>
+        </main>
+
+        <aside class="right-rail">
+          <div class="kpi-compact kpi-progress-card">
+            <span class="kpi-emoji">📈</span>
+            <div>
+              <div class="kpi-label">Postęp tygodniowy</div>
+              <div class="kpi-value" id="metric-weekly-complete-percent">0%</div>
+              <div class="tiny muted" id="metric-weekly-complete-sub"></div>
             </div>
           </div>
-        </div>
-        <div class="detail-actions">
-          <button id="add-training-btn" class="btn"><i data-lucide="plus" class="icon"></i>Zaplanuj treningi</button>
-          <button id="add-extra-btn" class="btn ghost"><i data-lucide="sparkles" class="icon"></i>Dodaj aktywność</button>
-          <button id="plan-vacation-range-btn" class="btn ghost"><i data-lucide="calendar-range" class="icon"></i>Zaplanuj urlop</button>
-        </div>
-      </section>
+          <div id="goal-progress-list" class="goal-progress-grid"></div>
+          <div class="kpi-compact">
+            <span class="kpi-emoji">📆</span>
+            <div>
+              <div class="kpi-label">Tygodnie zaliczone</div>
+              <div class="kpi-value" id="metric-weekly-complete-count">0/0</div>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <span class="kpi-emoji">🧍</span>
+            <div>
+              <div class="kpi-label">Dni aktywne</div>
+              <div class="kpi-value" id="metric-active-days">0/0</div>
+            </div>
+          </div>
+          <div class="kpi-compact">
+            <span class="kpi-emoji">✅</span>
+            <div>
+              <div class="kpi-label">Akcje wykonane</div>
+              <div class="kpi-value" id="metric-plan-completion">0/0</div>
+            </div>
+          </div>
+          <div class="kpi-compact metric-card--visual kpi-next-activity" id="metric-next-activity-card" data-activity-type="none">
+            <span class="metric-visual metric-visual--compact" id="metric-next-activity-visual"><i data-lucide="calendar" class="icon"></i></span>
+            <div>
+              <div class="kpi-label">Najbliższa aktywność</div>
+              <div class="kpi-value kpi-value--sm" id="metric-next-activity-date">Brak terminu</div>
+              <div class="tiny muted">Zaplanuj kolejny ruch</div>
+            </div>
+          </div>
+        </aside>
+      </div>
     </div>
-
-    <section class="card calendar-card">
-      <div class="card-header">
-        <div>
-          <h3>Harmonogram miesięczny</h3>
-          <p class="muted tiny">Pełny miesiąc w jednym widoku</p>
-        </div>
-        <div class="calendar-legend">
-          <span class="legend-tag gym">Siłownia</span>
-          <span class="legend-tag running">Bieganie</span>
-          <span class="legend-tag reading">Czytanie</span>
-          <span class="legend-tag extra">Dodatkowe</span>
-          <span class="legend-tag vacation">Urlop</span>
-        </div>
-      </div>
-      <div class="calendar-weekdays">
-        <span>Pon</span><span>Wt</span><span>Śr</span><span>Czw</span><span>Pt</span><span>Sob</span><span>Niedz</span>
-      </div>
-      <div id="calendar-grid" class="calendar-grid"></div>
-    </section>
-
-    <section class="card heatmap-card">
-      <div class="card-header">
-        <div>
-          <h3>Historia aktywności</h3>
-          <p class="muted tiny">Podsumowanie ukończonych zadań w ciągu roku</p>
-        </div>
-        <span class="month-chip" id="heatmap-year-label">--</span>
-      </div>
-      <div id="heatmap" class="heatmap"></div>
-      <div class="heatmap-legend">
-        <span>Brak</span>
-        <div class="heatmap-legend-scale">
-          <span data-level="0"></span>
-          <span data-level="1"></span>
-          <span data-level="2"></span>
-          <span data-level="3"></span>
-          <span data-level="4"></span>
-        </div>
-        <span>Intensywnie</span>
-      </div>
-    </section>
   </div>
-  </main>
 
 <div id="modal-overlay" class="modal-overlay">
   <div class="modal-card">
@@ -1500,7 +1947,8 @@ function renderHeader(monthStats, weekStats, upcomingWindow, yearStats) {
   if (sameMonth(new Date(), currentMonth)) todayButton.style.display = 'none';
   else todayButton.style.display = 'inline-flex';
   const weeklyPercentLabel = `${weekStats.averageGoalPercent}%`;
-  document.getElementById('metric-goal-progress').textContent = weeklyPercentLabel;
+  const goalProgressEl = document.getElementById('metric-goal-progress');
+  if (goalProgressEl) goalProgressEl.textContent = weeklyPercentLabel;
   const heroGoalProgress = document.getElementById('hero-goal-progress');
   if (heroGoalProgress) heroGoalProgress.textContent = weeklyPercentLabel;
   const goalProgressSub = document.getElementById('metric-goal-progress-sub');
@@ -1586,9 +2034,13 @@ function renderCalendar() {
     const vacationDay = isVacationDay(dateString);
     const plannedCount = activities.length + extras.length;
     const completedCount = activities.filter(a => a.completed).length + extras.filter(e => e.completed).length;
+    const pendingCount = Math.max(0, plannedCount - completedCount);
 
     const cell = document.createElement('div');
     cell.className = 'calendar-day';
+    cell.dataset.date = dateString;
+    cell.dataset.planned = String(plannedCount);
+    cell.dataset.completed = String(completedCount);
     if (date.getMonth() !== currentMonth.getMonth()) cell.classList.add('calendar-day--other-month');
     if (dateString === selectedDate) cell.classList.add('calendar-day--selected');
     if (normalizeDate(date).getTime() === today.getTime()) cell.classList.add('calendar-day--today');
@@ -1597,21 +2049,69 @@ function renderCalendar() {
     else if (plannedCount > 0 && completedCount === 0) cell.classList.add('calendar-day--planned');
     else if (plannedCount > 0) cell.classList.add('calendar-day--completed');
 
+    const stateKey = vacationDay
+      ? 'vacation'
+      : (plannedCount === 0
+        ? 'empty'
+        : (completedCount === 0
+          ? 'planned'
+          : (completedCount >= plannedCount ? 'done' : 'progress')));
+    cell.dataset.state = stateKey;
+
+    let statusLabel = 'Plan';
+    if (stateKey === 'vacation') statusLabel = 'Urlop';
+    else if (stateKey === 'empty') statusLabel = 'Wolne';
+    else if (stateKey === 'planned') statusLabel = 'Zaplanowano';
+    else if (stateKey === 'progress') statusLabel = 'W toku';
+    else if (stateKey === 'done') statusLabel = 'Zrealizowano';
+
+    let tooltipSummary = '';
+    if (stateKey === 'vacation') tooltipSummary = 'Urlop – dzień wolny od planów';
+    else if (plannedCount === 0) tooltipSummary = 'Brak zaplanowanych aktywności';
+    else {
+      tooltipSummary = `${completedCount} z ${plannedCount} ukończonych`;
+      if (pendingCount > 0) tooltipSummary += ` · ${pendingCount} otwarte`;
+    }
+    cell.title = tooltipSummary;
+    if (tooltipSummary) {
+      const ariaSummary = `${date.toLocaleDateString('pl-PL', { weekday: 'long', day: 'numeric', month: 'long' })} · ${tooltipSummary}`;
+      cell.setAttribute('aria-label', ariaSummary);
+    }
+
     const header = document.createElement('div');
     header.className = 'calendar-day-header';
+    const titleWrap = document.createElement('div');
+    titleWrap.className = 'calendar-day-title';
+    const weekday = document.createElement('span');
+    weekday.className = 'calendar-day-weekday';
+    weekday.textContent = date.toLocaleDateString('pl-PL', { weekday: 'short' }).replace('.', '').toUpperCase();
+    titleWrap.appendChild(weekday);
     const number = document.createElement('span');
     number.className = 'calendar-date-number';
     number.textContent = date.getDate();
-    header.appendChild(number);
+    titleWrap.appendChild(number);
+    header.appendChild(titleWrap);
+    const metaWrap = document.createElement('div');
+    metaWrap.className = 'calendar-day-meta';
+    const status = document.createElement('span');
+    status.className = 'calendar-day-status';
+    status.dataset.state = stateKey;
+    status.textContent = statusLabel;
+    metaWrap.appendChild(status);
     const badges = document.createElement('div');
     badges.className = 'calendar-day-badges';
     if (plannedCount > 0) {
       const badge = document.createElement('span');
       badge.className = 'calendar-badge';
       badge.textContent = plannedCount;
+      badge.title = 'Liczba zaplanowanych aktywności';
+      badge.setAttribute('aria-label', `${plannedCount} zaplanowanych aktywności`);
       badges.appendChild(badge);
     }
-    header.appendChild(badges);
+    if (badges.childElementCount > 0) {
+      metaWrap.appendChild(badges);
+    }
+    header.appendChild(metaWrap);
     cell.appendChild(header);
 
     const tags = document.createElement('div');
@@ -1664,14 +2164,27 @@ function renderCalendar() {
     }
     cell.appendChild(tags);
 
+    if (plannedCount > 0 || vacationDay) {
+      const progress = document.createElement('div');
+      progress.className = 'calendar-progress';
+      const fill = document.createElement('div');
+      fill.className = 'calendar-progress-fill';
+      fill.dataset.state = stateKey;
+      const ratio = plannedCount > 0 ? Math.min(1, Math.max(0, completedCount / plannedCount)) : 0;
+      const width = stateKey === 'vacation' ? 1 : ratio;
+      fill.style.width = `${Math.round(width * 100)}%`;
+      progress.appendChild(fill);
+      cell.appendChild(progress);
+    }
+
     const footer = document.createElement('div');
     footer.className = 'calendar-day-footer';
     const done = document.createElement('span');
     done.className = 'calendar-footer-label';
     done.textContent = vacationDay && plannedCount === 0 ? 'Urlop' : `${completedCount} ukończ.`;
     const remaining = document.createElement('span');
-    const openCount = Math.max(0, plannedCount - completedCount);
-    remaining.textContent = openCount > 0 ? `${openCount} otwarte` : '';
+    remaining.className = 'calendar-footer-remaining';
+    remaining.textContent = pendingCount > 0 ? `${pendingCount} otwarte` : '';
     footer.appendChild(done);
     footer.appendChild(remaining);
     cell.appendChild(footer);
@@ -1781,12 +2294,33 @@ function renderDayDetail() {
 function renderDayActivities(activities) {
   const list = document.getElementById('day-plan-list');
   const empty = document.getElementById('day-plan-empty');
+  const count = document.getElementById('day-plan-count');
+  const meta = document.getElementById('day-plan-meta');
+  const panel = document.getElementById('plan-training-panel');
   list.innerHTML = '';
   if (!activities.length) {
     empty.style.display = 'block';
+    if (count) count.textContent = '0';
+    if (meta) meta.textContent = 'Brak zaplanowanych treningów';
+    if (panel) {
+      panel.classList.add('is-empty');
+      panel.open = false;
+      panel.removeAttribute('data-user-collapsed');
+    }
     return;
   }
   empty.style.display = 'none';
+  if (count) count.textContent = activities.length.toString();
+  const completed = activities.filter(activity => activity.completed).length;
+  if (meta) meta.textContent = `${completed}/${activities.length} ukończone`;
+  if (panel) {
+    panel.classList.remove('is-empty');
+    if (panel.dataset.userCollapsed === 'true') {
+      panel.open = false;
+    } else {
+      panel.open = true;
+    }
+  }
 
   activities.forEach(activity => {
     const goal = GOAL_DEFINITIONS[activity.type];
@@ -1822,12 +2356,33 @@ function renderDayActivities(activities) {
 function renderDayExtras(extras) {
   const list = document.getElementById('day-extra-list');
   const empty = document.getElementById('day-extra-empty');
+  const count = document.getElementById('day-extra-count');
+  const meta = document.getElementById('day-extra-meta');
+  const panel = document.getElementById('plan-extra-panel');
   list.innerHTML = '';
   if (!extras.length) {
     empty.style.display = 'block';
+    if (count) count.textContent = '0';
+    if (meta) meta.textContent = 'Nic zaplanowanego';
+    if (panel) {
+      panel.classList.add('is-empty');
+      panel.open = false;
+      panel.removeAttribute('data-user-collapsed');
+    }
     return;
   }
   empty.style.display = 'none';
+  if (count) count.textContent = extras.length.toString();
+  const completed = extras.filter(extra => extra.completed).length;
+  if (meta) meta.textContent = `${completed}/${extras.length} ukończone`;
+  if (panel) {
+    panel.classList.remove('is-empty');
+    if (panel.dataset.userCollapsed === 'true') {
+      panel.open = false;
+    } else {
+      panel.open = true;
+    }
+  }
   extras.forEach(extra => {
     const item = document.createElement('div');
     item.className = 'detail-item';
@@ -1852,23 +2407,24 @@ function renderDayExtras(extras) {
 
 function renderGoalProgress(goalPercents) {
   const container = document.getElementById('goal-progress-list');
+  if (!container) return;
   container.innerHTML = '';
   if (!goalPercents) return;
+  const emojiMap = { gym: '🏋️', running: '🏃', reading: '📚' };
   Object.entries(goalPercents).forEach(([type, info]) => {
     const def = GOAL_DEFINITIONS[type];
+    if (!def) return;
     const item = document.createElement('div');
-    item.className = 'goal-progress-item';
+    item.className = 'goal-progress-item kpi-compact';
     const progressValue = Number(info.progress || 0).toLocaleString('pl-PL');
-    const targetValue = Number(info.target || 0).toLocaleString('pl-PL');
+    const targetValue = Number((info && info.target) || def.target || 0).toLocaleString('pl-PL');
     item.innerHTML = `
-      <div class="goal-progress-label">
-        <div>
-          <strong>${def.label}</strong>
-          <div class="muted tiny">${progressValue} / ${targetValue} ${def.unit}</div>
-        </div>
-        <span class="goal-progress-value">${info.percent}%</span>
+      <span class="kpi-emoji">${emojiMap[type] || '🏅'}</span>
+      <div class="goal-progress-body">
+        <div class="kpi-label">${def.label}</div>
+        <div class="kpi-value">${info.percent}%</div>
+        <div class="tiny muted">${progressValue} / ${targetValue} ${def.unit}</div>
       </div>
-      <div class="goal-progress-bar"><span style="width:${info.percent}%; background:${def.color};"></span></div>
     `;
     container.appendChild(item);
   });
@@ -2307,6 +2863,16 @@ function setupEventListeners() {
     const action = target.dataset.action;
     if (action === 'toggle-extra') toggleExtra(day, id);
     if (action === 'delete-extra') deleteExtra(day, id);
+  });
+
+  document.querySelectorAll('.plan-panel').forEach(panel => {
+    panel.addEventListener('toggle', () => {
+      if (panel.open) {
+        panel.removeAttribute('data-user-collapsed');
+      } else if (!panel.classList.contains('is-empty')) {
+        panel.dataset.userCollapsed = 'true';
+      }
+    });
   });
 
   document.getElementById('modal-overlay').addEventListener('click', (event) => {

--- a/trainings.html
+++ b/trainings.html
@@ -608,7 +608,7 @@
   align-self: flex-start;
 }
 
-.kpi-progress-card > div {
+.kpi-progress-card > .kpi-body {
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -1259,7 +1259,7 @@
         <aside class="right-rail">
           <div class="kpi-compact kpi-progress-card">
             <span class="kpi-emoji">📈</span>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Postęp tygodniowy</div>
               <div class="kpi-value" id="metric-weekly-complete-percent">0%</div>
               <div class="tiny muted" id="metric-weekly-complete-sub"></div>
@@ -1268,28 +1268,28 @@
           <div id="goal-progress-list" class="goal-progress-grid"></div>
           <div class="kpi-compact">
             <span class="kpi-emoji">📆</span>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Tygodnie zaliczone</div>
               <div class="kpi-value" id="metric-weekly-complete-count">0/0</div>
             </div>
           </div>
           <div class="kpi-compact">
             <span class="kpi-emoji">🧍</span>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Dni aktywne</div>
               <div class="kpi-value" id="metric-active-days">0/0</div>
             </div>
           </div>
           <div class="kpi-compact">
             <span class="kpi-emoji">✅</span>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Akcje wykonane</div>
               <div class="kpi-value" id="metric-plan-completion">0/0</div>
             </div>
           </div>
           <div class="kpi-compact metric-card--visual kpi-next-activity" id="metric-next-activity-card" data-activity-type="none">
             <span class="metric-visual metric-visual--compact" id="metric-next-activity-visual"><i data-lucide="calendar" class="icon"></i></span>
-            <div>
+            <div class="kpi-body">
               <div class="kpi-label">Najbliższa aktywność</div>
               <div class="kpi-value kpi-value--sm" id="metric-next-activity-date">Brak terminu</div>
               <div class="tiny muted">Zaplanuj kolejny ruch</div>
@@ -2420,7 +2420,7 @@ function renderGoalProgress(goalPercents) {
     const targetValue = Number((info && info.target) || def.target || 0).toLocaleString('pl-PL');
     item.innerHTML = `
       <span class="kpi-emoji">${emojiMap[type] || '🏅'}</span>
-      <div class="goal-progress-body">
+      <div class="goal-progress-body kpi-body">
         <div class="kpi-label">${def.label}</div>
         <div class="kpi-value">${info.percent}%</div>
         <div class="tiny muted">${progressValue} / ${targetValue} ${def.unit}</div>


### PR DESCRIPTION
## Summary
- adopt the shared sidebar/topbar layout in the loan module with a compact progress card, full-width charts, and scrollable schedule table
- add the requested right-rail KPI cards for capital, interest, average installment, and next payment while keeping insights inline with the progress section
- update dashboard rendering logic to feed the new KPIs and maintain next-payment metadata alongside the insight panel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d79e9f7890833196a78433494b05e2