### PR TITLE
Fuel analytics: default to 2 years and add month/quarter/year aggregation

### DIFF
--- a/fuel.html
+++ b/fuel.html
@@ -322,13 +322,20 @@
             <!-- Główny wykres: kolumny 1-2, wiersz 1 -->
             <div class="fc fd-main">
               <div class="fch">
-                <span class="fct" style="margin:0;">Miesięczne koszty i tankowania</span>
-                <select id="analytics-period-filter">
-                  <option value="12" selected>12 miesięcy</option>
-                  <option value="24">2 lata</option>
-                  <option value="36">3 lata</option>
-                  <option value="all">Wszystko</option>
-                </select>
+                <span class="fct" style="margin:0;">Koszty i tankowania</span>
+                <div style="display:flex; gap:8px; align-items:center;">
+                  <select id="analytics-grouping-filter">
+                    <option value="month" selected>Miesięcznie</option>
+                    <option value="quarter">Kwartalnie</option>
+                    <option value="year">Rocznie</option>
+                  </select>
+                  <select id="analytics-period-filter">
+                    <option value="12">12 miesięcy</option>
+                    <option value="24" selected>2 lata</option>
+                    <option value="36">3 lata</option>
+                    <option value="all">Wszystko</option>
+                  </select>
+                </div>
               </div>
               <div class="chart-area"><canvas id="monthly-costs-chart"></canvas></div>
             </div>
@@ -919,6 +926,7 @@ function resetForm() {
 
 function renderAnalytics() {
     const periodMonths = document.getElementById('analytics-period-filter').value;
+    const grouping = document.getElementById('analytics-grouping-filter').value;
     const now = new Date();
     let startDate = new Date(1970, 0, 1);
 
@@ -928,25 +936,60 @@ function renderAnalytics() {
     }
 
     const invoices = state.transactions.filter(tx => tx.type === 'invoice' && new Date(tx.date) >= startDate);
-    
-    const monthlyData = invoices.reduce((acc, tx) => {
-        const month = tx.date.slice(0, 7);
-        if (!acc[month]) {
-            acc[month] = { totalCost: 0, totalLiters: 0, count: 0 };
+
+    const groupedData = invoices.reduce((acc, tx) => {
+        const key = getGroupingKey(tx.date, grouping);
+        if (!acc[key]) {
+            acc[key] = { totalCost: 0, totalLiters: 0, count: 0 };
         }
-        acc[month].totalCost += Math.abs(tx.amount);
-        acc[month].totalLiters += tx.liters || 0;
-        acc[month].count += 1;
+        acc[key].totalCost += Math.abs(tx.amount);
+        acc[key].totalLiters += tx.liters || 0;
+        acc[key].count += 1;
         return acc;
     }, {});
 
-    const labels = Object.keys(monthlyData).sort();
-    const costs = labels.map(m => monthlyData[m].totalCost);
-    const counts = labels.map(m => monthlyData[m].count);
-    const avgPrices = labels.map(m => monthlyData[m].totalLiters > 0 ? monthlyData[m].totalCost / monthlyData[m].totalLiters : 0);
-    
-    renderMonthlyCostsChart(labels, costs, counts);
-    renderAvgPriceChart(labels, avgPrices);
+    const labels = Object.keys(groupedData).sort(groupingSort);
+    const costs = labels.map(m => groupedData[m].totalCost);
+    const counts = labels.map(m => groupedData[m].count);
+    const avgPrices = labels.map(m => groupedData[m].totalLiters > 0 ? groupedData[m].totalCost / groupedData[m].totalLiters : 0);
+
+    renderMonthlyCostsChart(labels, costs, counts, grouping);
+    renderAvgPriceChart(labels, avgPrices, grouping);
+}
+
+function getGroupingKey(dateStr, grouping) {
+    const [yearStr, monthStr] = dateStr.split('-');
+    const year = Number(yearStr);
+    const month = Number(monthStr);
+    if (grouping === 'year') return `${year}`;
+    if (grouping === 'quarter') return `${year}-Q${Math.ceil(month / 3)}`;
+    return `${year}-${String(month).padStart(2, '0')}`;
+}
+
+function groupingSort(a, b) {
+    const [ay, ar] = splitGroupingKey(a);
+    const [by, br] = splitGroupingKey(b);
+    if (ay !== by) return ay - by;
+    return ar - br;
+}
+
+function splitGroupingKey(key) {
+    if (key.includes('-Q')) {
+        const [y, q] = key.split('-Q');
+        return [Number(y), Number(q)];
+    }
+    if (key.includes('-')) {
+        const [y, m] = key.split('-');
+        return [Number(y), Number(m)];
+    }
+    return [Number(key), 1];
+}
+
+function formatChartLabel(label, grouping) {
+    if (grouping === 'year') return label;
+    if (grouping === 'quarter') return label;
+    const d = new Date(label + '-01');
+    return d.toLocaleDateString('pl-PL', { month: 'short', year: '2-digit' });
 }
 
 // Abbreviated number formatter for chart labels (e.g. 1234 → "1,2k")
@@ -983,15 +1026,12 @@ const datalabelsPlugin = {
     }
 };
 
-function renderMonthlyCostsChart(labels, costs, counts) {
+function renderMonthlyCostsChart(labels, costs, counts, grouping = 'month') {
     const canvas = document.getElementById('monthly-costs-chart');
     const ctx = canvas.getContext('2d');
     if (window.monthlyCostsChart) window.monthlyCostsChart.destroy();
 
-    const fmtLabels = labels.map(l => {
-        const d = new Date(l + '-01');
-        return d.toLocaleDateString('pl-PL', { month: 'short', year: '2-digit' });
-    });
+    const fmtLabels = labels.map(l => formatChartLabel(l, grouping));
 
     window.monthlyCostsChart = new Chart(ctx, {
         type: 'bar',
@@ -1121,15 +1161,12 @@ function renderMonthlyCostsChart(labels, costs, counts) {
 }
 
 
-function renderAvgPriceChart(labels, prices) {
+function renderAvgPriceChart(labels, prices, grouping = 'month') {
     const canvas = document.getElementById('avg-price-chart');
     const ctx = canvas.getContext('2d');
     if (window.avgPriceChart) window.avgPriceChart.destroy();
 
-    const fmtLabels = labels.map(l => {
-        const d = new Date(l + '-01');
-        return d.toLocaleDateString('pl-PL', { month: 'short', year: '2-digit' });
-    });
+    const fmtLabels = labels.map(l => formatChartLabel(l, grouping));
 
     window.avgPriceChart = new Chart(ctx, {
         type: 'line',
@@ -1320,6 +1357,7 @@ clearAllBtn.addEventListener('click', () => {
 // Initial setup
 dateInput.value = new Date().toISOString().slice(0,10);
 document.getElementById('analytics-period-filter').onchange = renderAnalytics;
+document.getElementById('analytics-grouping-filter').onchange = renderAnalytics;
 render();
 
 </script>

--- a/loan.html
+++ b/loan.html
@@ -686,6 +686,82 @@
       justify-content: flex-end;
       gap: 10px;
     }
+
+    /* === Editorial refresh (bez zmiany danych, headera i sidebara) === */
+    body[data-page="loan"] {
+      background: #faf8ff;
+    }
+    body[data-page="loan"] .content-main,
+    body[data-page="loan"] main.stack {
+      gap: 16px;
+    }
+    body[data-page="loan"] .card {
+      background: #ffffff;
+      border: 1px solid #e3e7f7;
+      border-radius: 18px;
+      box-shadow: 0 14px 34px -14px rgba(19, 27, 46, 0.18);
+    }
+    body[data-page="loan"] .loan-progress-card {
+      background: linear-gradient(160deg, #ffffff 0%, #f3f6ff 100%);
+      border-color: #dbe3ff;
+    }
+    body[data-page="loan"] .loan-progress-fill {
+      background: linear-gradient(90deg, #0050cb 0%, #3b82f6 100%);
+    }
+    body[data-page="loan"] .loan-progress-stat {
+      background: #f7f9ff;
+      border: 1px solid #e0e6fb;
+      border-radius: 14px;
+    }
+    body[data-page="loan"] .loan-tab-nav {
+      background: #eef2ff;
+      border: 1px solid #d9e1ff;
+      border-radius: 14px;
+      padding: 5px;
+    }
+    body[data-page="loan"] .loan-tab-btn {
+      border: none;
+      border-radius: 10px;
+      background: transparent;
+      color: #4a5670;
+      text-transform: none;
+      letter-spacing: 0.01em;
+      font-weight: 700;
+    }
+    body[data-page="loan"] .loan-tab-btn.active {
+      background: #ffffff;
+      color: #0050cb;
+      box-shadow: 0 6px 16px -10px rgba(0, 80, 203, 0.7);
+    }
+    body[data-page="loan"] .loan-chart-toggle,
+    body[data-page="loan"] .loan-chart-mode-btn {
+      border-radius: 10px;
+    }
+    body[data-page="loan"] .loan-chart-switch {
+      background: #eef2ff;
+      border-color: #d7dff8;
+    }
+    body[data-page="loan"] .loan-chart-mode-btn.active {
+      background: #0050cb;
+      color: #fff;
+      box-shadow: none;
+    }
+    body[data-page="loan"] .schedule-summary {
+      background: #f7f9ff;
+      border-color: #dbe4ff;
+      border-radius: 14px;
+    }
+    body[data-page="loan"] .schedule-item {
+      border-radius: 14px;
+      border: 1px solid #e3e7f7;
+      background: #fff;
+    }
+    body[data-page="loan"] .right-rail .kpi-compact {
+      border-radius: 14px;
+      border: 1px solid #dfe5f8;
+      background: linear-gradient(160deg, #ffffff 0%, #f6f8ff 100%);
+      box-shadow: 0 10px 24px -18px rgba(19, 27, 46, 0.28);
+    }
   </style>
 </head>
 <body data-page="loan">

--- a/loan.html
+++ b/loan.html
@@ -1546,6 +1546,19 @@ function renderCharts() {
 
   Chart.defaults.font.family = "'Inter', sans-serif";
   Chart.defaults.color = getComputedStyle(document.body).getPropertyValue('--muted').trim();
+  Chart.defaults.plugins.legend.labels.usePointStyle = true;
+  Chart.defaults.plugins.legend.labels.boxWidth = 10;
+  Chart.defaults.plugins.legend.labels.boxHeight = 10;
+  Chart.defaults.plugins.legend.labels.padding = 14;
+  Chart.defaults.plugins.legend.labels.color = '#595c5e';
+  Chart.defaults.plugins.legend.labels.font = { family: "'Inter', sans-serif", size: 12 };
+  Chart.defaults.plugins.tooltip.backgroundColor = '#1e2022';
+  Chart.defaults.plugins.tooltip.titleColor = '#f5f6f8';
+  Chart.defaults.plugins.tooltip.bodyColor = '#9b9d9f';
+  Chart.defaults.plugins.tooltip.borderColor = '#3a3d40';
+  Chart.defaults.plugins.tooltip.borderWidth = 1;
+  Chart.defaults.plugins.tooltip.cornerRadius = 10;
+  Chart.defaults.plugins.tooltip.padding = 12;
 
   // === Paid data ===
   const paidCount = payments.length;
@@ -1841,7 +1854,7 @@ function renderChartForPanel(panelType) {
               yRate: { type: 'linear', position: 'right', grid: { display: false }, min: yRateMin, max: yRateMax, ticks: { callback: (value) => `${value}%` } }
             },
             plugins: {
-              legend: { position: 'bottom', labels: { usePointStyle: true } },
+              legend: { position: 'top', align: 'end' },
               tooltip: {
                 callbacks: {
                   label: (context) => {
@@ -1945,7 +1958,7 @@ function renderChartForPanel(panelType) {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-              legend: { position: 'bottom' },
+              legend: { position: 'top', align: 'end' },
               tooltip: {
                 callbacks: {
                   label: (context) => `${context.dataset.label}: ${fmtChartValue(context.raw)}`
@@ -2022,7 +2035,7 @@ function renderChartForPanel(panelType) {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
-              legend: { position: 'bottom', labels: { usePointStyle: true } },
+              legend: { position: 'top', align: 'end' },
               tooltip: {
                 callbacks: {
                   label: (context) => `${context.dataset.label}: ${context.raw.toFixed(1)}%`
@@ -2101,7 +2114,7 @@ function renderChartForPanel(panelType) {
             maintainAspectRatio: false,
             interaction: { mode: 'index', intersect: false },
             plugins: {
-              legend: { position: 'bottom' },
+              legend: { position: 'top', align: 'end' },
               tooltip: {
                 callbacks: {
                   label: (context) => `${context.dataset.label}: ${fmtChartValue(context.raw)}`
@@ -2308,7 +2321,7 @@ function renderChartForPanel(panelType) {
               }
             },
             plugins: {
-              legend: { position: 'bottom' },
+              legend: { position: 'top', align: 'end' },
               tooltip: {
                 callbacks: {
                   label: (context) => {

--- a/loan.html
+++ b/loan.html
@@ -1559,6 +1559,11 @@ function renderCharts() {
   Chart.defaults.plugins.tooltip.borderWidth = 1;
   Chart.defaults.plugins.tooltip.cornerRadius = 10;
   Chart.defaults.plugins.tooltip.padding = 12;
+  Chart.defaults.elements.line.borderWidth = 2.5;
+  Chart.defaults.elements.point.borderWidth = 2;
+  Chart.defaults.elements.point.radius = 4;
+  Chart.defaults.elements.point.hoverRadius = 6;
+  Chart.defaults.elements.bar.borderRadius = 6;
 
   // === Paid data ===
   const paidCount = payments.length;
@@ -1717,15 +1722,17 @@ function destroyAllLoanCharts() {
 function getLoanPalette() {
   const styles = getComputedStyle(document.body);
   return {
-    green: styles.getPropertyValue('--green').trim(),
-    greenSoft: styles.getPropertyValue('--green-soft').trim(),
-    orange: styles.getPropertyValue('--orange').trim(),
-    orangeSoft: styles.getPropertyValue('--orange-soft').trim(),
-    blue: styles.getPropertyValue('--blue').trim(),
-    blueSoft: styles.getPropertyValue('--blue-soft').trim(),
+    // Chłodniejsza paleta wzorowana na module Paliwo (bardziej nowoczesna i spójna)
+    green: '#059669',
+    greenSoft: 'rgba(5, 150, 105, 0.18)',
+    orange: '#2563eb',
+    orangeSoft: 'rgba(37, 99, 235, 0.16)',
+    blue: '#0057c0',
+    blueSoft: 'rgba(0, 87, 192, 0.16)',
     line: styles.getPropertyValue('--line').trim(),
     card: styles.getPropertyValue('--card').trim(),
-    ink: styles.getPropertyValue('--ink').trim()
+    ink: styles.getPropertyValue('--ink').trim(),
+    muted: styles.getPropertyValue('--muted').trim()
   };
 }
 
@@ -1949,8 +1956,28 @@ function renderChartForPanel(panelType) {
           data: {
             labels,
             datasets: [
-              { label: 'Kapitał', data: principalSeries, borderColor: palette.green, backgroundColor: palette.greenSoft, fill: false, tension: 0.25, pointRadius: 3, pointBackgroundColor: palette.green },
-              { label: 'Odsetki', data: interestSeries, borderColor: palette.orange, backgroundColor: palette.orangeSoft, fill: false, tension: 0.25, pointRadius: 3, pointBackgroundColor: palette.orange }
+              {
+                label: 'Kapitał',
+                data: principalSeries,
+                borderColor: palette.green,
+                backgroundColor: palette.greenSoft,
+                fill: true,
+                tension: 0.35,
+                pointRadius: 4,
+                pointBackgroundColor: palette.green,
+                pointBorderColor: '#ffffff'
+              },
+              {
+                label: 'Odsetki',
+                data: interestSeries,
+                borderColor: palette.orange,
+                backgroundColor: palette.orangeSoft,
+                fill: true,
+                tension: 0.35,
+                pointRadius: 4,
+                pointBackgroundColor: palette.orange,
+                pointBorderColor: '#ffffff'
+              }
             ]
           },
           plugins: [ChartDataLabels],
@@ -2103,9 +2130,9 @@ function renderChartForPanel(panelType) {
           data: {
             labels,
             datasets: [
-              { label: 'Kapitał skumulowany', data: cumulativePrincipal, borderColor: palette.green, backgroundColor: palette.greenSoft, fill: false, tension: 0.25, pointRadius: 0 },
-              { label: 'Odsetki skumulowane', data: cumulativeInterest, borderColor: palette.orange, backgroundColor: palette.orangeSoft, fill: false, tension: 0.25, pointRadius: 0 },
-              { label: 'Łącznie', data: cumulativePrincipal.map((value, index) => value + cumulativeInterest[index]), borderColor: palette.blue, backgroundColor: palette.blueSoft, fill: false, borderDash: [6, 4], tension: 0.25, pointRadius: 0 }
+              { label: 'Kapitał skumulowany', data: cumulativePrincipal, borderColor: palette.green, backgroundColor: palette.greenSoft, fill: true, tension: 0.3, pointRadius: 2, pointBackgroundColor: palette.green, pointBorderColor: '#fff' },
+              { label: 'Odsetki skumulowane', data: cumulativeInterest, borderColor: palette.orange, backgroundColor: palette.orangeSoft, fill: true, tension: 0.3, pointRadius: 2, pointBackgroundColor: palette.orange, pointBorderColor: '#fff' },
+              { label: 'Łącznie', data: cumulativePrincipal.map((value, index) => value + cumulativeInterest[index]), borderColor: palette.blue, backgroundColor: palette.blueSoft, fill: false, borderDash: [6, 4], tension: 0.3, pointRadius: 2, pointBackgroundColor: palette.blue, pointBorderColor: '#fff' }
             ]
           },
           plugins: [ChartDataLabels],

--- a/loan.html
+++ b/loan.html
@@ -695,6 +695,56 @@
     body[data-page="loan"] main.stack {
       gap: 16px;
     }
+    body[data-page="loan"] .content {
+      grid-template-columns: 1fr;
+    }
+    body[data-page="loan"] .right-rail {
+      display: none;
+    }
+    body[data-page="loan"] .loan-bento-summary {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px;
+    }
+    body[data-page="loan"] .loan-bento-card {
+      background: #fff;
+      border: 1px solid #e3e7f7;
+      border-radius: 14px;
+      box-shadow: 0 12px 32px -18px rgba(19, 27, 46, 0.22);
+      padding: 16px 18px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    body[data-page="loan"] .loan-bento-card .label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 800;
+      color: #58627b;
+    }
+    body[data-page="loan"] .loan-bento-card .value {
+      font-size: 27px;
+      font-weight: 900;
+      color: #131b2e;
+      line-height: 1.05;
+      letter-spacing: -0.02em;
+    }
+    body[data-page="loan"] .loan-bento-card .note {
+      font-size: 12px;
+      color: #6a7288;
+      font-weight: 600;
+    }
+    body[data-page="loan"] .loan-bento-card.hero {
+      background: linear-gradient(145deg, #0050cb 0%, #0066ff 100%);
+      border-color: transparent;
+      color: #fff;
+    }
+    body[data-page="loan"] .loan-bento-card.hero .label,
+    body[data-page="loan"] .loan-bento-card.hero .value,
+    body[data-page="loan"] .loan-bento-card.hero .note {
+      color: #fff;
+    }
     body[data-page="loan"] .card {
       background: #ffffff;
       border: 1px solid #e3e7f7;
@@ -761,6 +811,16 @@
       border: 1px solid #dfe5f8;
       background: linear-gradient(160deg, #ffffff 0%, #f6f8ff 100%);
       box-shadow: 0 10px 24px -18px rgba(19, 27, 46, 0.28);
+    }
+    @media (max-width: 1100px) {
+      body[data-page="loan"] .loan-bento-summary {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+    @media (max-width: 640px) {
+      body[data-page="loan"] .loan-bento-summary {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
 </head>
@@ -858,6 +918,29 @@
             </section>
 
             <div id="dashboard-container" class="stack tight" style="display: none;">
+              <section class="loan-bento-summary">
+                <article class="loan-bento-card">
+                  <span class="label">Pozostało do spłaty</span>
+                  <span class="value" id="capital-remaining">—</span>
+                  <span class="note" id="capital-remaining-note">—</span>
+                </article>
+                <article class="loan-bento-card">
+                  <span class="label">Następna rata</span>
+                  <span class="value" id="next-payment">—</span>
+                  <span class="note" id="next-payment-note">—</span>
+                </article>
+                <article class="loan-bento-card">
+                  <span class="label">Kapitał spłacony</span>
+                  <span class="value" id="capital-paid">—</span>
+                  <span class="note" id="capital-paid-note">—</span>
+                </article>
+                <article class="loan-bento-card hero">
+                  <span class="label">Śr. rata</span>
+                  <span class="value" id="avg-installment">—</span>
+                  <span class="note" id="avg-installment-note">—</span>
+                </article>
+              </section>
+
               <section class="card loan-progress-card">
                 <div class="loan-progress-header">
                   <h2 class="title">Postęp spłaty kapitału</h2>
@@ -1017,21 +1100,21 @@
           </div>
         </main>
 
-        <aside class="right-rail">
+        <aside class="right-rail" aria-hidden="true">
           <div class="kpi-compact">
             <span class="kpi-emoji">💰</span>
             <div class="kpi-body">
               <span class="kpi-label">Kapitał pozostały</span>
-              <span class="kpi-value" id="capital-remaining">—</span>
-              <span class="tiny muted" id="capital-remaining-note"></span>
+              <span class="kpi-value" id="capital-remaining-legacy">—</span>
+              <span class="tiny muted" id="capital-remaining-note-legacy"></span>
             </div>
           </div>
           <div class="kpi-compact">
             <span class="kpi-emoji">📉</span>
             <div class="kpi-body">
               <span class="kpi-label">Kapitał spłacony</span>
-              <span class="kpi-value" id="capital-paid">—</span>
-              <span class="tiny muted" id="capital-paid-note"></span>
+              <span class="kpi-value" id="capital-paid-legacy">—</span>
+              <span class="tiny muted" id="capital-paid-note-legacy"></span>
             </div>
           </div>
           <div class="kpi-compact">
@@ -1046,16 +1129,16 @@
             <span class="kpi-emoji">💸</span>
             <div class="kpi-body">
               <span class="kpi-label">Śr. rata</span>
-              <span class="kpi-value" id="avg-installment">—</span>
-              <span class="tiny muted" id="avg-installment-note"></span>
+              <span class="kpi-value" id="avg-installment-legacy">—</span>
+              <span class="tiny muted" id="avg-installment-note-legacy"></span>
             </div>
           </div>
           <div class="kpi-compact">
             <span class="kpi-emoji">⏳</span>
             <div class="kpi-body">
               <span class="kpi-label">Następna rata</span>
-              <span class="kpi-value" id="next-payment">—</span>
-              <span class="tiny muted" id="next-payment-note"></span>
+              <span class="kpi-value" id="next-payment-legacy">—</span>
+              <span class="tiny muted" id="next-payment-note-legacy"></span>
             </div>
           </div>
         </aside>
@@ -1799,12 +1882,12 @@ function getLoanPalette() {
   const styles = getComputedStyle(document.body);
   return {
     // Chłodniejsza paleta wzorowana na module Paliwo (bardziej nowoczesna i spójna)
-    green: '#059669',
-    greenSoft: 'rgba(5, 150, 105, 0.18)',
-    orange: '#2563eb',
-    orangeSoft: 'rgba(37, 99, 235, 0.16)',
-    blue: '#0057c0',
-    blueSoft: 'rgba(0, 87, 192, 0.16)',
+    green: '#0050cb',
+    greenSoft: 'rgba(0, 102, 255, 0.18)',
+    orange: '#7b97ff',
+    orangeSoft: 'rgba(123, 151, 255, 0.20)',
+    blue: '#003fa4',
+    blueSoft: 'rgba(0, 80, 203, 0.16)',
     line: styles.getPropertyValue('--line').trim(),
     card: styles.getPropertyValue('--card').trim(),
     ink: styles.getPropertyValue('--ink').trim(),


### PR DESCRIPTION
### Motivation
- Provide a longer default historical window for the fuel charts so the page shows 2 years on reload instead of 12 months.
- Allow examining aggregated trends at different resolutions (monthly, quarterly, yearly) to support higher-level analysis.
- Keep existing monthly detail while enabling quick switching between aggregation levels in the UI.

### Description
- Changed the analytics controls: added a new grouping selector `#analytics-grouping-filter` with options `month`, `quarter`, and `year`, and set the period selector default to `24` (2 years).
- Reworked `renderAnalytics()` to aggregate invoice rows into buckets using a new `getGroupingKey()` function and to sort buckets via `groupingSort()`/`splitGroupingKey()` before charting.
- Updated chart rendering functions to accept a `grouping` parameter and use `formatChartLabel()` so X-axis labels render sensibly for months, quarters and years.
- Wired the new grouping selector to re-render analytics on change and preserved existing behavior for the period selector.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9e5ea5ca48331a7e36c0246979124)