### PR TITLE
Revamp sidebar navigation styling

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -529,18 +529,57 @@
 <body data-page="budget">
   <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link active" href="budget.html" aria-current="page"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header">
+        <span class="sidebar__emoji">🧭</span>
+        <span class="sidebar__brand">LifeOS</span>
+      </div>
+      <nav class="sidebar__nav" aria-label="Sekcje LifeOS">
+        <ul class="sidebar__list">
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="index.html" data-page="dashboard">
+              <span class="sidebar__icon">📊</span>
+              <span class="sidebar__label">Dashboard</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="budget.html" data-page="budget">
+              <span class="sidebar__icon">💰</span>
+              <span class="sidebar__label">Budżet</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="fuel.html" data-page="fuel">
+              <span class="sidebar__icon">⛽</span>
+              <span class="sidebar__label">Paliwo</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="trainings.html" data-page="trainings">
+              <span class="sidebar__icon">💪</span>
+              <span class="sidebar__label">Treningi</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="loan.html" data-page="loan">
+              <span class="sidebar__icon">🏦</span>
+              <span class="sidebar__label">Kredyt</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="tasks.html" data-page="tasks">
+              <span class="sidebar__icon">✅</span>
+              <span class="sidebar__label">Zadania</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="house.html" data-page="house">
+              <span class="sidebar__icon">🏠</span>
+              <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+        </ul>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
@@ -1351,6 +1390,21 @@
     </div>
   </div>
 
+  <script>
+    (function activateSidebarLink() {
+      const currentPage = document.body.dataset.page;
+      if (!currentPage) return;
+      document.querySelectorAll('.sidebar__link[data-page]').forEach((link) => {
+        if (link.dataset.page === currentPage) {
+          link.classList.add('sidebar__link--active');
+          link.setAttribute('aria-current', 'page');
+        } else {
+          link.classList.remove('sidebar__link--active');
+          link.removeAttribute('aria-current');
+        }
+      });
+    })();
+  </script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
   // --- Storage & helpers ------------------------------------------------------

--- a/fuel.html
+++ b/fuel.html
@@ -89,18 +89,57 @@
 <body data-page="fuel">
   <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link active" href="fuel.html" aria-current="page"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header">
+        <span class="sidebar__emoji">🧭</span>
+        <span class="sidebar__brand">LifeOS</span>
+      </div>
+      <nav class="sidebar__nav" aria-label="Sekcje LifeOS">
+        <ul class="sidebar__list">
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="index.html" data-page="dashboard">
+              <span class="sidebar__icon">📊</span>
+              <span class="sidebar__label">Dashboard</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="budget.html" data-page="budget">
+              <span class="sidebar__icon">💰</span>
+              <span class="sidebar__label">Budżet</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="fuel.html" data-page="fuel">
+              <span class="sidebar__icon">⛽</span>
+              <span class="sidebar__label">Paliwo</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="trainings.html" data-page="trainings">
+              <span class="sidebar__icon">💪</span>
+              <span class="sidebar__label">Treningi</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="loan.html" data-page="loan">
+              <span class="sidebar__icon">🏦</span>
+              <span class="sidebar__label">Kredyt</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="tasks.html" data-page="tasks">
+              <span class="sidebar__icon">✅</span>
+              <span class="sidebar__label">Zadania</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="house.html" data-page="house">
+              <span class="sidebar__icon">🏠</span>
+              <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+        </ul>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
@@ -277,6 +316,21 @@
     </div>
   </div>
 
+<script>
+  (function activateSidebarLink() {
+    const currentPage = document.body.dataset.page;
+    if (!currentPage) return;
+    document.querySelectorAll('.sidebar__link[data-page]').forEach((link) => {
+      if (link.dataset.page === currentPage) {
+        link.classList.add('sidebar__link--active');
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.classList.remove('sidebar__link--active');
+        link.removeAttribute('aria-current');
+      }
+    });
+  })();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 const FUEL_STORAGE_KEY = 'lifeos_fuel_v1';

--- a/house.html
+++ b/house.html
@@ -133,91 +133,6 @@
       font-size: 18px;
     }
 
-    /* Sidebar */
-    .sidebar {
-      width: 280px;
-      background: var(--sidebar-bg);
-      display: flex;
-      flex-direction: column;
-      transition: var(--transition);
-      border-right: 1px solid var(--border);
-      z-index: 100;
-      flex-shrink: 0;
-    }
-    
-    .sidebar-header {
-      padding: 24px;
-      border-bottom: 1px solid rgba(255,255,255,0.1);
-    }
-    
-    .logo {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-    }
-    
-    .logo-icon {
-      width: 48px;
-      height: 48px;
-      background: linear-gradient(135deg, var(--primary), var(--info));
-      border-radius: var(--radius);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 24px;
-      box-shadow: var(--shadow-lg);
-    }
-    
-    .logo-text h1 {
-      font-size: 20px;
-      font-weight: 900;
-      color: #ffffff;
-      letter-spacing: -0.5px;
-    }
-    
-    .logo-text p {
-      font-size: 12px;
-      color: var(--text-tertiary);
-      margin-top: 2px;
-    }
-
-    .nav-menu {
-      flex: 1;
-      overflow-y: auto;
-      padding: 16px;
-      list-style: none;
-    }
-    
-    .nav-item {
-      margin-bottom: 4px;
-    }
-    
-    .nav-item a {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 12px 16px;
-      border-radius: var(--radius-sm);
-      text-decoration: none;
-      font-weight: 500;
-      font-size: 14px;
-      color: var(--text-tertiary);
-      transition: var(--transition);
-      position: relative;
-      overflow: hidden;
-    }
-    
-    .nav-item a:hover {
-      background: rgba(255,255,255,0.05);
-      color: #ffffff;
-    }
-    
-    .nav-item a.active {
-      background: var(--primary);
-      color: #ffffff;
-      box-shadow: var(--shadow-md);
-    }
-    
     .nav-icon {
       font-size: 16px;
       line-height: 1;
@@ -1943,18 +1858,57 @@
 <body data-page="house">
   <div class="app-shell">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link active" href="house.html" aria-current="page"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header">
+        <span class="sidebar__emoji">🧭</span>
+        <span class="sidebar__brand">LifeOS</span>
+      </div>
+      <nav class="sidebar__nav" aria-label="Sekcje LifeOS">
+        <ul class="sidebar__list">
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="index.html" data-page="dashboard">
+              <span class="sidebar__icon">📊</span>
+              <span class="sidebar__label">Dashboard</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="budget.html" data-page="budget">
+              <span class="sidebar__icon">💰</span>
+              <span class="sidebar__label">Budżet</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="fuel.html" data-page="fuel">
+              <span class="sidebar__icon">⛽</span>
+              <span class="sidebar__label">Paliwo</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="trainings.html" data-page="trainings">
+              <span class="sidebar__icon">💪</span>
+              <span class="sidebar__label">Treningi</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="loan.html" data-page="loan">
+              <span class="sidebar__icon">🏦</span>
+              <span class="sidebar__label">Kredyt</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="tasks.html" data-page="tasks">
+              <span class="sidebar__icon">✅</span>
+              <span class="sidebar__label">Zadania</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="house.html" data-page="house">
+              <span class="sidebar__icon">🏠</span>
+              <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+        </ul>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
@@ -2358,6 +2312,21 @@
   <div id="app-tooltip" class="hidden"></div>
 
 
+  <script>
+    (function activateSidebarLink() {
+      const currentPage = document.body.dataset.page;
+      if (!currentPage) return;
+      document.querySelectorAll('.sidebar__link[data-page]').forEach((link) => {
+        if (link.dataset.page === currentPage) {
+          link.classList.add('sidebar__link--active');
+          link.setAttribute('aria-current', 'page');
+        } else {
+          link.classList.remove('sidebar__link--active');
+          link.removeAttribute('aria-current');
+        }
+      });
+    })();
+  </script>
   <script>
     // App State
     const APP_KEY = 'buildmaster_pro_v11';

--- a/index.html
+++ b/index.html
@@ -184,18 +184,57 @@
 <body data-page="dashboard">
   <div class="app-shell">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link active" href="index.html" aria-current="page"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header">
+        <span class="sidebar__emoji">🧭</span>
+        <span class="sidebar__brand">LifeOS</span>
+      </div>
+      <nav class="sidebar__nav" aria-label="Sekcje LifeOS">
+        <ul class="sidebar__list">
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="index.html" data-page="dashboard">
+              <span class="sidebar__icon">📊</span>
+              <span class="sidebar__label">Dashboard</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="budget.html" data-page="budget">
+              <span class="sidebar__icon">💰</span>
+              <span class="sidebar__label">Budżet</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="fuel.html" data-page="fuel">
+              <span class="sidebar__icon">⛽</span>
+              <span class="sidebar__label">Paliwo</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="trainings.html" data-page="trainings">
+              <span class="sidebar__icon">💪</span>
+              <span class="sidebar__label">Treningi</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="loan.html" data-page="loan">
+              <span class="sidebar__icon">🏦</span>
+              <span class="sidebar__label">Kredyt</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="tasks.html" data-page="tasks">
+              <span class="sidebar__icon">✅</span>
+              <span class="sidebar__label">Zadania</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="house.html" data-page="house">
+              <span class="sidebar__icon">🏠</span>
+              <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+        </ul>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twoje centrum dowodzenia życiem.</strong>
       </div>
     </aside>
@@ -272,6 +311,22 @@
   </div>
 
   <div id="notification" class="notification"></div>
+
+  <script>
+    (function activateSidebarLink() {
+      const currentPage = document.body.dataset.page;
+      if (!currentPage) return;
+      document.querySelectorAll('.sidebar__link[data-page]').forEach((link) => {
+        if (link.dataset.page === currentPage) {
+          link.classList.add('sidebar__link--active');
+          link.setAttribute('aria-current', 'page');
+        } else {
+          link.classList.remove('sidebar__link--active');
+          link.removeAttribute('aria-current');
+        }
+      });
+    })();
+  </script>
 
 <script>
 /* === STORAGE KEYS === */

--- a/loan.html
+++ b/loan.html
@@ -494,18 +494,57 @@
 
   <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link active" href="loan.html" aria-current="page"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header">
+        <span class="sidebar__emoji">🧭</span>
+        <span class="sidebar__brand">LifeOS</span>
+      </div>
+      <nav class="sidebar__nav" aria-label="Sekcje LifeOS">
+        <ul class="sidebar__list">
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="index.html" data-page="dashboard">
+              <span class="sidebar__icon">📊</span>
+              <span class="sidebar__label">Dashboard</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="budget.html" data-page="budget">
+              <span class="sidebar__icon">💰</span>
+              <span class="sidebar__label">Budżet</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="fuel.html" data-page="fuel">
+              <span class="sidebar__icon">⛽</span>
+              <span class="sidebar__label">Paliwo</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="trainings.html" data-page="trainings">
+              <span class="sidebar__icon">💪</span>
+              <span class="sidebar__label">Treningi</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="loan.html" data-page="loan">
+              <span class="sidebar__icon">🏦</span>
+              <span class="sidebar__label">Kredyt</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="tasks.html" data-page="tasks">
+              <span class="sidebar__icon">✅</span>
+              <span class="sidebar__label">Zadania</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="house.html" data-page="house">
+              <span class="sidebar__icon">🏠</span>
+              <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+        </ul>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
@@ -733,6 +772,21 @@
     </div>
   </div>
 
+<script>
+  (function activateSidebarLink() {
+    const currentPage = document.body.dataset.page;
+    if (!currentPage) return;
+    document.querySelectorAll('.sidebar__link[data-page]').forEach((link) => {
+      if (link.dataset.page === currentPage) {
+        link.classList.add('sidebar__link--active');
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.classList.remove('sidebar__link--active');
+        link.removeAttribute('aria-current');
+      }
+    });
+  })();
+</script>
 <script>
 const STORAGE_KEY = 'lifeos_loan_v1';
 

--- a/styles.css
+++ b/styles.css
@@ -115,7 +115,7 @@ a:hover {
 
 .app-shell {
   display: grid;
-  grid-template-columns: 240px 1fr;
+  grid-template-columns: 260px 1fr;
   min-height: 100vh;
   background: var(--bg);
 }
@@ -242,77 +242,113 @@ a:hover {
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 24px 20px;
-  width: 240px;
-  background: var(--sidebar-bg);
-  color: #fff;
+  gap: 28px;
+  padding: 28px 22px;
+  width: 260px;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.88) 0%, rgba(30, 41, 59, 0.8) 100%);
+  color: var(--sidebar-text);
   position: sticky;
   top: 0;
   height: 100vh;
+  border-right: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 20px 44px -32px rgb(15 23 42 / 0.65);
+  backdrop-filter: blur(18px);
 }
 
-.sidebar-header {
+.sidebar__header {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   font-weight: 700;
   font-size: 16px;
   letter-spacing: 0.04em;
+  color: #f8fafc;
 }
 
-.sidebar-header .emoji {
+.sidebar__emoji {
   font-size: 20px;
+  filter: drop-shadow(0 2px 6px rgba(15, 23, 42, 0.35));
 }
 
-.sidebar-nav {
+.sidebar__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.sidebar__nav {
+  display: block;
+}
+
+.sidebar__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.nav-link {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
-  border-radius: 12px;
-  color: inherit;
-  font-weight: 600;
-  font-size: 13px;
-  transition: background-color var(--transition), color var(--transition), transform var(--transition);
+.sidebar__item {
+  margin: 0;
 }
 
-.nav-link .icon {
+  .sidebar__link {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 16px;
+    min-height: 44px;
+    height: 44px;
+    font-weight: 600;
+  font-size: 14px;
+  color: rgba(248, 250, 252, 0.86);
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: transparent;
+  transition: transform var(--transition), background-color var(--transition), border-color var(--transition), color var(--transition), box-shadow var(--transition);
+  position: relative;
+}
+
+.sidebar__icon {
   font-size: 16px;
-  width: 20px;
+  width: 24px;
   text-align: center;
+  flex-shrink: 0;
 }
 
-.nav-link:hover,
-.nav-link:focus-visible {
-  background: var(--sidebar-hover);
+.sidebar__label {
+  line-height: 1.2;
+}
+
+.sidebar__link:hover,
+.sidebar__link:focus-visible {
+  background: rgba(248, 250, 252, 0.12);
   color: #f8fafc;
+  border-color: rgba(248, 250, 252, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(248, 250, 252, 0.12), 0 12px 30px -26px rgba(15, 23, 42, 0.6);
+  transform: translateX(2px);
 }
 
-.nav-link.active,
-.nav-link[aria-current="page"] {
-  background: rgba(148, 163, 184, 0.18);
-  color: #fff;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.3);
+.sidebar__link--active,
+.sidebar__link[aria-current="page"] {
+  background: rgba(148, 163, 184, 0.2);
+  color: #ffffff;
+  border-color: rgba(226, 232, 240, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(248, 250, 252, 0.2), 0 14px 34px -24px rgba(15, 23, 42, 0.65);
 }
 
-.sidebar-footer {
+.sidebar__footer {
   margin-top: auto;
   font-size: 12px;
-  color: rgba(226, 232, 240, 0.7);
+  color: rgba(226, 232, 240, 0.72);
   line-height: 1.5;
 }
 
-.sidebar-footer strong {
+.sidebar__footer strong {
   display: block;
   color: #fff;
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 }
 
 .card {
@@ -448,19 +484,24 @@ a:hover {
     height: auto;
     flex-direction: column;
     gap: 16px;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.18);
     width: 100%;
+    border-right: none;
   }
 
-  .sidebar-nav {
+  .sidebar__list {
     flex-direction: row;
     flex-wrap: wrap;
     gap: 8px;
   }
 
-  .nav-link {
+  .sidebar__item {
     flex: 1 1 140px;
+  }
+
+  .sidebar__link {
     justify-content: flex-start;
+    width: 100%;
   }
 
   .topbar {
@@ -488,7 +529,7 @@ a:hover {
     padding: 18px;
   }
 
-  .nav-link {
+  .sidebar__item {
     flex: 1 1 120px;
   }
 

--- a/tasks.html
+++ b/tasks.html
@@ -177,18 +177,57 @@
 <body data-page="tasks">
   <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link" href="trainings.html"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link active" href="tasks.html" aria-current="page"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header">
+        <span class="sidebar__emoji">🧭</span>
+        <span class="sidebar__brand">LifeOS</span>
+      </div>
+      <nav class="sidebar__nav" aria-label="Sekcje LifeOS">
+        <ul class="sidebar__list">
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="index.html" data-page="dashboard">
+              <span class="sidebar__icon">📊</span>
+              <span class="sidebar__label">Dashboard</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="budget.html" data-page="budget">
+              <span class="sidebar__icon">💰</span>
+              <span class="sidebar__label">Budżet</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="fuel.html" data-page="fuel">
+              <span class="sidebar__icon">⛽</span>
+              <span class="sidebar__label">Paliwo</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="trainings.html" data-page="trainings">
+              <span class="sidebar__icon">💪</span>
+              <span class="sidebar__label">Treningi</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="loan.html" data-page="loan">
+              <span class="sidebar__icon">🏦</span>
+              <span class="sidebar__label">Kredyt</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="tasks.html" data-page="tasks">
+              <span class="sidebar__icon">✅</span>
+              <span class="sidebar__label">Zadania</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="house.html" data-page="house">
+              <span class="sidebar__icon">🏠</span>
+              <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+        </ul>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
@@ -388,6 +427,21 @@
   <div class="modal-card"><p id="modal-text"></p><div id="modal-actions" class="modal-actions"></div></div>
 </div>
 
+<script>
+  (function activateSidebarLink() {
+    const currentPage = document.body.dataset.page;
+    if (!currentPage) return;
+    document.querySelectorAll('.sidebar__link[data-page]').forEach((link) => {
+      if (link.dataset.page === currentPage) {
+        link.classList.add('sidebar__link--active');
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.classList.remove('sidebar__link--active');
+        link.removeAttribute('aria-current');
+      }
+    });
+  })();
+</script>
 <script>
 // --- KONFIGURACJA ---
 const TASKS_STORAGE_KEY = 'lifeos_tasks_pro_v2';

--- a/trainings.html
+++ b/trainings.html
@@ -571,18 +571,57 @@
 <body data-page="trainings">
   <div class="layout">
     <aside class="sidebar" aria-label="Główna nawigacja">
-      <div class="sidebar-header"><span class="emoji">🧭</span><span>LifeOS</span></div>
-      <nav class="sidebar-nav">
-        <a class="nav-link" href="index.html"><span class="icon">📊</span><span>Dashboard</span></a>
-        <a class="nav-link" href="budget.html"><span class="icon">💰</span><span>Budżet</span></a>
-        <a class="nav-link" href="fuel.html"><span class="icon">⛽</span><span>Paliwo</span></a>
-        <a class="nav-link active" href="trainings.html" aria-current="page"><span class="icon">💪</span><span>Treningi</span></a>
-        <a class="nav-link" href="loan.html"><span class="icon">🏦</span><span>Kredyt</span></a>
-        <a class="nav-link" href="tasks.html"><span class="icon">✅</span><span>Zadania</span></a>
-        <a class="nav-link" href="house.html"><span class="icon">🏠</span><span>Budowa</span></a>
-        <a class="nav-link" href="index.html#settings"><span class="icon">⚙️</span><span>Ustawienia</span></a>
+      <div class="sidebar__header">
+        <span class="sidebar__emoji">🧭</span>
+        <span class="sidebar__brand">LifeOS</span>
+      </div>
+      <nav class="sidebar__nav" aria-label="Sekcje LifeOS">
+        <ul class="sidebar__list">
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="index.html" data-page="dashboard">
+              <span class="sidebar__icon">📊</span>
+              <span class="sidebar__label">Dashboard</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="budget.html" data-page="budget">
+              <span class="sidebar__icon">💰</span>
+              <span class="sidebar__label">Budżet</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="fuel.html" data-page="fuel">
+              <span class="sidebar__icon">⛽</span>
+              <span class="sidebar__label">Paliwo</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="trainings.html" data-page="trainings">
+              <span class="sidebar__icon">💪</span>
+              <span class="sidebar__label">Treningi</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="loan.html" data-page="loan">
+              <span class="sidebar__icon">🏦</span>
+              <span class="sidebar__label">Kredyt</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="tasks.html" data-page="tasks">
+              <span class="sidebar__icon">✅</span>
+              <span class="sidebar__label">Zadania</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="house.html" data-page="house">
+              <span class="sidebar__icon">🏠</span>
+              <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+        </ul>
       </nav>
-      <div class="sidebar-footer">
+      <div class="sidebar__footer">
         <strong>Twój cyfrowy dom</strong>
         Zarządzaj budżetem, zadaniami i celami w jednym miejscu.
       </div>
@@ -716,6 +755,21 @@
 </div>
 <div id="save-status">Zapisano zmiany</div>
 
+<script>
+  (function activateSidebarLink() {
+    const currentPage = document.body.dataset.page;
+    if (!currentPage) return;
+    document.querySelectorAll('.sidebar__link[data-page]').forEach((link) => {
+      if (link.dataset.page === currentPage) {
+        link.classList.add('sidebar__link--active');
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.classList.remove('sidebar__link--active');
+        link.removeAttribute('aria-current');
+      }
+    });
+  })();
+</script>
 <script>
 const STORAGE_KEY = 'lifeos_trainings_month_v1';
 const LEGACY_STORAGE_KEY = 'lifeos_trainings_v1';


### PR DESCRIPTION
## Summary
- unify the sidebar markup across all LifeOS pages, removing the obsolete settings link
- refresh the sidebar styling with a fixed width, consistent link sizing, and a glassy hover treatment
- add a small helper script to flag the active section based on each page's data-page attribute

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d932eb82948331b909c6b33d751a35