### PR TITLE
Refine sidebar navigation styling

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -529,18 +529,31 @@
 <body data-page="budget">
   <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link active" href="budget.html" aria-current="page"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header"><span class="sidebar__emoji">🧭</span><span class="sidebar__title">LifeOS</span></div>
+      <nav class="sidebar__nav">
+        <a class="sidebar__link" data-page="dashboard" href="index.html">
+          <span class="sidebar__icon">📊</span><span class="sidebar__label">Dashboard</span>
+        </a>
+        <a class="sidebar__link" data-page="budget" href="budget.html" aria-current="page">
+          <span class="sidebar__icon">💰</span><span class="sidebar__label">Budżet</span>
+        </a>
+        <a class="sidebar__link" data-page="fuel" href="fuel.html">
+          <span class="sidebar__icon">⛽</span><span class="sidebar__label">Paliwo</span>
+        </a>
+        <a class="sidebar__link" data-page="trainings" href="trainings.html">
+          <span class="sidebar__icon">💪</span><span class="sidebar__label">Treningi</span>
+        </a>
+        <a class="sidebar__link" data-page="loan" href="loan.html">
+          <span class="sidebar__icon">🏦</span><span class="sidebar__label">Kredyt</span>
+        </a>
+        <a class="sidebar__link" data-page="tasks" href="tasks.html">
+          <span class="sidebar__icon">✅</span><span class="sidebar__label">Zadania</span>
+        </a>
+        <a class="sidebar__link" data-page="house" href="house.html">
+          <span class="sidebar__icon">🏠</span><span class="sidebar__label">Budowa</span>
+        </a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>

--- a/fuel.html
+++ b/fuel.html
@@ -89,18 +89,31 @@
 <body data-page="fuel">
   <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link active" href="fuel.html" aria-current="page"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header"><span class="sidebar__emoji">🧭</span><span class="sidebar__title">LifeOS</span></div>
+      <nav class="sidebar__nav">
+        <a class="sidebar__link" data-page="dashboard" href="index.html">
+          <span class="sidebar__icon">📊</span><span class="sidebar__label">Dashboard</span>
+        </a>
+        <a class="sidebar__link" data-page="budget" href="budget.html">
+          <span class="sidebar__icon">💰</span><span class="sidebar__label">Budżet</span>
+        </a>
+        <a class="sidebar__link" data-page="fuel" href="fuel.html" aria-current="page">
+          <span class="sidebar__icon">⛽</span><span class="sidebar__label">Paliwo</span>
+        </a>
+        <a class="sidebar__link" data-page="trainings" href="trainings.html">
+          <span class="sidebar__icon">💪</span><span class="sidebar__label">Treningi</span>
+        </a>
+        <a class="sidebar__link" data-page="loan" href="loan.html">
+          <span class="sidebar__icon">🏦</span><span class="sidebar__label">Kredyt</span>
+        </a>
+        <a class="sidebar__link" data-page="tasks" href="tasks.html">
+          <span class="sidebar__icon">✅</span><span class="sidebar__label">Zadania</span>
+        </a>
+        <a class="sidebar__link" data-page="house" href="house.html">
+          <span class="sidebar__icon">🏠</span><span class="sidebar__label">Budowa</span>
+        </a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>

--- a/house.html
+++ b/house.html
@@ -135,87 +135,24 @@
 
     /* Sidebar */
     .sidebar {
-      width: 280px;
-      background: var(--sidebar-bg);
-      display: flex;
-      flex-direction: column;
-      transition: var(--transition);
       border-right: 1px solid var(--border);
-      z-index: 100;
-      flex-shrink: 0;
-    }
-    
-    .sidebar-header {
-      padding: 24px;
-      border-bottom: 1px solid rgba(255,255,255,0.1);
-    }
-    
-    .logo {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-    }
-    
-    .logo-icon {
-      width: 48px;
-      height: 48px;
-      background: linear-gradient(135deg, var(--primary), var(--info));
-      border-radius: var(--radius);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 24px;
-      box-shadow: var(--shadow-lg);
-    }
-    
-    .logo-text h1 {
-      font-size: 20px;
-      font-weight: 900;
-      color: #ffffff;
-      letter-spacing: -0.5px;
-    }
-    
-    .logo-text p {
-      font-size: 12px;
-      color: var(--text-tertiary);
-      margin-top: 2px;
+      transition: transform var(--transition);
     }
 
-    .nav-menu {
+    .sidebar__header {
+      padding: 24px 22px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .sidebar__nav {
       flex: 1;
       overflow-y: auto;
-      padding: 16px;
-      list-style: none;
+      padding: 12px 0;
     }
-    
-    .nav-item {
-      margin-bottom: 4px;
-    }
-    
-    .nav-item a {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 12px 16px;
-      border-radius: var(--radius-sm);
-      text-decoration: none;
-      font-weight: 500;
-      font-size: 14px;
-      color: var(--text-tertiary);
-      transition: var(--transition);
-      position: relative;
-      overflow: hidden;
-    }
-    
-    .nav-item a:hover {
-      background: rgba(255,255,255,0.05);
-      color: #ffffff;
-    }
-    
-    .nav-item a.active {
-      background: var(--primary);
-      color: #ffffff;
-      box-shadow: var(--shadow-md);
+
+    .sidebar__footer {
+      padding: 0 22px 24px;
+      border-top: 1px solid rgba(255, 255, 255, 0.1);
     }
     
     .nav-icon {
@@ -274,11 +211,6 @@
       display: flex;
       flex-direction: column;
       gap: 24px;
-    }
-
-    .sidebar-footer {
-      padding: 16px;
-      border-top: 1px solid rgba(255,255,255,0.1);
     }
 
     /* Main Content */
@@ -1881,15 +1813,17 @@
     @media (max-width: 768px) {
       .sidebar {
         position: fixed;
-        left: -280px;
+        left: 0;
         top: 0;
         bottom: 0;
+        width: 260px;
         z-index: 999;
         box-shadow: var(--shadow-xl);
+        transform: translateX(-100%);
       }
-      
+
       .sidebar.active {
-        left: 0;
+        transform: translateX(0);
       }
 
       #app-overlay.active {
@@ -1943,18 +1877,31 @@
 <body data-page="house">
   <div class="app-shell">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link active" href="house.html" aria-current="page"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header"><span class="sidebar__emoji">🧭</span><span class="sidebar__title">LifeOS</span></div>
+      <nav class="sidebar__nav">
+        <a class="sidebar__link" data-page="dashboard" href="index.html">
+          <span class="sidebar__icon">📊</span><span class="sidebar__label">Dashboard</span>
+        </a>
+        <a class="sidebar__link" data-page="budget" href="budget.html">
+          <span class="sidebar__icon">💰</span><span class="sidebar__label">Budżet</span>
+        </a>
+        <a class="sidebar__link" data-page="fuel" href="fuel.html">
+          <span class="sidebar__icon">⛽</span><span class="sidebar__label">Paliwo</span>
+        </a>
+        <a class="sidebar__link" data-page="trainings" href="trainings.html">
+          <span class="sidebar__icon">💪</span><span class="sidebar__label">Treningi</span>
+        </a>
+        <a class="sidebar__link" data-page="loan" href="loan.html">
+          <span class="sidebar__icon">🏦</span><span class="sidebar__label">Kredyt</span>
+        </a>
+        <a class="sidebar__link" data-page="tasks" href="tasks.html">
+          <span class="sidebar__icon">✅</span><span class="sidebar__label">Zadania</span>
+        </a>
+        <a class="sidebar__link" data-page="house" href="house.html" aria-current="page">
+          <span class="sidebar__icon">🏠</span><span class="sidebar__label">Budowa</span>
+        </a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>

--- a/index.html
+++ b/index.html
@@ -184,18 +184,31 @@
 <body data-page="dashboard">
   <div class="app-shell">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link active" href="index.html" aria-current="page"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header"><span class="sidebar__emoji">🧭</span><span class="sidebar__title">LifeOS</span></div>
+      <nav class="sidebar__nav">
+        <a class="sidebar__link" data-page="dashboard" href="index.html" aria-current="page">
+          <span class="sidebar__icon">📊</span><span class="sidebar__label">Dashboard</span>
+        </a>
+        <a class="sidebar__link" data-page="budget" href="budget.html">
+          <span class="sidebar__icon">💰</span><span class="sidebar__label">Budżet</span>
+        </a>
+        <a class="sidebar__link" data-page="fuel" href="fuel.html">
+          <span class="sidebar__icon">⛽</span><span class="sidebar__label">Paliwo</span>
+        </a>
+        <a class="sidebar__link" data-page="trainings" href="trainings.html">
+          <span class="sidebar__icon">💪</span><span class="sidebar__label">Treningi</span>
+        </a>
+        <a class="sidebar__link" data-page="loan" href="loan.html">
+          <span class="sidebar__icon">🏦</span><span class="sidebar__label">Kredyt</span>
+        </a>
+        <a class="sidebar__link" data-page="tasks" href="tasks.html">
+          <span class="sidebar__icon">✅</span><span class="sidebar__label">Zadania</span>
+        </a>
+        <a class="sidebar__link" data-page="house" href="house.html">
+          <span class="sidebar__icon">🏠</span><span class="sidebar__label">Budowa</span>
+        </a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twoje centrum dowodzenia życiem.</strong>
       </div>
     </aside>

--- a/loan.html
+++ b/loan.html
@@ -494,18 +494,31 @@
 
   <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link active" href="loan.html" aria-current="page"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header"><span class="sidebar__emoji">🧭</span><span class="sidebar__title">LifeOS</span></div>
+      <nav class="sidebar__nav">
+        <a class="sidebar__link" data-page="dashboard" href="index.html">
+          <span class="sidebar__icon">📊</span><span class="sidebar__label">Dashboard</span>
+        </a>
+        <a class="sidebar__link" data-page="budget" href="budget.html">
+          <span class="sidebar__icon">💰</span><span class="sidebar__label">Budżet</span>
+        </a>
+        <a class="sidebar__link" data-page="fuel" href="fuel.html">
+          <span class="sidebar__icon">⛽</span><span class="sidebar__label">Paliwo</span>
+        </a>
+        <a class="sidebar__link" data-page="trainings" href="trainings.html">
+          <span class="sidebar__icon">💪</span><span class="sidebar__label">Treningi</span>
+        </a>
+        <a class="sidebar__link" data-page="loan" href="loan.html" aria-current="page">
+          <span class="sidebar__icon">🏦</span><span class="sidebar__label">Kredyt</span>
+        </a>
+        <a class="sidebar__link" data-page="tasks" href="tasks.html">
+          <span class="sidebar__icon">✅</span><span class="sidebar__label">Zadania</span>
+        </a>
+        <a class="sidebar__link" data-page="house" href="house.html">
+          <span class="sidebar__icon">🏠</span><span class="sidebar__label">Budowa</span>
+        </a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>

--- a/styles.css
+++ b/styles.css
@@ -242,74 +242,116 @@ a:hover {
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 24px 20px;
-  width: 240px;
-  background: var(--sidebar-bg);
-  color: #fff;
+  gap: 28px;
+  padding: 28px 22px;
+  width: 260px;
+  flex: 0 0 260px;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92) 0%, rgba(15, 23, 42, 0.86) 100%);
+  color: #f8fafc;
   position: sticky;
   top: 0;
   height: 100vh;
+  border-right: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 20px 0 45px -35px rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(18px);
 }
 
-.sidebar-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-weight: 700;
-  font-size: 16px;
-  letter-spacing: 0.04em;
-}
-
-.sidebar-header .emoji {
-  font-size: 20px;
-}
-
-.sidebar-nav {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.nav-link {
+.sidebar__header {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 10px 12px;
-  border-radius: 12px;
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  color: #e2e8f0;
+}
+
+.sidebar__title {
+  margin: 0;
+}
+
+.sidebar__emoji {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 44px;
+  padding: 0 16px;
+  border-radius: 14px;
   color: inherit;
   font-weight: 600;
-  font-size: 13px;
-  transition: background-color var(--transition), color var(--transition), transform var(--transition);
+  font-size: 14px;
+  line-height: 44px;
+  text-decoration: none;
+  transition: transform var(--transition), box-shadow var(--transition), background-color var(--transition), color var(--transition);
+  position: relative;
+  overflow: hidden;
 }
 
-.nav-link .icon {
+.sidebar__icon {
   font-size: 16px;
-  width: 20px;
+  width: 24px;
   text-align: center;
+  flex-shrink: 0;
 }
 
-.nav-link:hover,
-.nav-link:focus-visible {
-  background: var(--sidebar-hover);
+.sidebar__label {
+  position: relative;
+  z-index: 1;
+}
+
+.sidebar__link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(148, 163, 184, 0.14);
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.sidebar__link:hover::after,
+.sidebar__link:focus-visible::after {
+  opacity: 1;
+}
+
+.sidebar__link:hover,
+.sidebar__link:focus-visible {
   color: #f8fafc;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.28);
+  transform: translateX(2px);
 }
 
-.nav-link.active,
-.nav-link[aria-current="page"] {
-  background: rgba(148, 163, 184, 0.18);
+.sidebar__link[aria-current="page"],
+body[data-page="dashboard"] .sidebar__link[data-page="dashboard"],
+body[data-page="budget"] .sidebar__link[data-page="budget"],
+body[data-page="fuel"] .sidebar__link[data-page="fuel"],
+body[data-page="trainings"] .sidebar__link[data-page="trainings"],
+body[data-page="loan"] .sidebar__link[data-page="loan"],
+body[data-page="tasks"] .sidebar__link[data-page="tasks"],
+body[data-page="house"] .sidebar__link[data-page="house"] {
   color: #fff;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.3);
+  background: rgba(148, 163, 184, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35), 0 6px 18px -12px rgba(148, 163, 184, 0.8);
 }
 
-.sidebar-footer {
+.sidebar__footer {
   margin-top: auto;
   font-size: 12px;
   color: rgba(226, 232, 240, 0.7);
   line-height: 1.5;
 }
 
-.sidebar-footer strong {
+.sidebar__footer strong {
   display: block;
   color: #fff;
   margin-bottom: 4px;
@@ -452,13 +494,13 @@ a:hover {
     width: 100%;
   }
 
-  .sidebar-nav {
+  .sidebar__nav {
     flex-direction: row;
     flex-wrap: wrap;
     gap: 8px;
   }
 
-  .nav-link {
+  .sidebar__link {
     flex: 1 1 140px;
     justify-content: flex-start;
   }
@@ -488,7 +530,7 @@ a:hover {
     padding: 18px;
   }
 
-  .nav-link {
+  .sidebar__link {
     flex: 1 1 120px;
   }
 

--- a/tasks.html
+++ b/tasks.html
@@ -177,18 +177,31 @@
 <body data-page="tasks">
   <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link active" href="tasks.html" aria-current="page"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header"><span class="sidebar__emoji">🧭</span><span class="sidebar__title">LifeOS</span></div>
+      <nav class="sidebar__nav">
+        <a class="sidebar__link" data-page="dashboard" href="index.html">
+          <span class="sidebar__icon">📊</span><span class="sidebar__label">Dashboard</span>
+        </a>
+        <a class="sidebar__link" data-page="budget" href="budget.html">
+          <span class="sidebar__icon">💰</span><span class="sidebar__label">Budżet</span>
+        </a>
+        <a class="sidebar__link" data-page="fuel" href="fuel.html">
+          <span class="sidebar__icon">⛽</span><span class="sidebar__label">Paliwo</span>
+        </a>
+        <a class="sidebar__link" data-page="trainings" href="trainings.html">
+          <span class="sidebar__icon">💪</span><span class="sidebar__label">Treningi</span>
+        </a>
+        <a class="sidebar__link" data-page="loan" href="loan.html">
+          <span class="sidebar__icon">🏦</span><span class="sidebar__label">Kredyt</span>
+        </a>
+        <a class="sidebar__link" data-page="tasks" href="tasks.html" aria-current="page">
+          <span class="sidebar__icon">✅</span><span class="sidebar__label">Zadania</span>
+        </a>
+        <a class="sidebar__link" data-page="house" href="house.html">
+          <span class="sidebar__icon">🏠</span><span class="sidebar__label">Budowa</span>
+        </a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>

--- a/trainings.html
+++ b/trainings.html
@@ -571,18 +571,31 @@
 <body data-page="trainings">
   <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link active" href="trainings.html" aria-current="page"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header"><span class="sidebar__emoji">🧭</span><span class="sidebar__title">LifeOS</span></div>
+      <nav class="sidebar__nav">
+        <a class="sidebar__link" data-page="dashboard" href="index.html">
+          <span class="sidebar__icon">📊</span><span class="sidebar__label">Dashboard</span>
+        </a>
+        <a class="sidebar__link" data-page="budget" href="budget.html">
+          <span class="sidebar__icon">💰</span><span class="sidebar__label">Budżet</span>
+        </a>
+        <a class="sidebar__link" data-page="fuel" href="fuel.html">
+          <span class="sidebar__icon">⛽</span><span class="sidebar__label">Paliwo</span>
+        </a>
+        <a class="sidebar__link" data-page="trainings" href="trainings.html" aria-current="page">
+          <span class="sidebar__icon">💪</span><span class="sidebar__label">Treningi</span>
+        </a>
+        <a class="sidebar__link" data-page="loan" href="loan.html">
+          <span class="sidebar__icon">🏦</span><span class="sidebar__label">Kredyt</span>
+        </a>
+        <a class="sidebar__link" data-page="tasks" href="tasks.html">
+          <span class="sidebar__icon">✅</span><span class="sidebar__label">Zadania</span>
+        </a>
+        <a class="sidebar__link" data-page="house" href="house.html">
+          <span class="sidebar__icon">🏠</span><span class="sidebar__label">Budowa</span>
+        </a>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>


### PR DESCRIPTION
## Summary
- standardize the sidebar navigation markup across dashboard and module pages, removing the obsolete settings link and wiring active states through aria attributes
- refresh sidebar styling in `styles.css` with fixed dimensions, typography, and glassy hover/active effects, plus responsive tweaks for narrow screens
- align the house module overrides with the shared BEM-style sidebar structure and mobile slide-in behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d932eb82948331b909c6b33d751a35