### PR TITLE
Standardize LifeOS sidebar navigation

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -527,26 +527,25 @@
   </style>
 </head>
 <body data-page="budget">
-  <div class="layout">
-    <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link active" href="budget.html" aria-current="page"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+  <div class="app-shell">
+    <aside class="app-sidebar" aria-label="Główna nawigacja">
+      <div class="app-sidebar__brand"><span class="app-sidebar__brand-emoji" aria-hidden="true">🧭</span><span>LifeOS</span></div>
+      <nav class="app-sidebar__nav">
+        <a class="app-sidebar__link" data-page="dashboard" href="index.html"><span class="app-sidebar__icon" aria-hidden="true">📊</span><span class="app-sidebar__label">Dashboard</span></a>
+        <a class="app-sidebar__link" data-page="budget" href="budget.html"><span class="app-sidebar__icon" aria-hidden="true">💰</span><span class="app-sidebar__label">Budżet</span></a>
+        <a class="app-sidebar__link" data-page="fuel" href="fuel.html"><span class="app-sidebar__icon" aria-hidden="true">⛽</span><span class="app-sidebar__label">Paliwo</span></a>
+        <a class="app-sidebar__link" data-page="trainings" href="trainings.html"><span class="app-sidebar__icon" aria-hidden="true">💪</span><span class="app-sidebar__label">Treningi</span></a>
+        <a class="app-sidebar__link" data-page="loan" href="loan.html"><span class="app-sidebar__icon" aria-hidden="true">🏦</span><span class="app-sidebar__label">Kredyt</span></a>
+        <a class="app-sidebar__link" data-page="tasks" href="tasks.html"><span class="app-sidebar__icon" aria-hidden="true">✅</span><span class="app-sidebar__label">Zadania</span></a>
+        <a class="app-sidebar__link" data-page="house" href="house.html"><span class="app-sidebar__icon" aria-hidden="true">🏠</span><span class="app-sidebar__label">Budowa</span></a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="app-sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
     </aside>
 
-    <div class="main">
+    <div class="app-main">
       <header class="topbar">
         <div class="row" style="align-items:center;justify-content:space-between;gap:16px">
           <div>
@@ -1353,6 +1352,14 @@
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
+  (function setActiveSidebarLink() {
+    const currentPage = document.body.dataset.page;
+    if (!currentPage) return;
+    document.querySelectorAll('.app-sidebar__link').forEach((link) => {
+      link.toggleAttribute('aria-current', link.dataset.page === currentPage);
+    });
+  })();
+
   // --- Storage & helpers ------------------------------------------------------
   const STORAGE_KEY='lifeos_budget_v4';
 

--- a/fuel.html
+++ b/fuel.html
@@ -87,26 +87,25 @@
   </style>
 </head>
 <body data-page="fuel">
-  <div class="layout">
-    <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link active" href="fuel.html" aria-current="page"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+  <div class="app-shell">
+    <aside class="app-sidebar" aria-label="Główna nawigacja">
+      <div class="app-sidebar__brand"><span class="app-sidebar__brand-emoji" aria-hidden="true">🧭</span><span>LifeOS</span></div>
+      <nav class="app-sidebar__nav">
+        <a class="app-sidebar__link" data-page="dashboard" href="index.html"><span class="app-sidebar__icon" aria-hidden="true">📊</span><span class="app-sidebar__label">Dashboard</span></a>
+        <a class="app-sidebar__link" data-page="budget" href="budget.html"><span class="app-sidebar__icon" aria-hidden="true">💰</span><span class="app-sidebar__label">Budżet</span></a>
+        <a class="app-sidebar__link" data-page="fuel" href="fuel.html"><span class="app-sidebar__icon" aria-hidden="true">⛽</span><span class="app-sidebar__label">Paliwo</span></a>
+        <a class="app-sidebar__link" data-page="trainings" href="trainings.html"><span class="app-sidebar__icon" aria-hidden="true">💪</span><span class="app-sidebar__label">Treningi</span></a>
+        <a class="app-sidebar__link" data-page="loan" href="loan.html"><span class="app-sidebar__icon" aria-hidden="true">🏦</span><span class="app-sidebar__label">Kredyt</span></a>
+        <a class="app-sidebar__link" data-page="tasks" href="tasks.html"><span class="app-sidebar__icon" aria-hidden="true">✅</span><span class="app-sidebar__label">Zadania</span></a>
+        <a class="app-sidebar__link" data-page="house" href="house.html"><span class="app-sidebar__icon" aria-hidden="true">🏠</span><span class="app-sidebar__label">Budowa</span></a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="app-sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
     </aside>
 
-    <div class="main">
+    <div class="app-main">
       <header class="topbar">
         <div class="topbar-info">
           <p class="topbar-eyebrow">Finanse</p>
@@ -279,6 +278,14 @@
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
+(function setActiveSidebarLink() {
+  const currentPage = document.body.dataset.page;
+  if (!currentPage) return;
+  document.querySelectorAll('.app-sidebar__link').forEach((link) => {
+    link.toggleAttribute('aria-current', link.dataset.page === currentPage);
+  });
+})();
+
 const FUEL_STORAGE_KEY = 'lifeos_fuel_v1';
 const KPI_STORAGE_KEY = 'lifeos_kpis_v1';
 

--- a/house.html
+++ b/house.html
@@ -133,91 +133,6 @@
       font-size: 18px;
     }
 
-    /* Sidebar */
-    .sidebar {
-      width: 280px;
-      background: var(--sidebar-bg);
-      display: flex;
-      flex-direction: column;
-      transition: var(--transition);
-      border-right: 1px solid var(--border);
-      z-index: 100;
-      flex-shrink: 0;
-    }
-    
-    .sidebar-header {
-      padding: 24px;
-      border-bottom: 1px solid rgba(255,255,255,0.1);
-    }
-    
-    .logo {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-    }
-    
-    .logo-icon {
-      width: 48px;
-      height: 48px;
-      background: linear-gradient(135deg, var(--primary), var(--info));
-      border-radius: var(--radius);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 24px;
-      box-shadow: var(--shadow-lg);
-    }
-    
-    .logo-text h1 {
-      font-size: 20px;
-      font-weight: 900;
-      color: #ffffff;
-      letter-spacing: -0.5px;
-    }
-    
-    .logo-text p {
-      font-size: 12px;
-      color: var(--text-tertiary);
-      margin-top: 2px;
-    }
-
-    .nav-menu {
-      flex: 1;
-      overflow-y: auto;
-      padding: 16px;
-      list-style: none;
-    }
-    
-    .nav-item {
-      margin-bottom: 4px;
-    }
-    
-    .nav-item a {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 12px 16px;
-      border-radius: var(--radius-sm);
-      text-decoration: none;
-      font-weight: 500;
-      font-size: 14px;
-      color: var(--text-tertiary);
-      transition: var(--transition);
-      position: relative;
-      overflow: hidden;
-    }
-    
-    .nav-item a:hover {
-      background: rgba(255,255,255,0.05);
-      color: #ffffff;
-    }
-    
-    .nav-item a.active {
-      background: var(--primary);
-      color: #ffffff;
-      box-shadow: var(--shadow-md);
-    }
-    
     .nav-icon {
       font-size: 16px;
       line-height: 1;
@@ -274,11 +189,6 @@
       display: flex;
       flex-direction: column;
       gap: 24px;
-    }
-
-    .sidebar-footer {
-      padding: 16px;
-      border-top: 1px solid rgba(255,255,255,0.1);
     }
 
     /* Main Content */
@@ -1879,7 +1789,7 @@
     }
 
     @media (max-width: 768px) {
-      .sidebar {
+      .app-sidebar {
         position: fixed;
         left: -280px;
         top: 0;
@@ -1887,8 +1797,8 @@
         z-index: 999;
         box-shadow: var(--shadow-xl);
       }
-      
-      .sidebar.active {
+
+      .app-sidebar.active {
         left: 0;
       }
 
@@ -1942,19 +1852,18 @@
 </head>
 <body data-page="house">
   <div class="app-shell">
-    <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link active" href="house.html" aria-current="page"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+    <aside class="app-sidebar" aria-label="Główna nawigacja">
+      <div class="app-sidebar__brand"><span class="app-sidebar__brand-emoji" aria-hidden="true">🧭</span><span>LifeOS</span></div>
+      <nav class="app-sidebar__nav">
+        <a class="app-sidebar__link" data-page="dashboard" href="index.html"><span class="app-sidebar__icon" aria-hidden="true">📊</span><span class="app-sidebar__label">Dashboard</span></a>
+        <a class="app-sidebar__link" data-page="budget" href="budget.html"><span class="app-sidebar__icon" aria-hidden="true">💰</span><span class="app-sidebar__label">Budżet</span></a>
+        <a class="app-sidebar__link" data-page="fuel" href="fuel.html"><span class="app-sidebar__icon" aria-hidden="true">⛽</span><span class="app-sidebar__label">Paliwo</span></a>
+        <a class="app-sidebar__link" data-page="trainings" href="trainings.html"><span class="app-sidebar__icon" aria-hidden="true">💪</span><span class="app-sidebar__label">Treningi</span></a>
+        <a class="app-sidebar__link" data-page="loan" href="loan.html"><span class="app-sidebar__icon" aria-hidden="true">🏦</span><span class="app-sidebar__label">Kredyt</span></a>
+        <a class="app-sidebar__link" data-page="tasks" href="tasks.html"><span class="app-sidebar__icon" aria-hidden="true">✅</span><span class="app-sidebar__label">Zadania</span></a>
+        <a class="app-sidebar__link" data-page="house" href="house.html"><span class="app-sidebar__icon" aria-hidden="true">🏠</span><span class="app-sidebar__label">Budowa</span></a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="app-sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
@@ -2359,6 +2268,14 @@
 
 
   <script>
+    (function setActiveSidebarLink() {
+      const currentPage = document.body.dataset.page;
+      if (!currentPage) return;
+      document.querySelectorAll('.app-sidebar__link').forEach((link) => {
+        link.toggleAttribute('aria-current', link.dataset.page === currentPage);
+      });
+    })();
+
     // App State
     const APP_KEY = 'buildmaster_pro_v11';
     const safeParse = (raw, fallbackFactory) => {

--- a/index.html
+++ b/index.html
@@ -183,19 +183,18 @@
 </head>
 <body data-page="dashboard">
   <div class="app-shell">
-    <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link active" href="index.html" aria-current="page"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+    <aside class="app-sidebar" aria-label="Główna nawigacja">
+      <div class="app-sidebar__brand"><span class="app-sidebar__brand-emoji" aria-hidden="true">🧭</span><span>LifeOS</span></div>
+      <nav class="app-sidebar__nav">
+        <a class="app-sidebar__link" data-page="dashboard" href="index.html"><span class="app-sidebar__icon" aria-hidden="true">📊</span><span class="app-sidebar__label">Dashboard</span></a>
+        <a class="app-sidebar__link" data-page="budget" href="budget.html"><span class="app-sidebar__icon" aria-hidden="true">💰</span><span class="app-sidebar__label">Budżet</span></a>
+        <a class="app-sidebar__link" data-page="fuel" href="fuel.html"><span class="app-sidebar__icon" aria-hidden="true">⛽</span><span class="app-sidebar__label">Paliwo</span></a>
+        <a class="app-sidebar__link" data-page="trainings" href="trainings.html"><span class="app-sidebar__icon" aria-hidden="true">💪</span><span class="app-sidebar__label">Treningi</span></a>
+        <a class="app-sidebar__link" data-page="loan" href="loan.html"><span class="app-sidebar__icon" aria-hidden="true">🏦</span><span class="app-sidebar__label">Kredyt</span></a>
+        <a class="app-sidebar__link" data-page="tasks" href="tasks.html"><span class="app-sidebar__icon" aria-hidden="true">✅</span><span class="app-sidebar__label">Zadania</span></a>
+        <a class="app-sidebar__link" data-page="house" href="house.html"><span class="app-sidebar__icon" aria-hidden="true">🏠</span><span class="app-sidebar__label">Budowa</span></a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="app-sidebar__footer">
         <strong>Twoje centrum dowodzenia życiem.</strong>
       </div>
     </aside>
@@ -274,6 +273,14 @@
   <div id="notification" class="notification"></div>
 
 <script>
+(function setActiveSidebarLink() {
+  const currentPage = document.body.dataset.page;
+  if (!currentPage) return;
+  document.querySelectorAll('.app-sidebar__link').forEach((link) => {
+    link.toggleAttribute('aria-current', link.dataset.page === currentPage);
+  });
+})();
+
 /* === STORAGE KEYS === */
 const BUDGET_STORAGE_KEY = 'lifeos_budget_v4';
 const FUEL_STORAGE_KEY = 'lifeos_fuel_v1';

--- a/loan.html
+++ b/loan.html
@@ -492,26 +492,25 @@
 </head>
 <body data-page="loan">
 
-  <div class="layout">
-    <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link active" href="loan.html" aria-current="page"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+  <div class="app-shell">
+    <aside class="app-sidebar" aria-label="Główna nawigacja">
+      <div class="app-sidebar__brand"><span class="app-sidebar__brand-emoji" aria-hidden="true">🧭</span><span>LifeOS</span></div>
+      <nav class="app-sidebar__nav">
+        <a class="app-sidebar__link" data-page="dashboard" href="index.html"><span class="app-sidebar__icon" aria-hidden="true">📊</span><span class="app-sidebar__label">Dashboard</span></a>
+        <a class="app-sidebar__link" data-page="budget" href="budget.html"><span class="app-sidebar__icon" aria-hidden="true">💰</span><span class="app-sidebar__label">Budżet</span></a>
+        <a class="app-sidebar__link" data-page="fuel" href="fuel.html"><span class="app-sidebar__icon" aria-hidden="true">⛽</span><span class="app-sidebar__label">Paliwo</span></a>
+        <a class="app-sidebar__link" data-page="trainings" href="trainings.html"><span class="app-sidebar__icon" aria-hidden="true">💪</span><span class="app-sidebar__label">Treningi</span></a>
+        <a class="app-sidebar__link" data-page="loan" href="loan.html"><span class="app-sidebar__icon" aria-hidden="true">🏦</span><span class="app-sidebar__label">Kredyt</span></a>
+        <a class="app-sidebar__link" data-page="tasks" href="tasks.html"><span class="app-sidebar__icon" aria-hidden="true">✅</span><span class="app-sidebar__label">Zadania</span></a>
+        <a class="app-sidebar__link" data-page="house" href="house.html"><span class="app-sidebar__icon" aria-hidden="true">🏠</span><span class="app-sidebar__label">Budowa</span></a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="app-sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
     </aside>
 
-    <div class="main">
+    <div class="app-main">
       <header class="topbar">
         <div class="topbar-info">
           <p class="topbar-eyebrow">Finanse</p>
@@ -734,6 +733,14 @@
   </div>
 
 <script>
+(function setActiveSidebarLink() {
+  const currentPage = document.body.dataset.page;
+  if (!currentPage) return;
+  document.querySelectorAll('.app-sidebar__link').forEach((link) => {
+    link.toggleAttribute('aria-current', link.dataset.page === currentPage);
+  });
+})();
+
 const STORAGE_KEY = 'lifeos_loan_v1';
 
 const defaultState = {

--- a/styles.css
+++ b/styles.css
@@ -51,6 +51,9 @@
   --sidebar-text: #e2e8f0;
   --sidebar-accent: hsl(var(--accent-h) 85% 68%);
   --sidebar-hover: rgba(148, 163, 184, 0.12);
+  --sidebar-width: 260px;
+  --sidebar-link-height: 44px;
+  --sidebar-link-font-size: 14px;
   --topbar-bg: #ffffff;
   --topbar-border: rgba(15, 23, 42, 0.08);
   --text-primary: var(--ink);
@@ -115,7 +118,7 @@ a:hover {
 
 .app-shell {
   display: grid;
-  grid-template-columns: 240px 1fr;
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   min-height: 100vh;
   background: var(--bg);
 }
@@ -197,18 +200,6 @@ a:hover {
   grid-template-columns: minmax(0, 1fr) 280px;
 }
 
-.layout {
-  display: flex;
-  min-height: 100vh;
-}
-
-.main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  background: var(--bg);
-}
-
 .content {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 320px;
@@ -239,80 +230,101 @@ a:hover {
   gap: 16px;
 }
 
-.sidebar {
+.app-sidebar {
+  position: sticky;
+  top: 0;
+  align-self: start;
   display: flex;
   flex-direction: column;
   gap: 24px;
-  padding: 24px 20px;
-  width: 240px;
-  background: var(--sidebar-bg);
-  color: #fff;
-  position: sticky;
-  top: 0;
-  height: 100vh;
+  padding: 28px 22px;
+  width: var(--sidebar-width);
+  min-height: 100vh;
+  color: var(--sidebar-text);
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.88) 0%, rgba(30, 41, 59, 0.82) 100%);
+  border-right: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 32px 0 60px -48px rgba(15, 23, 42, 0.7);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
 }
 
-.sidebar-header {
+.app-sidebar__brand {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   font-weight: 700;
   font-size: 16px;
   letter-spacing: 0.04em;
 }
 
-.sidebar-header .emoji {
-  font-size: 20px;
+.app-sidebar__brand-emoji {
+  font-size: 22px;
+  line-height: 1;
 }
 
-.sidebar-nav {
+.app-sidebar__nav {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
-.nav-link {
+.app-sidebar__link {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 10px 12px;
-  border-radius: 12px;
-  color: inherit;
+  height: var(--sidebar-link-height);
+  padding: 0 16px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  color: rgba(226, 232, 240, 0.88);
   font-weight: 600;
-  font-size: 13px;
-  transition: background-color var(--transition), color var(--transition), transform var(--transition);
+  font-size: var(--sidebar-link-font-size);
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  transition: background-color var(--transition), border-color var(--transition), color var(--transition),
+    transform var(--transition), box-shadow var(--transition);
 }
 
-.nav-link .icon {
-  font-size: 16px;
-  width: 20px;
+.app-sidebar__icon {
+  font-size: 18px;
+  width: 24px;
   text-align: center;
+  flex-shrink: 0;
 }
 
-.nav-link:hover,
-.nav-link:focus-visible {
-  background: var(--sidebar-hover);
+.app-sidebar__label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.app-sidebar__link:hover,
+.app-sidebar__link:focus-visible {
+  background: rgba(148, 163, 184, 0.16);
+  border-color: rgba(148, 163, 184, 0.38);
   color: #f8fafc;
+  box-shadow: 0 18px 28px -24px rgba(15, 23, 42, 0.8);
 }
 
-.nav-link.active,
-.nav-link[aria-current="page"] {
-  background: rgba(148, 163, 184, 0.18);
-  color: #fff;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.3);
+.app-sidebar__link[aria-current="page"] {
+  background: rgba(148, 163, 184, 0.22);
+  border-color: rgba(148, 163, 184, 0.48);
+  color: #ffffff;
+  box-shadow: 0 22px 32px -22px rgba(15, 23, 42, 0.85);
 }
 
-.sidebar-footer {
+.app-sidebar__footer {
   margin-top: auto;
   font-size: 12px;
   color: rgba(226, 232, 240, 0.7);
   line-height: 1.5;
 }
 
-.sidebar-footer strong {
+.app-sidebar__footer strong {
   display: block;
-  color: #fff;
-  margin-bottom: 4px;
+  color: #ffffff;
+  margin-bottom: 6px;
 }
 
 .card {
@@ -443,22 +455,26 @@ a:hover {
     grid-template-columns: 1fr;
   }
 
-  .sidebar {
+  .app-sidebar {
     position: static;
-    height: auto;
-    flex-direction: column;
-    gap: 16px;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
     width: 100%;
+    min-height: auto;
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: linear-gradient(165deg, rgba(15, 23, 42, 0.92) 0%, rgba(15, 23, 42, 0.88) 100%);
+    gap: 18px;
   }
 
-  .sidebar-nav {
+  .app-sidebar__nav {
     flex-direction: row;
     flex-wrap: wrap;
     gap: 8px;
   }
 
-  .nav-link {
+  .app-sidebar__link {
     flex: 1 1 140px;
     justify-content: flex-start;
   }
@@ -488,7 +504,7 @@ a:hover {
     padding: 18px;
   }
 
-  .nav-link {
+  .app-sidebar__link {
     flex: 1 1 120px;
   }
 

--- a/tasks.html
+++ b/tasks.html
@@ -175,26 +175,25 @@
   </style>
 </head>
 <body data-page="tasks">
-  <div class="layout">
-    <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link active" href="tasks.html" aria-current="page"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+  <div class="app-shell">
+    <aside class="app-sidebar" aria-label="Główna nawigacja">
+      <div class="app-sidebar__brand"><span class="app-sidebar__brand-emoji" aria-hidden="true">🧭</span><span>LifeOS</span></div>
+      <nav class="app-sidebar__nav">
+        <a class="app-sidebar__link" data-page="dashboard" href="index.html"><span class="app-sidebar__icon" aria-hidden="true">📊</span><span class="app-sidebar__label">Dashboard</span></a>
+        <a class="app-sidebar__link" data-page="budget" href="budget.html"><span class="app-sidebar__icon" aria-hidden="true">💰</span><span class="app-sidebar__label">Budżet</span></a>
+        <a class="app-sidebar__link" data-page="fuel" href="fuel.html"><span class="app-sidebar__icon" aria-hidden="true">⛽</span><span class="app-sidebar__label">Paliwo</span></a>
+        <a class="app-sidebar__link" data-page="trainings" href="trainings.html"><span class="app-sidebar__icon" aria-hidden="true">💪</span><span class="app-sidebar__label">Treningi</span></a>
+        <a class="app-sidebar__link" data-page="loan" href="loan.html"><span class="app-sidebar__icon" aria-hidden="true">🏦</span><span class="app-sidebar__label">Kredyt</span></a>
+        <a class="app-sidebar__link" data-page="tasks" href="tasks.html"><span class="app-sidebar__icon" aria-hidden="true">✅</span><span class="app-sidebar__label">Zadania</span></a>
+        <a class="app-sidebar__link" data-page="house" href="house.html"><span class="app-sidebar__icon" aria-hidden="true">🏠</span><span class="app-sidebar__label">Budowa</span></a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="app-sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
     </aside>
 
-    <div class="main">
+    <div class="app-main">
       <header class="topbar">
         <div>
           <h1 class="topbar-title">Zadania</h1>
@@ -389,6 +388,14 @@
 </div>
 
 <script>
+(function setActiveSidebarLink() {
+  const currentPage = document.body.dataset.page;
+  if (!currentPage) return;
+  document.querySelectorAll('.app-sidebar__link').forEach((link) => {
+    link.toggleAttribute('aria-current', link.dataset.page === currentPage);
+  });
+})();
+
 // --- KONFIGURACJA ---
 const TASKS_STORAGE_KEY = 'lifeos_tasks_pro_v2';
 const DAY_IN_MS = 24 * 60 * 60 * 1000;

--- a/trainings.html
+++ b/trainings.html
@@ -569,26 +569,25 @@
   </style>
 </head>
 <body data-page="trainings">
-  <div class="layout">
-    <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link active" href="trainings.html" aria-current="page"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+  <div class="app-shell">
+    <aside class="app-sidebar" aria-label="Główna nawigacja">
+      <div class="app-sidebar__brand"><span class="app-sidebar__brand-emoji" aria-hidden="true">🧭</span><span>LifeOS</span></div>
+      <nav class="app-sidebar__nav">
+        <a class="app-sidebar__link" data-page="dashboard" href="index.html"><span class="app-sidebar__icon" aria-hidden="true">📊</span><span class="app-sidebar__label">Dashboard</span></a>
+        <a class="app-sidebar__link" data-page="budget" href="budget.html"><span class="app-sidebar__icon" aria-hidden="true">💰</span><span class="app-sidebar__label">Budżet</span></a>
+        <a class="app-sidebar__link" data-page="fuel" href="fuel.html"><span class="app-sidebar__icon" aria-hidden="true">⛽</span><span class="app-sidebar__label">Paliwo</span></a>
+        <a class="app-sidebar__link" data-page="trainings" href="trainings.html"><span class="app-sidebar__icon" aria-hidden="true">💪</span><span class="app-sidebar__label">Treningi</span></a>
+        <a class="app-sidebar__link" data-page="loan" href="loan.html"><span class="app-sidebar__icon" aria-hidden="true">🏦</span><span class="app-sidebar__label">Kredyt</span></a>
+        <a class="app-sidebar__link" data-page="tasks" href="tasks.html"><span class="app-sidebar__icon" aria-hidden="true">✅</span><span class="app-sidebar__label">Zadania</span></a>
+        <a class="app-sidebar__link" data-page="house" href="house.html"><span class="app-sidebar__icon" aria-hidden="true">🏠</span><span class="app-sidebar__label">Budowa</span></a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="app-sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
     </aside>
 
-    <div class="main">
+    <div class="app-main">
       <header class="topbar">
         <div>
           <p class="topbar-eyebrow">Program treningowy</p>
@@ -717,6 +716,14 @@
 <div id="save-status">Zapisano zmiany</div>
 
 <script>
+(function setActiveSidebarLink() {
+  const currentPage = document.body.dataset.page;
+  if (!currentPage) return;
+  document.querySelectorAll('.app-sidebar__link').forEach((link) => {
+    link.toggleAttribute('aria-current', link.dataset.page === currentPage);
+  });
+})();
+
 const STORAGE_KEY = 'lifeos_trainings_month_v1';
 const LEGACY_STORAGE_KEY = 'lifeos_trainings_v1';
 const MIGRATION_FLAG_KEY = 'lifeos_trainings_migrated_to_month_v1';


### PR DESCRIPTION
## Summary
- replace each page’s sidebar markup with a shared `app-sidebar` navigation and drop the obsolete Settings link
- refresh the sidebar styling for fixed sizing, glass-like hover states, and accessible active states tied to `body[data-page]`
- add lightweight scripts so pages automatically mark their active navigation link via `aria-current`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d932eb82948331b909c6b33d751a35