### PR TITLE
Unify design system: migrate to global tokens & modernize UI

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -4643,6 +4643,12 @@
               <span class="sidebar__label">Budowa</span>
             </a>
           </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="investments.html" data-page="investments">
+              <span class="material-symbols-outlined">show_chart</span>
+              <span class="sidebar__label">Inwestycje</span>
+            </a>
+          </li>
         </ul>
       </nav>
       <div class="sidebar__footer">

--- a/budget.html
+++ b/budget.html
@@ -18,12 +18,42 @@
     }
 
     .budget-tabs {
-      position: sticky;
-      top: 0;
+      display: flex;
+      gap: 2px;
+      border-bottom: 1px solid var(--line);
       background: var(--bg);
-      z-index: 8;
-      padding: 8px 0;
+      position: sticky;
+      top: var(--topbar-height);
+      z-index: 10;
+      overflow-x: auto;
+      padding: 0;
       margin-bottom: 0;
+    }
+
+    .budget-tabs .tab {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 10px 16px 11px;
+      border-radius: 0;
+      border: none;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -1px;
+      background: transparent;
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 12px;
+      white-space: nowrap;
+      transition: color .15s, border-color .15s;
+    }
+    .budget-tabs .tab:hover { color: var(--ink); background: transparent; box-shadow: none; }
+    .budget-tabs .tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+      font-weight: 800;
+      background: transparent;
+      border-radius: 0;
+      box-shadow: none;
     }
 
     .trend {
@@ -4657,33 +4687,30 @@
     </aside>
 
     <div class="main">
-      <header class="site-header" role="banner">
-        <div class="site-header__left">
-          <div class="site-header__greeting">
-            <h1 class="site-header__title">Budżet</h1>
-          </div>
-          <div class="live-badge">
-            <span class="live-dot"></span>
-            Finanse osobiste
-          </div>
+      <header class="page-header" role="banner">
+        <div class="page-header__top">
+          <span class="page-overline">Finanse</span>
+          <h1 class="page-title">
+            <span class="material-symbols-outlined page-title__icon">payments</span>
+            <span class="page-title__text">Budżet</span>
+          </h1>
+          <div class="live-badge"><span class="live-dot"></span>Finanse osobiste</div>
         </div>
-        <div class="site-header__right" aria-label="Akcje strony">
+        <div class="page-header__actions">
           <div class="toolbar budget-month-nav">
-            <button class="btn soft" id="prevMonthBtn" title="Poprzedni miesiąc">←</button>
+            <button class="btn ghost icon-btn" id="prevMonthBtn" title="Poprzedni miesiąc"><span class="material-symbols-outlined">chevron_left</span></button>
             <span class="pill" id="workingMonth">YYYY-MM</span>
-            <button class="btn soft" id="nextMonthBtn" title="Następny miesiąc">→</button>
+            <button class="btn ghost icon-btn" id="nextMonthBtn" title="Następny miesiąc"><span class="material-symbols-outlined">chevron_right</span></button>
           </div>
-          <div class="header-btn-group budget-io-actions">
-            <button class="btn ghost" id="exportBtn">⬇️ Eksport JSON</button>
-            <button class="btn ghost" id="importBtn">⬆️ Import JSON</button>
-            <input type="file" id="importFile" accept="application/json" style="display:none" />
-          </div>
+          <button class="btn ghost" id="exportBtn"><span class="material-symbols-outlined">download</span>Eksport</button>
+          <button class="btn ghost" id="importBtn"><span class="material-symbols-outlined">upload</span>Import</button>
+          <input type="file" id="importFile" accept="application/json" style="display:none" />
         </div>
       </header>
 
       <div class="content">
         <main class="page-content content-main stack">
-    <div class="tabs budget-tabs" style="margin-top:12px">
+    <div class="tabs budget-tabs">
       <button class="tab active" data-tab="dashboard">Dashboard</button>
       <button class="tab" data-tab="overview">Przegląd</button>
       <button class="tab" data-tab="incomes">Przychody</button>

--- a/budget.html
+++ b/budget.html
@@ -62,17 +62,17 @@
     .inv-kpi-card .inv-kpi-label { font-size:11px; font-weight:700; color:var(--muted); text-transform:uppercase; letter-spacing:.03em; }
     .inv-kpi-card .inv-kpi-value { font-size:20px; font-weight:700; color:var(--ink); line-height:1.2; }
     .inv-kpi-card .inv-kpi-sub { font-size:11px; color:var(--muted); }
-    .inv-kpi-card.positive .inv-kpi-value { color:#16a34a; }
-    .inv-kpi-card.negative .inv-kpi-value { color:#dc2626; }
-    .inv-kpi-card.accent { background:linear-gradient(135deg,#2563eb 0%,#1d4ed8 100%); border-color:transparent; }
+    .inv-kpi-card.positive .inv-kpi-value { color:var(--green); }
+    .inv-kpi-card.negative .inv-kpi-value { color:var(--red); }
+    .inv-kpi-card.accent { background:linear-gradient(135deg,var(--accent) 0%,var(--accent) 100%); border-color:transparent; }
     .inv-kpi-card.accent .inv-kpi-label { color:rgba(255,255,255,.75); }
     .inv-kpi-card.accent .inv-kpi-value { color:#fff; }
     .inv-kpi-card.accent .inv-kpi-sub { color:rgba(255,255,255,.65); }
 
     .inv-trade-tabs { display:inline-flex; gap:0; border-radius:10px; overflow:hidden; border:1px solid rgba(148,163,184,.3); }
     .inv-trade-tab { border:none; background:transparent; padding:8px 20px; font-weight:600; font-size:13px; cursor:pointer; color:var(--muted); transition:all .2s; }
-    .inv-trade-tab.is-active { background:#2563eb; color:#fff; }
-    .inv-trade-tab.sell-active { background:#dc2626; color:#fff; }
+    .inv-trade-tab.is-active { background:var(--accent); color:#fff; }
+    .inv-trade-tab.sell-active { background:var(--red); color:#fff; }
     .inv-trade-grid { display:flex; flex-wrap:wrap; align-items:flex-end; gap:12px; margin-top:10px; }
     .inv-trade-field { display:flex; flex-direction:column; gap:4px; min-width:130px; flex:0 1 auto; font-size:13px; font-weight:500; }
     .inv-trade-field.grow { flex:1 1 180px; }
@@ -81,16 +81,16 @@
     @media(max-width:720px){ .inv-trade-grid{flex-direction:column;align-items:stretch} }
 
     .inv-sell-info { background:rgba(148,163,184,.08); border:1px solid rgba(148,163,184,.2); border-radius:10px; padding:10px 14px; font-size:13px; color:var(--ink); width:100%; line-height:1.6; }
-    .inv-sell-info .pos { color:#16a34a; font-weight:600; }
-    .inv-sell-info .neg { color:#dc2626; font-weight:600; }
+    .inv-sell-info .pos { color:var(--green); font-weight:600; }
+    .inv-sell-info .neg { color:var(--red); font-weight:600; }
 
     .inv-price-input { width:90px; height:30px; font-size:12px; text-align:right; border:1px solid rgba(148,163,184,.3); border-radius:6px; padding:0 6px; }
-    .inv-pnl-pos { color:#16a34a; font-weight:600; }
-    .inv-pnl-neg { color:#dc2626; font-weight:600; }
+    .inv-pnl-pos { color:var(--green); font-weight:600; }
+    .inv-pnl-neg { color:var(--red); font-weight:600; }
     .inv-pnl-na { color:var(--muted); font-style:italic; }
 
-    .inv-side-buy { display:inline-block; padding:2px 8px; border-radius:6px; font-size:11px; font-weight:700; background:rgba(34,197,94,.12); color:#16a34a; }
-    .inv-side-sell { display:inline-block; padding:2px 8px; border-radius:6px; font-size:11px; font-weight:700; background:rgba(239,68,68,.12); color:#dc2626; }
+    .inv-side-buy { display:inline-block; padding:2px 8px; border-radius:6px; font-size:11px; font-weight:700; background:rgba(34,197,94,.12); color:var(--green); }
+    .inv-side-sell { display:inline-block; padding:2px 8px; border-radius:6px; font-size:11px; font-weight:700; background:rgba(239,68,68,.12); color:var(--red); }
     .inv-source-badge { display:inline-block; padding:2px 6px; border-radius:4px; font-size:10px; font-weight:600; background:rgba(148,163,184,.12); color:var(--muted); }
 
     .inv-trade-filters { display:inline-flex; gap:4px; padding:3px; border-radius:8px; background:rgba(148,163,184,.1); }
@@ -145,9 +145,9 @@
     .inv-hub-kpi .kpi-label { font-size:10px; font-weight:700; color:var(--muted); text-transform:uppercase; letter-spacing:.04em; }
     .inv-hub-kpi .kpi-val { font-size:18px; font-weight:700; color:var(--ink); }
     .inv-hub-kpi .kpi-sub { font-size:11px; color:var(--muted); }
-    .inv-hub-kpi.positive .kpi-val { color:#16a34a; }
-    .inv-hub-kpi.negative .kpi-val { color:#dc2626; }
-    .inv-hub-kpi.accent { background:linear-gradient(135deg,#2563eb 0%,#1d4ed8 100%); border-color:transparent; }
+    .inv-hub-kpi.positive .kpi-val { color:var(--green); }
+    .inv-hub-kpi.negative .kpi-val { color:var(--red); }
+    .inv-hub-kpi.accent { background:linear-gradient(135deg,var(--accent) 0%,var(--accent) 100%); border-color:transparent; }
     .inv-hub-kpi.accent .kpi-label { color:rgba(255,255,255,.7); }
     .inv-hub-kpi.accent .kpi-val { color:#fff; }
     .inv-hub-kpi.accent .kpi-sub { color:rgba(255,255,255,.6); }
@@ -169,11 +169,11 @@
     .inv-hub-calc-field { display:flex; flex-direction:column; gap:4px; font-size:13px; font-weight:500; }
     .inv-hub-calc-field input, .inv-hub-calc-field select { height:38px; }
     .inv-hub-calc-result { margin-top:14px; padding:14px; background:rgba(37,99,235,.06); border:1px solid rgba(37,99,235,.18); border-radius:12px; }
-    .inv-hub-calc-result .big { font-size:22px; font-weight:800; color:#2563eb; }
+    .inv-hub-calc-result .big { font-size:22px; font-weight:800; color:var(--accent); }
     .inv-hub-calc-result .detail { font-size:12px; color:var(--muted); margin-top:4px; }
     .inv-hub-calc-chart-box { height:380px; margin-top:16px; position:relative; }
 
-    .inv-hub-streak { display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:8px; background:rgba(37,99,235,.08); font-size:12px; font-weight:600; color:#2563eb; }
+    .inv-hub-streak { display:inline-flex; align-items:center; gap:6px; padding:6px 12px; border-radius:8px; background:rgba(37,99,235,.08); font-size:12px; font-weight:600; color:var(--accent); }
     .inv-hub-table { width:100%; border-collapse:collapse; font-size:13px; }
     .inv-hub-table th { text-align:left; font-size:11px; font-weight:700; color:var(--muted); text-transform:uppercase; padding:8px 10px; border-bottom:1px solid rgba(148,163,184,.2); }
     .inv-hub-table td { padding:8px 10px; border-bottom:1px solid rgba(148,163,184,.1); }
@@ -186,9 +186,9 @@
     .inv-hub-time-tabs { display:inline-flex; gap:3px; padding:3px; border-radius:999px; background:rgba(148,163,184,.14); }
     .inv-hub-time-tab { border:none; background:transparent; padding:5px 11px; border-radius:999px; font-size:11px; font-weight:600; color:var(--muted); cursor:pointer; transition:background .18s,color .18s; white-space:nowrap; }
     .inv-hub-time-tab:hover { background:rgba(255,255,255,.6); color:var(--ink); }
-    .inv-hub-time-tab.is-active { background:#2563eb; color:#fff; box-shadow:0 2px 8px rgba(37,99,235,.3); }
+    .inv-hub-time-tab.is-active { background:var(--accent); color:#fff; box-shadow:0 2px 8px rgba(37,99,235,.3); }
     .inv-hub-time-range-wrap { display:flex; align-items:center; gap:6px; }
-    .inv-hub-time-range-wrap input[type=range] { accent-color:#2563eb; }
+    .inv-hub-time-range-wrap input[type=range] { accent-color:var(--accent); }
     .inv-hub-section-divider { border:none; border-top:1px solid rgba(148,163,184,.13); margin:18px 0 12px; }
 
     /* --- Monthly Performance heatmap-table ----------------------------------- */
@@ -198,8 +198,8 @@
     .inv-hub-monthly-table tr:last-child td { border-bottom:none; }
     .inv-hub-monthly-table tr:hover td { background:rgba(37,99,235,.04); }
     .inv-hub-month-badge { display:inline-block; padding:2px 7px; border-radius:5px; font-size:10px; font-weight:700; text-transform:uppercase; }
-    .inv-hub-pill-pos { background:rgba(34,197,94,.12); color:#16a34a; }
-    .inv-hub-pill-neg { background:rgba(239,68,68,.1); color:#dc2626; }
+    .inv-hub-pill-pos { background:rgba(34,197,94,.12); color:var(--green); }
+    .inv-hub-pill-neg { background:rgba(239,68,68,.1); color:var(--red); }
     .inv-hub-pill-neu { background:rgba(148,163,184,.12); color:var(--muted); }
 
     /* --- DCA Table ----------------------------------------------------------- */
@@ -218,14 +218,14 @@
     .inv-hub-sim-card--green { background:rgba(5,150,105,.06); border-color:rgba(5,150,105,.2); }
     .inv-hub-sim-card--purple { background:rgba(139,92,246,.06); border-color:rgba(139,92,246,.2); }
     .inv-hub-sim-card__label { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.05em; color:var(--muted); margin-bottom:6px; }
-    .inv-hub-sim-card--blue .inv-hub-sim-card__label { color:#2563eb; }
+    .inv-hub-sim-card--blue .inv-hub-sim-card__label { color:var(--accent); }
     .inv-hub-sim-card--green .inv-hub-sim-card__label { color:#059669; }
     .inv-hub-sim-card--purple .inv-hub-sim-card__label { color:#7c3aed; }
     .inv-hub-sim-card__value { font-size:22px; font-weight:800; color:var(--ink); line-height:1.1; }
     .inv-hub-sim-card--green .inv-hub-sim-card__value { color:#059669; }
     .inv-hub-sim-card--purple .inv-hub-sim-card__value { color:#7c3aed; }
     .inv-hub-sim-card__roi { font-size:14px; font-weight:700; margin:3px 0 5px; }
-    .inv-hub-sim-card--green .inv-hub-sim-card__roi { color:#16a34a; }
+    .inv-hub-sim-card--green .inv-hub-sim-card__roi { color:var(--green); }
     .inv-hub-sim-card--purple .inv-hub-sim-card__roi { color:#6d28d9; }
     .inv-hub-sim-card__detail { font-size:11px; color:var(--muted); line-height:1.5; }
     .inv-hub-sim-card__detail strong { color:var(--ink); font-weight:700; }
@@ -265,11 +265,11 @@
     .inv-cal-group-label { font-size:9px; font-weight:700; text-transform:uppercase; letter-spacing:.07em; color:var(--muted); padding-left:2px; }
     .inv-cal-tabs { display:inline-flex; gap:2px; padding:2px; border-radius:999px; background:rgba(148,163,184,.13); }
     .inv-cal-tab { border:none; background:transparent; padding:5px 12px; border-radius:999px; font-size:11px; font-weight:600; color:var(--muted); cursor:pointer; transition:all .15s; white-space:nowrap; }
-    .inv-cal-tab:hover:not(.is-active) { background:rgba(37,99,235,.1); color:#2563eb; }
-    .inv-cal-tab.is-active { background:#2563eb; color:#fff; box-shadow:0 2px 8px rgba(37,99,235,.28); }
+    .inv-cal-tab:hover:not(.is-active) { background:rgba(37,99,235,.1); color:var(--accent); }
+    .inv-cal-tab.is-active { background:var(--accent); color:#fff; box-shadow:0 2px 8px rgba(37,99,235,.28); }
     .inv-cal-nav { display:flex; align-items:center; gap:8px; margin-left:auto; }
     .inv-cal-nav-btn { border:1px solid rgba(148,163,184,.3); background:var(--surface); border-radius:9px; width:32px; height:32px; font-size:20px; line-height:1; color:var(--ink); cursor:pointer; display:flex; align-items:center; justify-content:center; transition:background .15s; }
-    .inv-cal-nav-btn:hover { background:rgba(37,99,235,.08); border-color:#2563eb; }
+    .inv-cal-nav-btn:hover { background:rgba(37,99,235,.08); border-color:var(--accent); }
     .inv-cal-nav-title { font-size:14px; font-weight:700; min-width:150px; text-align:center; color:var(--ink); }
 
     /* Legend */
@@ -295,7 +295,7 @@
     .inv-cal-day--n1  { background:rgba(252,165,165,.65); } .inv-cal-day--n1  .inv-cal-day-val { color:#991b1b; }
     .inv-cal-day--n2  { background:rgba(239,68,68,.72); } .inv-cal-day--n2  .inv-cal-day-val,.inv-cal-day--n2  .inv-cal-day-num { color:#fff; }
     .inv-cal-day--nn2 { background:rgba(185,28,28,.90); } .inv-cal-day--nn2 .inv-cal-day-val,.inv-cal-day--nn2 .inv-cal-day-num { color:#fff; }
-    .inv-cal-day--today-ring { outline:2.5px solid #2563eb; outline-offset:2px; }
+    .inv-cal-day--today-ring { outline:2.5px solid var(--accent); outline-offset:2px; }
 
     /* Weekly grid */
     .inv-cal-week-grid { display:flex; flex-direction:column; gap:5px; }
@@ -315,36 +315,36 @@
     .inv-cal-roadto-value { font-size:20px; font-weight:800; color:var(--ink); line-height:1.2; }
     .inv-cal-roadto-rhs { text-align:right; }
     .inv-cal-roadto-goal-wrap { display:flex; align-items:center; gap:4px; justify-content:flex-end; }
-    .inv-cal-roadto-goal-btn { font-size:13px; font-weight:700; color:#2563eb; cursor:pointer; border:none; background:transparent; padding:0; text-decoration:underline dotted; text-underline-offset:2px; }
+    .inv-cal-roadto-goal-btn { font-size:13px; font-weight:700; color:var(--accent); cursor:pointer; border:none; background:transparent; padding:0; text-decoration:underline dotted; text-underline-offset:2px; }
     .inv-cal-roadto-goal-btn:hover { color:#7c3aed; }
     .inv-cal-roadto-goal-edit-icon { font-size:11px; color:var(--muted); cursor:pointer; }
     .inv-cal-roadto-remaining { font-size:11px; color:var(--muted); margin-top:2px; }
     .inv-cal-roadto-track-wrap { position:relative; }
     .inv-cal-roadto-track-outer { position:relative; margin-bottom:2px; }
     .inv-cal-roadto-track { position:relative; height:22px; border-radius:11px; background:rgba(148,163,184,.18); overflow:hidden; cursor:pointer; }
-    .inv-cal-roadto-fill { height:100%; border-radius:11px; background:linear-gradient(90deg,#2563eb 0%,#7c3aed 60%,#a855f7 100%); transition:width .7s cubic-bezier(.4,0,.2,1); min-width:0; position:relative; }
+    .inv-cal-roadto-fill { height:100%; border-radius:11px; background:linear-gradient(90deg,var(--accent) 0%,#7c3aed 60%,#a855f7 100%); transition:width .7s cubic-bezier(.4,0,.2,1); min-width:0; position:relative; }
     .inv-cal-roadto-fill::after { content:''; position:absolute; inset:0; background:linear-gradient(180deg,rgba(255,255,255,.22) 0%,transparent 60%); border-radius:inherit; }
     .inv-cal-roadto-fill-label { position:absolute; left:0; top:0; height:100%; display:flex; align-items:center; padding:0 10px; font-size:11px; font-weight:700; color:#fff; pointer-events:none; white-space:nowrap; }
     .inv-cal-roadto-pct-label { position:absolute; right:8px; top:50%; transform:translateY(-50%); font-size:11px; font-weight:700; color:var(--muted); pointer-events:none; }
-    .inv-cal-roadto-done { background:linear-gradient(90deg,#16a34a,#22c55e); }
+    .inv-cal-roadto-done { background:linear-gradient(90deg,var(--green),#22c55e); }
     .inv-cal-roadto-tick { position:absolute; top:0; width:2px; height:22px; background:rgba(255,255,255,.55); transform:translateX(-50%); pointer-events:none; z-index:1; }
     .inv-cal-roadto-tick.achieved { background:rgba(255,255,255,.9); }
     .inv-cal-roadto-stats { display:flex; gap:8px; margin-top:10px; flex-wrap:wrap; }
     .inv-cal-roadto-chip { display:inline-flex; align-items:center; gap:5px; padding:3px 9px; border-radius:999px; font-size:11px; font-weight:700; }
     .inv-cal-roadto-chip.pos { background:rgba(34,197,94,.12); color:#15803d; }
     .inv-cal-roadto-chip.neg { background:rgba(239,68,68,.1); color:#b91c1c; }
-    .inv-cal-roadto-chip.eta { background:rgba(37,99,235,.1); color:#1d4ed8; }
+    .inv-cal-roadto-chip.eta { background:rgba(37,99,235,.1); color:var(--accent); }
     .inv-cal-milestones { display:grid; grid-template-columns:repeat(5,1fr); gap:6px; margin-top:10px; }
     .inv-cal-milestone { border-radius:10px; padding:7px 9px 6px; border:1px solid; display:flex; flex-direction:column; gap:1px; cursor:default; }
     .inv-cal-milestone.achieved { background:rgba(22,163,74,.07); border-color:rgba(22,163,74,.22); }
     .inv-cal-milestone.future { background:rgba(37,99,235,.05); border-color:rgba(37,99,235,.14); }
     .inv-cal-milestone.no-eta { background:rgba(148,163,184,.06); border-color:rgba(148,163,184,.18); }
     .inv-cal-milestone-badge { font-size:9px; font-weight:700; text-transform:uppercase; letter-spacing:.04em; color:var(--muted); margin-bottom:1px; }
-    .inv-cal-milestone.achieved .inv-cal-milestone-badge { color:#16a34a; }
+    .inv-cal-milestone.achieved .inv-cal-milestone-badge { color:var(--green); }
     .inv-cal-milestone-val { font-size:11px; font-weight:800; color:var(--ink); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
     .inv-cal-milestone-date { font-size:10px; color:var(--muted); white-space:nowrap; }
-    .inv-cal-milestone.achieved .inv-cal-milestone-date { color:#16a34a; font-weight:600; }
-    .inv-cal-milestone.future .inv-cal-milestone-date { color:#2563eb; }
+    .inv-cal-milestone.achieved .inv-cal-milestone-date { color:var(--green); font-weight:600; }
+    .inv-cal-milestone.future .inv-cal-milestone-date { color:var(--accent); }
     @media(max-width:600px){ .inv-cal-milestones { grid-template-columns:repeat(3,1fr); } }
 
     /* ===================== MONTHLY AGGREGATE CALENDAR VIEW ==================== */
@@ -366,9 +366,9 @@
     .inv-r100k-mult-group { display:flex; flex-direction:column; gap:3px; }
     .inv-r100k-mult-label { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.05em; color:var(--muted); }
     .inv-r100k-mult-row { display:flex; align-items:center; gap:6px; }
-    .inv-r100k-mult-input { width:68px; height:36px; font-size:18px; font-weight:800; color:#2563eb; text-align:center; border:2px solid rgba(37,99,235,.25); border-radius:9px; background:rgba(37,99,235,.04); padding:0 4px; }
-    .inv-r100k-mult-input:focus { outline:none; border-color:#2563eb; background:rgba(37,99,235,.07); }
-    .inv-r100k-mult-unit { font-size:18px; font-weight:800; color:#2563eb; }
+    .inv-r100k-mult-input { width:68px; height:36px; font-size:18px; font-weight:800; color:var(--accent); text-align:center; border:2px solid rgba(37,99,235,.25); border-radius:9px; background:rgba(37,99,235,.04); padding:0 4px; }
+    .inv-r100k-mult-input:focus { outline:none; border-color:var(--accent); background:rgba(37,99,235,.07); }
+    .inv-r100k-mult-unit { font-size:18px; font-weight:800; color:var(--accent); }
     .inv-r100k-legend { display:flex; gap:14px; flex-wrap:wrap; align-items:center; margin-bottom:4px; }
     .inv-r100k-legend-item { display:flex; align-items:center; gap:6px; font-size:11px; color:var(--muted); font-weight:600; }
     .inv-r100k-legend-swatch { width:22px; height:3px; border-radius:2px; flex-shrink:0; }
@@ -380,12 +380,12 @@
     .inv-r100k-cp.future { background:rgba(37,99,235,.04); border-color:rgba(37,99,235,.12); }
     .inv-r100k-cp.no-eta { background:rgba(148,163,184,.05); border-color:rgba(148,163,184,.15); }
     .inv-r100k-cp-pct { font-size:9px; font-weight:700; text-transform:uppercase; letter-spacing:.05em; color:var(--muted); margin-bottom:1px; }
-    .inv-r100k-cp.achieved .inv-r100k-cp-pct { color:#16a34a; }
+    .inv-r100k-cp.achieved .inv-r100k-cp-pct { color:var(--green); }
     .inv-r100k-cp-val { font-size:12px; font-weight:800; color:var(--ink); }
     .inv-r100k-cp-row { font-size:10px; line-height:1.55; }
     .inv-r100k-cp-row.base { color:var(--muted); }
-    .inv-r100k-cp-row.acc { color:#2563eb; font-weight:700; }
-    .inv-r100k-cp-row.saved { color:#16a34a; font-weight:700; }
+    .inv-r100k-cp-row.acc { color:var(--accent); font-weight:700; }
+    .inv-r100k-cp-row.saved { color:var(--green); font-weight:700; }
     @media(max-width:600px){ .inv-r100k-cps { grid-template-columns:repeat(3,1fr); } }
 
     /* Tooltip */
@@ -409,9 +409,9 @@
     .eom2-kpi .kpi-label { font-size:11px; font-weight:700; color:var(--muted); text-transform:uppercase; letter-spacing:.03em; }
     .eom2-kpi .kpi-val { font-size:22px; font-weight:700; color:var(--ink); line-height:1.2; }
     .eom2-kpi .kpi-sub { font-size:11px; color:var(--muted); }
-    .eom2-kpi.positive .kpi-val { color:#16a34a; }
-    .eom2-kpi.negative .kpi-val { color:#dc2626; }
-    .eom2-kpi.accent { background:linear-gradient(135deg,#2563eb 0%,#1d4ed8 100%); border-color:transparent; }
+    .eom2-kpi.positive .kpi-val { color:var(--green); }
+    .eom2-kpi.negative .kpi-val { color:var(--red); }
+    .eom2-kpi.accent { background:linear-gradient(135deg,var(--accent) 0%,var(--accent) 100%); border-color:transparent; }
     .eom2-kpi.accent .kpi-label { color:rgba(255,255,255,.7); }
     .eom2-kpi.accent .kpi-val { color:#fff; }
     .eom2-kpi.accent .kpi-sub { color:rgba(255,255,255,.6); }
@@ -424,8 +424,8 @@
     .eom2-booking-group { margin-bottom:12px; }
     .eom2-booking-group-title { display:flex; justify-content:space-between; gap:10px; align-items:center; font-size:11px; font-weight:700; color:var(--muted); text-transform:uppercase; letter-spacing:.04em; padding:6px 0 4px; border-bottom:1px solid rgba(148,163,184,.15); margin-bottom:6px; }
     .eom2-booking-group-summary { font-size:11px; font-weight:600; text-transform:none; letter-spacing:0; }
-    .eom2-booking-group-summary.pos { color:#16a34a; }
-    .eom2-booking-group-summary.neg { color:#dc2626; }
+    .eom2-booking-group-summary.pos { color:var(--green); }
+    .eom2-booking-group-summary.neg { color:var(--red); }
     .eom2-booking-row { display:flex; align-items:center; gap:10px; padding:6px 0; border-bottom:1px solid rgba(148,163,184,.08); }
     .eom2-booking-row:last-child { border-bottom:none; }
     .eom2-booking-name { flex:1; min-width:120px; font-size:13px; font-weight:500; }
@@ -434,11 +434,11 @@
     .eom2-booking-input { width:130px; }
     .eom2-booking-input input { width:100%; height:34px; text-align:right; font-weight:600; }
     .eom2-booking-delta { min-width:90px; text-align:right; font-size:12px; font-weight:600; }
-    .eom2-booking-delta.pos { color:#16a34a; }
-    .eom2-booking-delta.neg { color:#dc2626; }
+    .eom2-booking-delta.pos { color:var(--green); }
+    .eom2-booking-delta.neg { color:var(--red); }
     .eom2-booking-actions { min-width:30px; text-align:center; }
     .eom2-booking-actions button { background:none; border:none; cursor:pointer; color:var(--muted); font-size:14px; padding:2px 4px; }
-    .eom2-booking-actions button:hover { color:#dc2626; }
+    .eom2-booking-actions button:hover { color:var(--red); }
 
     .eom2-bridge-head { display:flex; justify-content:space-between; align-items:center; gap:8px; flex-wrap:wrap; }
     .eom2-bridge-table td, .eom2-bridge-table th { vertical-align:middle; }
@@ -449,8 +449,8 @@
     .eom2-gainer-item:last-child { border-bottom:none; }
     .eom2-gainer-name { font-weight:500; }
     .eom2-gainer-delta { font-weight:700; }
-    .eom2-gainer-delta.pos { color:#16a34a; }
-    .eom2-gainer-delta.neg { color:#dc2626; }
+    .eom2-gainer-delta.pos { color:var(--green); }
+    .eom2-gainer-delta.neg { color:var(--red); }
 
     .eom-hero {
       margin-top: 16px;
@@ -1075,7 +1075,7 @@
 
     .insight-pill.positive { background: rgba(34, 197, 94, 0.16); color: #166534; border-color: rgba(34, 197, 94, 0.38); }
     .insight-pill.negative { background: rgba(239, 68, 68, 0.16); color: #991b1b; border-color: rgba(239, 68, 68, 0.38); }
-    .insight-pill.info { background: rgba(59, 130, 246, 0.14); color: #1d4ed8; border-color: rgba(59, 130, 246, 0.32); }
+    .insight-pill.info { background: rgba(59, 130, 246, 0.14); color: var(--accent); border-color: rgba(59, 130, 246, 0.32); }
     .insight-pill.warning { background: rgba(249, 115, 22, 0.16); color: #b45309; border-color: rgba(249, 115, 22, 0.32); }
     .insight-pill.is-highlighted { border-color: rgba(37, 99, 235, 0.6); box-shadow: 0 4px 12px rgba(37, 99, 235, 0.18); }
     .eom-mom-auto-card.is-highlighted { box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12); transform: translateY(-1px); }
@@ -2305,12 +2305,12 @@
     .an-kpi-label { font-size:11px; font-weight:700; color:var(--muted); text-transform:uppercase; letter-spacing:.03em; }
     .an-kpi-val { font-size:22px; font-weight:700; line-height:1.2; margin-top:2px; }
     .an-kpi-sub { font-size:11px; color:var(--muted); margin-top:2px; }
-    .an-kpi.accent { background:linear-gradient(135deg,#2563eb 0%,#1d4ed8 100%); border-color:transparent; }
+    .an-kpi.accent { background:linear-gradient(135deg,var(--accent) 0%,var(--accent) 100%); border-color:transparent; }
     .an-kpi.accent .an-kpi-label { color:rgba(255,255,255,.7); }
     .an-kpi.accent .an-kpi-val { color:#fff; }
     .an-kpi.accent .an-kpi-sub { color:rgba(255,255,255,.6); }
-    .an-kpi.green .an-kpi-val { color:#16a34a; }
-    .an-kpi.red .an-kpi-val { color:#dc2626; }
+    .an-kpi.green .an-kpi-val { color:var(--green); }
+    .an-kpi.red .an-kpi-val { color:var(--red); }
 
     .an-cat-bar-row { display:flex; align-items:center; gap:10px; padding:6px 0; border-bottom:1px solid rgba(148,163,184,.08); }
     .an-cat-bar-row:last-child { border-bottom:none; }
@@ -2659,7 +2659,7 @@
     .mom-detail-close:focus-visible {
       outline: none;
       background: rgba(37, 99, 235, 0.18);
-      color: #1d4ed8;
+      color: var(--accent);
       transform: translateY(-1px);
     }
 
@@ -2749,13 +2749,13 @@
 
     .mom-detail-sort button.is-active {
       background: linear-gradient(135deg, rgba(37, 99, 235, 0.16), rgba(37, 99, 235, 0.32));
-      color: #1d4ed8;
+      color: var(--accent);
       box-shadow: 0 10px 18px rgba(37, 99, 235, 0.18);
       transform: translateY(-1px);
     }
 
     .mom-detail-sort button:not(.is-active):hover {
-      color: #1d4ed8;
+      color: var(--accent);
       background: rgba(37, 99, 235, 0.12);
     }
 
@@ -2852,11 +2852,11 @@
     }
 
     .mom-detail-hero-value.positive {
-      color: #16a34a;
+      color: var(--green);
     }
 
     .mom-detail-hero-value.negative {
-      color: #dc2626;
+      color: var(--red);
     }
 
     .mom-detail-hero-value.neutral {
@@ -2869,11 +2869,11 @@
     }
 
     .mom-detail-hero-change.positive {
-      color: #16a34a;
+      color: var(--green);
     }
 
     .mom-detail-hero-change.negative {
-      color: #dc2626;
+      color: var(--red);
     }
 
     .mom-detail-hero-change.neutral {
@@ -4369,12 +4369,12 @@
 
     .mom-detail-daylist-panel[open] > summary {
       margin-bottom: 14px;
-      color: #1d4ed8;
+      color: var(--accent);
     }
 
     .mom-detail-daylist-panel[open] > summary::after {
       content: '▲';
-      color: #1d4ed8;
+      color: var(--accent);
     }
 
     .mom-detail-daylist-section {
@@ -4998,7 +4998,7 @@
               <label class="inv-trade-field">Przeznaczenie<select name="sellDestination"><option value="reinvest">Pula reinwestycyjna</option><option value="budget">Wypłata do budżetu</option></select></label>
               <label class="inv-trade-field grow">Notatka<input name="note" placeholder="np. Take profit, rebalancing" /></label>
               <div class="inv-sell-info" id="inv-sell-preview">Wybierz aktywo i wpisz ilość, aby zobaczyć podgląd transakcji.</div>
-              <button class="btn" type="submit" style="background:#dc2626">Zapisz sprzedaż</button>
+              <button class="btn" type="submit" style="background:var(--red)">Zapisz sprzedaż</button>
             </form>
           </div>
 
@@ -5057,8 +5057,8 @@
             <div class="row" style="justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px">
               <strong>Analityka</strong>
               <div class="inv-analytics-nav" role="tablist">
-                <button type="button" class="inv-analytics-btn is-active" data-inv-panel-btn="hub" style="background:linear-gradient(135deg,#2563eb,#7c3aed);color:#fff;box-shadow:0 4px 16px rgba(37,99,235,.35)">Hub analityczny</button>
-                <button type="button" class="inv-analytics-btn" data-inv-panel-btn="calendar" style="background:linear-gradient(135deg,#0891b2,#2563eb);color:#fff;box-shadow:0 2px 8px rgba(8,145,178,.25)">Kalendarz P&amp;L</button>
+                <button type="button" class="inv-analytics-btn is-active" data-inv-panel-btn="hub" style="background:linear-gradient(135deg,var(--accent),#7c3aed);color:#fff;box-shadow:0 4px 16px rgba(37,99,235,.35)">Hub analityczny</button>
+                <button type="button" class="inv-analytics-btn" data-inv-panel-btn="calendar" style="background:linear-gradient(135deg,#0891b2,var(--accent));color:#fff;box-shadow:0 2px 8px rgba(8,145,178,.25)">Kalendarz P&amp;L</button>
                 <button type="button" class="inv-analytics-btn" data-inv-panel-btn="road100k" data-roadto-nav-btn style="background:linear-gradient(135deg,#7c3aed,#db2777);color:#fff;box-shadow:0 2px 8px rgba(124,58,237,.24)">Road to 100k</button>
               </div>
             </div>
@@ -5227,7 +5227,7 @@
                           <button type="button" class="inv-hub-dep-mode" data-dep-mode="weekly">Tygodniowe</button>
                         </div>
                         <div style="display:flex;align-items:center;gap:5px">
-                          <input type="range" id="inv-hub-dep-range" min="1" max="52" value="12" style="width:70px;accent-color:#2563eb" />
+                          <input type="range" id="inv-hub-dep-range" min="1" max="52" value="12" style="width:70px;accent-color:var(--accent)" />
                           <span class="muted" style="font-size:10px;min-width:40px" id="inv-hub-dep-range-label">12 mies.</span>
                         </div>
                       </div>
@@ -5372,12 +5372,12 @@
           </div>
           <div class="eom2-kpi">
             <span class="kpi-label">Aktywa</span>
-            <span class="kpi-val" id="eom2-kpi-assets" style="color:#16a34a">—</span>
+            <span class="kpi-val" id="eom2-kpi-assets" style="color:var(--green)">—</span>
             <span class="kpi-sub" id="eom2-kpi-assets-sub"></span>
           </div>
           <div class="eom2-kpi">
             <span class="kpi-label">Zobowiązania</span>
-            <span class="kpi-val" id="eom2-kpi-debt" style="color:#dc2626">—</span>
+            <span class="kpi-val" id="eom2-kpi-debt" style="color:var(--red)">—</span>
             <span class="kpi-sub" id="eom2-kpi-debt-sub"></span>
           </div>
         </div>
@@ -5471,11 +5471,11 @@
         <!-- Bottleneck Analysis -->
         <div class="eom2-bottleneck-row">
           <div class="card stack" style="flex:1">
-            <strong style="color:#16a34a">Największe wzrosty</strong>
+            <strong style="color:var(--green)">Największe wzrosty</strong>
             <div id="eom2-top-gainers"></div>
           </div>
           <div class="card stack" style="flex:1">
-            <strong style="color:#dc2626">Wymagają uwagi</strong>
+            <strong style="color:var(--red)">Wymagają uwagi</strong>
             <div id="eom2-top-losers"></div>
           </div>
         </div>
@@ -7635,7 +7635,7 @@
     const status=document.getElementById('inv-refresh-status');
     if(!status) return;
     status.textContent=msg;
-    status.style.color=isError?'#dc2626':'var(--muted)';
+    status.style.color=isError?'var(--red)':'var(--muted)';
   }
 
   function invCorsCandidates(url){
@@ -9251,7 +9251,7 @@
       return {val,frac:f,...invCalMilestoneInfo(arr,val,currentVal,avgDaily)};
     });
 
-    const rc=v=>v>0?'#16a34a':v<0?'#dc2626':'var(--muted)';
+    const rc=v=>v>0?'var(--green)':v<0?'var(--red)':'var(--muted)';
     const sign=v=>v>=0?'+':'';
     const fmtDelta=v=>`${sign(v)}${fmt(v,cur)}`;
 
@@ -9360,7 +9360,7 @@
     if(!tt) return;
     const sign=v=>v>=0?'+':'';
     const fmtD=v=>`${sign(v)}${fmt(v,d.cur)}`;
-    const rc=v=>v>0?'#16a34a':v<0?'#dc2626':'var(--muted)';
+    const rc=v=>v>0?'var(--green)':v<0?'var(--red)':'var(--muted)';
 
     let h=`<div class="inv-cal-tooltip-title">Road to ${fmt(d.goal,d.cur)}</div>`;
     h+=`<div class="inv-cal-tooltip-row"><span>Aktualna wartość</span><span class="val">${fmt(d.currentVal,d.cur)}</span></div>`;
@@ -9368,7 +9368,7 @@
     if(!d.done){
       h+=`<div class="inv-cal-tooltip-row"><span>Pozostało do celu</span><span class="val">${fmt(d.remaining,d.cur)}</span></div>`;
     } else {
-      h+=`<div class="inv-cal-tooltip-row"><span>Nadwyżka ponad cel</span><span class="val" style="color:#16a34a">+${fmt(d.currentVal-d.goal,d.cur)}</span></div>`;
+      h+=`<div class="inv-cal-tooltip-row"><span>Nadwyżka ponad cel</span><span class="val" style="color:var(--green)">+${fmt(d.currentVal-d.goal,d.cur)}</span></div>`;
     }
 
     if(d.avgDaily!==null||d.avgWeekly!==null){
@@ -9384,8 +9384,8 @@
 
     if(!d.done&&d.daysToGoal){
       h+=`<hr class="inv-cal-tooltip-sep"><div class="inv-cal-tooltip-sub">Prognoza (wg śr. dziennej)</div>`;
-      h+=`<div class="inv-cal-tooltip-row"><span>Dni do celu</span><span class="val" style="color:#2563eb">~${d.daysToGoal} dni</span></div>`;
-      h+=`<div class="inv-cal-tooltip-row"><span>Tygodni do celu</span><span class="val" style="color:#2563eb">~${d.weeksToGoal} tyg.</span></div>`;
+      h+=`<div class="inv-cal-tooltip-row"><span>Dni do celu</span><span class="val" style="color:var(--accent)">~${d.daysToGoal} dni</span></div>`;
+      h+=`<div class="inv-cal-tooltip-row"><span>Tygodni do celu</span><span class="val" style="color:var(--accent)">~${d.weeksToGoal} tyg.</span></div>`;
       if(d.etaDate) h+=`<div class="inv-cal-tooltip-row"><span>Szacowana data celu</span><span class="val">${d.etaDate}</span></div>`;
     }
 
@@ -9394,14 +9394,14 @@
       for(const cp of d.checkpoints){
         const cpFmtV=cp.val>=1000?(cp.val/1000).toFixed(0)+'k '+d.cur:fmt(cp.val,d.cur);
         if(cp.achieved){
-          h+=`<div class="inv-cal-tooltip-row"><span>${cpFmtV}</span><span class="val" style="color:#16a34a">✓ ${cp.date}</span></div>`;
+          h+=`<div class="inv-cal-tooltip-row"><span>${cpFmtV}</span><span class="val" style="color:var(--green)">✓ ${cp.date}</span></div>`;
         } else if(cp.date){
-          h+=`<div class="inv-cal-tooltip-row"><span>${cpFmtV}</span><span class="val" style="color:#2563eb">~${cp.date}</span></div>`;
+          h+=`<div class="inv-cal-tooltip-row"><span>${cpFmtV}</span><span class="val" style="color:var(--accent)">~${cp.date}</span></div>`;
         }
       }
     }
 
-    if(d.done) h+=`<div style="margin-top:8px;font-weight:700;color:#16a34a;text-align:center">Cel osiągnięty!</div>`;
+    if(d.done) h+=`<div style="margin-top:8px;font-weight:700;color:var(--green);text-align:center">Cel osiągnięty!</div>`;
 
     tt.innerHTML=h;
     tt.style.display='block';
@@ -9892,7 +9892,7 @@
     const prevDate=cell.dataset.prevDate||'';
     const deltaLabel=invCalView==='weekly'?'WoW':(invCalView==='months'?'MoM':'DoD');
 
-    const rc=v=>v>=0?'#16a34a':'#dc2626';
+    const rc=v=>v>=0?'var(--green)':'var(--red)';
     let h=`<div class="inv-cal-tooltip-title">${date}</div>`;
     h+=`<div class="inv-cal-tooltip-row"><span>ROI całkowity</span><span class="val" style="color:${rc(roi)}">${roi>=0?'+':''}${roi.toFixed(2)}%</span></div>`;
     h+=`<div class="inv-cal-tooltip-row"><span>P&L całkowity</span><span class="val" style="color:${rc(pnl)}">${pnl>=0?'+':''}${fmt(pnl,cur)}</span></div>`;

--- a/chart-defaults.js
+++ b/chart-defaults.js
@@ -1,0 +1,104 @@
+/**
+ * chart-defaults.js — LifeOS Unified Chart Configuration
+ * Ładować po Chart.js, przed inicjalizacją wykresów.
+ * Zapewnia spójny wygląd wszystkich wykresów w aplikacji.
+ */
+(function () {
+  if (typeof Chart === 'undefined') return;
+
+  /* ── Typografia ──────────────────────────────────────────── */
+  Chart.defaults.font.family = "'Inter', system-ui, -apple-system, sans-serif";
+  Chart.defaults.font.size   = 12;
+  Chart.defaults.font.weight = '500';
+
+  /* ── Kolory ──────────────────────────────────────────────── */
+  Chart.defaults.color = '#595c5e'; /* var(--muted) */
+
+  /* ── Legenda ─────────────────────────────────────────────── */
+  Chart.defaults.plugins.legend.position = 'bottom';
+  Chart.defaults.plugins.legend.labels.padding      = 16;
+  Chart.defaults.plugins.legend.labels.usePointStyle = true;
+  Chart.defaults.plugins.legend.labels.pointStyleWidth = 10;
+  Chart.defaults.plugins.legend.labels.boxHeight    = 8;
+
+  /* ── Tooltip ─────────────────────────────────────────────── */
+  Chart.defaults.plugins.tooltip.backgroundColor  = '#ffffff';
+  Chart.defaults.plugins.tooltip.borderColor      = '#dadde0'; /* var(--line) */
+  Chart.defaults.plugins.tooltip.borderWidth      = 1;
+  Chart.defaults.plugins.tooltip.titleColor       = '#2c2f31'; /* var(--ink) */
+  Chart.defaults.plugins.tooltip.bodyColor        = '#595c5e'; /* var(--muted) */
+  Chart.defaults.plugins.tooltip.padding          = 10;
+  Chart.defaults.plugins.tooltip.cornerRadius     = 10;
+  Chart.defaults.plugins.tooltip.boxPadding       = 4;
+  Chart.defaults.plugins.tooltip.titleFont        = { weight: '700', size: 12 };
+  Chart.defaults.plugins.tooltip.bodyFont         = { size: 12 };
+
+  /* ── Osie ────────────────────────────────────────────────── */
+  Chart.defaults.scales.linear  = Chart.defaults.scales.linear  || {};
+  Chart.defaults.scales.category = Chart.defaults.scales.category || {};
+
+  /* Siatka osi Y */
+  if (Chart.defaults.scales.linear) {
+    Chart.defaults.scales.linear.grid = {
+      color: 'rgba(218, 221, 224, 0.6)', /* var(--line) @ 60% */
+      drawTicks: false,
+    };
+    Chart.defaults.scales.linear.border = { display: false };
+    Chart.defaults.scales.linear.ticks  = {
+      padding: 8,
+      color: '#595c5e',
+    };
+  }
+
+  /* Oś X — bez siatki pionowej */
+  if (Chart.defaults.scales.category) {
+    Chart.defaults.scales.category.grid   = { display: false };
+    Chart.defaults.scales.category.border = { display: false };
+    Chart.defaults.scales.category.ticks  = {
+      padding: 6,
+      color: '#595c5e',
+    };
+  }
+
+  /* ── Elementy ────────────────────────────────────────────── */
+  Chart.defaults.elements.bar.borderRadius    = 6;
+  Chart.defaults.elements.bar.borderSkipped   = 'bottom';
+
+  Chart.defaults.elements.line.tension        = 0.35;
+  Chart.defaults.elements.line.borderWidth    = 2;
+
+  Chart.defaults.elements.point.radius        = 3;
+  Chart.defaults.elements.point.hoverRadius   = 5;
+  Chart.defaults.elements.point.borderWidth   = 2;
+
+  Chart.defaults.elements.arc.borderWidth     = 2;
+  Chart.defaults.elements.arc.borderColor     = '#ffffff';
+
+  /* ── Animacje ────────────────────────────────────────────── */
+  Chart.defaults.animation.duration = 400;
+  Chart.defaults.animation.easing   = 'easeOutQuart';
+
+  /* ── Paleta kolorów aplikacji (eksportowana globalnie) ───── */
+  window.LIFEOS_CHART_COLORS = {
+    blue:   '#0057c0',
+    green:  '#059669',
+    red:    '#b31b25',
+    orange: '#ea580c',
+    purple: '#5f2bf2',
+    yellow: '#facc15',
+    /* wersje z przezroczystością */
+    blueSoft:   'rgba(0, 87, 192, 0.12)',
+    greenSoft:  'rgba(5, 150, 105, 0.12)',
+    redSoft:    'rgba(179, 27, 37, 0.12)',
+    orangeSoft: 'rgba(234, 88, 12, 0.12)',
+    purpleSoft: 'rgba(95, 43, 242, 0.12)',
+    /* seria 6 kolorów do wykresów wieloliniowych */
+    palette: [
+      '#0057c0', '#059669', '#ea580c', '#5f2bf2', '#b31b25', '#facc15',
+    ],
+    paletteAlpha: [
+      'rgba(0,87,192,0.75)', 'rgba(5,150,105,0.75)', 'rgba(234,88,12,0.75)',
+      'rgba(95,43,242,0.75)', 'rgba(179,27,37,0.75)', 'rgba(250,204,21,0.75)',
+    ],
+  };
+})();

--- a/fuel.html
+++ b/fuel.html
@@ -6,6 +6,7 @@
   <title>LifeOS — Paliwo</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
   <style>
@@ -20,7 +21,7 @@
     }
 
     .fkpi-hero {
-      background: linear-gradient(145deg, #0057c0 0%, #003d8f 100%);
+      background: linear-gradient(145deg, var(--accent) 0%, #003d8f 100%);
       border-radius: 13px;
       padding: 14px 18px;
       display: flex;
@@ -202,7 +203,7 @@
   </style>
 </head>
 <body data-page="fuel">
-  <div class="layout">
+  <div class="app-shell">
     <aside class="sidebar" aria-label="Główna nawigacja">
       <div class="sidebar__header">
         <span class="sidebar__emoji">🧭</span>
@@ -272,17 +273,16 @@
     </aside>
 
     <div class="main">
-      <header class="site-header" role="banner">
-        <div class="site-header__left">
-          <div class="site-header__greeting">
-            <h1 class="site-header__title">Paliwo</h1>
-          </div>
-          <div class="live-badge">
-            <span class="live-dot"></span>
-            Monitoring kosztów paliwa
-          </div>
+      <header class="page-header">
+        <div class="page-header__top">
+          <span class="page-overline">Pojazd</span>
+          <h1 class="page-title">
+            <span class="material-symbols-outlined page-title__icon">local_gas_station</span>
+            <span class="page-title__text">Paliwo</span>
+          </h1>
         </div>
-        <div class="site-header__right" aria-label="Akcje strony">
+        <div class="page-header__actions">
+          <div class="live-badge"><span class="live-dot"></span>Monitoring kosztów</div>
           <button id="import-csv-btn" class="btn soft">Importuj z CSV</button>
           <input type="file" id="csv-file-input" accept=".csv" style="display:none;">
           <button id="export-csv-btn" class="btn soft">Eksportuj do CSV</button>
@@ -461,6 +461,7 @@
   })();
 </script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="chart-defaults.js"></script>
 <script>
 const FUEL_STORAGE_KEY = 'lifeos_fuel_v1';
 const KPI_STORAGE_KEY = 'lifeos_kpis_v1';

--- a/fuel.html
+++ b/fuel.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="pl">
+<html lang="pl" data-theme="light">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -256,6 +256,12 @@
             <a class="sidebar__link" href="house.html" data-page="house">
               <span class="material-symbols-outlined">construction</span>
               <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="investments.html" data-page="investments">
+              <span class="material-symbols-outlined">show_chart</span>
+              <span class="sidebar__label">Inwestycje</span>
             </a>
           </li>
         </ul>

--- a/house.html
+++ b/house.html
@@ -1228,9 +1228,15 @@
           </a>
         </li>
         <li class="sidebar__item">
-          <a class="sidebar__link" href="house.html" data-page="house">
+          <a class="sidebar__link sidebar__link--active" href="house.html" data-page="house">
             <span class="material-symbols-outlined">construction</span>
             <span class="sidebar__label">Budowa</span>
+          </a>
+        </li>
+        <li class="sidebar__item">
+          <a class="sidebar__link" href="investments.html" data-page="investments">
+            <span class="material-symbols-outlined">show_chart</span>
+            <span class="sidebar__label">Inwestycje</span>
           </a>
         </li>
       </ul>

--- a/house.html
+++ b/house.html
@@ -281,7 +281,7 @@
       position: relative;
     }
     .bm-tab:hover { color: var(--bm-ink-2); }
-    .bm-tab.active { color: var(--bm-orange); border-bottom-color: var(--bm-orange); }
+    .bm-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
 
     .bm-tab-badge {
       background: var(--bm-red);

--- a/house.html
+++ b/house.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="pl" data-theme="dark">
+<html lang="pl" data-theme="light">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -10,6 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="chart-defaults.js" defer></script>
   <style>
     /* ========================================================
        BUILD MASTER — DESIGN SYSTEM (Blueprint Noir)
@@ -115,62 +116,6 @@
       flex-direction: column;
       overflow: hidden;
       min-height: 0;
-    }
-
-    /* ── Top Bar ──────────────────────────────────────── */
-    .bm-topbar {
-      background: var(--bm-surface);
-      border-bottom: 1px solid var(--bm-border);
-      padding: 0 28px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      height: 64px;
-      flex-shrink: 0;
-      gap: 16px;
-    }
-
-    .bm-topbar-left {
-      display: flex;
-      align-items: center;
-      gap: 14px;
-    }
-
-    .bm-logo-icon {
-      width: 36px;
-      height: 36px;
-      background: var(--bm-orange-dim);
-      border: 1px solid rgba(249,115,22,.3);
-      border-radius: 8px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 18px;
-    }
-
-    .bm-project-name {
-      font-family: var(--bm-head);
-      font-size: 18px;
-      font-weight: 700;
-      color: var(--bm-ink);
-      letter-spacing: .3px;
-    }
-
-    .bm-project-name small {
-      display: block;
-      font-family: var(--bm-body);
-      font-size: 11px;
-      font-weight: 500;
-      color: var(--bm-orange);
-      letter-spacing: .5px;
-      text-transform: uppercase;
-      margin-top: -2px;
-    }
-
-    .bm-topbar-actions {
-      display: flex;
-      align-items: center;
-      gap: 8px;
     }
 
     /* ── Buttons ──────────────────────────────────────── */
@@ -1149,7 +1094,6 @@
       .bm-kanban-cols { grid-template-columns: 1fr; }
       .bm-form-row    { grid-template-columns: 1fr; }
       .bm-content     { padding: 16px; }
-      .bm-topbar      { padding: 0 16px; }
     }
 
     /* ── Alert box ────────────────────────────────────── */
@@ -1253,30 +1197,31 @@
   <div class="app-main bm-wrap bm-main-bg">
 
     <!-- Top Bar -->
-    <header class="site-header">
-      <div class="site-header__left">
-        <div class="site-header__greeting">
-          <h2 class="site-header__title">BuildMaster Pro</h2>
-          <p style="margin:0;font-size:12px;color:var(--muted);">
-            <small style="font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);">Projekt budowlany</small>
-            <span id="bm-project-display-name" style="display:block;margin-top:2px;">Budowa Domu</span>
-          </p>
-        </div>
-        <div class="live-badge">
-          <span class="live-dot"></span>
-          Live Syncing
-        </div>
+    <header class="page-header">
+      <div class="page-header__top">
+        <span class="page-overline">Budowa</span>
+        <h1 class="page-title">
+          <span class="material-symbols-outlined page-title__icon">construction</span>
+          <span class="page-title__text" id="bm-project-display-name">BuildMaster Pro</span>
+        </h1>
+        <div class="live-badge"><span class="live-dot"></span>Live</div>
       </div>
-      <div class="site-header__right">
-        <div class="header-btn-group">
-          <button class="btn" onclick="bm.openSettingsModal()">Projekt</button>
-          <button class="btn" onclick="bm.exportData()">Eksport</button>
-          <button class="btn" onclick="bm.importData()">Import</button>
-          <button class="btn" onclick="bm.generateReport()">Raport</button>
-        </div>
-        <a href="#" class="header-icon-btn" id="bm-theme-btn" title="Zmień motyw" onclick="bm.toggleTheme(); return false;">
+      <div class="page-header__actions">
+        <button class="btn" onclick="bm.openSettingsModal()">
+          <span class="material-symbols-outlined">settings</span>Projekt
+        </button>
+        <button class="btn" onclick="bm.exportData()">
+          <span class="material-symbols-outlined">download</span>Eksport
+        </button>
+        <button class="btn" onclick="bm.importData()">
+          <span class="material-symbols-outlined">upload</span>Import
+        </button>
+        <button class="btn" onclick="bm.generateReport()">
+          <span class="material-symbols-outlined">article</span>Raport
+        </button>
+        <button class="btn ghost icon-btn" id="bm-theme-btn" title="Zmień motyw" onclick="bm.toggleTheme(); return false;">
           <span class="material-symbols-outlined">dark_mode</span>
-        </a>
+        </button>
       </div>
     </header>
 
@@ -1287,16 +1232,16 @@
 
     <!-- Tab Navigation -->
     <nav class="bm-tabs-bar" id="bm-tabs">
-      <button class="bm-tab active" data-tab="overview">📊 Panel główny</button>
-      <button class="bm-tab" data-tab="timeline">📅 Harmonogram</button>
-      <button class="bm-tab" data-tab="phases">✅ Etapy &amp; Zadania <span class="bm-tab-badge bm-hidden" id="bm-tasks-badge">0</span></button>
-      <button class="bm-tab" data-tab="budget">💰 Budżet</button>
-      <button class="bm-tab" data-tab="simulation">🧮 Symulacja</button>
-      <button class="bm-tab" data-tab="contractors">👷 Wykonawcy</button>
-      <button class="bm-tab" data-tab="materials">🧱 Materiały</button>
-      <button class="bm-tab" data-tab="projects">🏡 Projekty</button>
-      <button class="bm-tab" data-tab="docs">🔗 Linki &amp; Notatki</button>
-      <button class="bm-tab" data-tab="weather">🌤️ Pogoda</button>
+      <button class="bm-tab active" data-tab="overview"><span class="material-symbols-outlined" style="font-size:16px;vertical-align:-3px">dashboard</span> Panel główny</button>
+      <button class="bm-tab" data-tab="timeline"><span class="material-symbols-outlined" style="font-size:16px;vertical-align:-3px">calendar_month</span> Harmonogram</button>
+      <button class="bm-tab" data-tab="phases"><span class="material-symbols-outlined" style="font-size:16px;vertical-align:-3px">check_circle</span> Etapy &amp; Zadania <span class="bm-tab-badge bm-hidden" id="bm-tasks-badge">0</span></button>
+      <button class="bm-tab" data-tab="budget"><span class="material-symbols-outlined" style="font-size:16px;vertical-align:-3px">payments</span> Budżet</button>
+      <button class="bm-tab" data-tab="simulation"><span class="material-symbols-outlined" style="font-size:16px;vertical-align:-3px">calculate</span> Symulacja</button>
+      <button class="bm-tab" data-tab="contractors"><span class="material-symbols-outlined" style="font-size:16px;vertical-align:-3px">engineering</span> Wykonawcy</button>
+      <button class="bm-tab" data-tab="materials"><span class="material-symbols-outlined" style="font-size:16px;vertical-align:-3px">foundation</span> Materiały</button>
+      <button class="bm-tab" data-tab="projects"><span class="material-symbols-outlined" style="font-size:16px;vertical-align:-3px">home</span> Projekty</button>
+      <button class="bm-tab" data-tab="docs"><span class="material-symbols-outlined" style="font-size:16px;vertical-align:-3px">link</span> Linki &amp; Notatki</button>
+      <button class="bm-tab" data-tab="weather"><span class="material-symbols-outlined" style="font-size:16px;vertical-align:-3px">wb_sunny</span> Pogoda</button>
     </nav>
 
     <!-- Scrollable Content Area -->
@@ -1581,7 +1526,7 @@ const PHASE_COLORS = [
 ];
 
 const defaultState = () => ({
-  theme: 'dark',
+  theme: 'light',
   project: {
     name: 'Budowa Domu Jednorodzinnego',
     address: '',

--- a/index.html
+++ b/index.html
@@ -135,6 +135,12 @@
               <span class="sidebar__label">Budowa</span>
             </a>
           </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="investments.html" data-page="investments">
+              <span class="material-symbols-outlined">show_chart</span>
+              <span class="sidebar__label">Inwestycje</span>
+            </a>
+          </li>
         </ul>
       </nav>
 

--- a/inventory.html
+++ b/inventory.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="pl">
+<html lang="pl" data-theme="light">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -195,6 +195,12 @@
             <a class="sidebar__link" href="house.html" data-page="house">
               <span class="material-symbols-outlined">construction</span>
               <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="investments.html" data-page="investments">
+              <span class="material-symbols-outlined">show_chart</span>
+              <span class="sidebar__label">Inwestycje</span>
             </a>
           </li>
         </ul>

--- a/inventory.html
+++ b/inventory.html
@@ -6,6 +6,7 @@
   <title>LifeOS — Magazyn</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
     <style>
@@ -46,24 +47,6 @@
     }
     .table-modern tbody tr:nth-child(even) { background: #f8fafc; }
     .table-modern td { vertical-align: top; }
-    .kpi-card {
-      background: #0f172a;
-      color: #fff;
-      border-radius: 14px;
-      padding: 16px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-      min-height: 120px;
-    }
-    .kpi-card.light {
-      background: var(--surface);
-      color: var(--ink);
-      border: 1px solid var(--line);
-    }
-    .kpi-card .label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; opacity: 0.7; }
-    .kpi-card .value { font-size: 26px; font-weight: 700; }
-    .kpi-card .sub { font-size: 12px; opacity: 0.8; }
     .chart-empty {
       position: absolute;
       inset: 0;
@@ -132,16 +115,13 @@
     
     /* Styles for KPIs in the right rail */
     .right-rail .inventory-kpis {
-      grid-template-columns: 1fr; /* Stack KPIs vertically */
+      grid-template-columns: 1fr;
       margin-top: 0;
-    }
-    .right-rail .kpi-card {
-        margin-bottom: 12px;
     }
   </style>
 </head>
 <body data-page="inventory">
-  <div class="layout">
+  <div class="app-shell">
     <aside class="sidebar" aria-label="Główna nawigacja">
       <div class="sidebar__header">
         <span class="sidebar__emoji">🧭</span>
@@ -211,21 +191,16 @@
     </aside>
 
     <div class="main">
-      <header class="site-header" role="banner">
-        <div class="site-header__left">
-          <div class="site-header__greeting">
-            <h1 class="site-header__title">Magazyn</h1>
-          </div>
-          <div class="live-badge">
-            <span class="live-dot"></span>
-            Stan i rotacja towarów
-          </div>
+      <header class="page-header">
+        <div class="page-header__top">
+          <span class="page-overline">Handel</span>
+          <h1 class="page-title">
+            <span class="material-symbols-outlined page-title__icon">inventory_2</span>
+            <span class="page-title__text">Magazyn</span>
+          </h1>
         </div>
-        <div class="site-header__right" aria-label="Akcje strony">
-          <div class="page-header__badges">
-            <span class="badge">💾 Dane lokalne</span>
-            <span class="badge">📈 Analiza offline</span>
-          </div>
+        <div class="page-header__actions">
+          <div class="live-badge"><span class="live-dot"></span>Stan i rotacja towarów</div>
         </div>
       </header>
 
@@ -407,30 +382,30 @@
         </main>
         <aside class="right-rail">
           <div class="inventory-kpis">
-            <div class="kpi-card light">
-              <div class="label">Towar na stanie</div>
-              <div class="value" id="inv-kpi-stock-count">0</div>
-              <div class="sub" id="inv-kpi-stock-extra">Koszt zakupu: —</div>
+            <div class="kpi-tile">
+              <div class="kpi-tile__overline">Towar na stanie</div>
+              <div class="kpi-tile__value" id="inv-kpi-stock-count">0</div>
+              <div class="kpi-tile__note" id="inv-kpi-stock-extra">Koszt zakupu: —</div>
             </div>
-            <div class="kpi-card light">
-              <div class="label">Wycena (wybrana waluta)</div>
-              <div class="value" id="inv-kpi-stock-worth">—</div>
-              <div class="sub" id="inv-kpi-stock-worth-sub">Śr. koszt i czas w magazynie</div>
+            <div class="kpi-tile">
+              <div class="kpi-tile__overline">Wycena (wybrana waluta)</div>
+              <div class="kpi-tile__value kpi-tile__value--sm" id="inv-kpi-stock-worth">—</div>
+              <div class="kpi-tile__note" id="inv-kpi-stock-worth-sub">Śr. koszt i czas w magazynie</div>
             </div>
-            <div class="kpi-card light">
-              <div class="label">Planowana sprzedaż</div>
-              <div class="value" id="inv-kpi-plan-worth">—</div>
-              <div class="sub" id="inv-kpi-plan-extra">Brak planów sprzedaży</div>
+            <div class="kpi-tile">
+              <div class="kpi-tile__overline">Planowana sprzedaż</div>
+              <div class="kpi-tile__value kpi-tile__value--sm" id="inv-kpi-plan-worth">—</div>
+              <div class="kpi-tile__note" id="inv-kpi-plan-extra">Brak planów sprzedaży</div>
             </div>
-            <div class="kpi-card">
-              <div class="label">Sprzedane pozycje</div>
-              <div class="value" id="inv-kpi-sold-count">0</div>
-              <div class="sub" id="inv-kpi-sold-revenue">Przychód: —</div>
+            <div class="kpi-tile kpi-tile--green">
+              <div class="kpi-tile__overline">Sprzedane pozycje</div>
+              <div class="kpi-tile__value" id="inv-kpi-sold-count">0</div>
+              <div class="kpi-tile__note" id="inv-kpi-sold-revenue">Przychód: —</div>
             </div>
-            <div class="kpi-card">
-              <div class="label">Zrealizowany wynik</div>
-              <div class="value" id="inv-kpi-sold-pnl">—</div>
-              <div class="sub" id="inv-kpi-sold-roi">ROI: —</div>
+            <div class="kpi-tile kpi-tile--accent">
+              <div class="kpi-tile__overline">Zrealizowany wynik</div>
+              <div class="kpi-tile__value kpi-tile__value--sm" id="inv-kpi-sold-pnl">—</div>
+              <div class="kpi-tile__note" id="inv-kpi-sold-roi">ROI: —</div>
             </div>
           </div>
         </aside>
@@ -454,6 +429,7 @@
     })();
   </script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="chart-defaults.js"></script>
   <script>
   // --- Storage & helpers ------------------------------------------------------
   const STORAGE_KEY='lifeos_budget_v4';

--- a/investments.html
+++ b/investments.html
@@ -1,14 +1,16 @@
 <!doctype html>
-<html lang="pl">
+<html lang="pl" data-theme="light">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>LifeOS — Inwestycje (tryb arkusza)</title>
-  <link rel="stylesheet" href="styles.css">
+  <title>LifeOS — Inwestycje</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="chart-defaults.js" defer></script>
   <style>
     /* Minimalny, arkuszowy wygląd */
     .sheet-card { border: 1px solid var(--line); border-radius: 14px; background: var(--card); box-shadow: 0 10px 30px rgba(15,23,42,0.05); }
@@ -60,20 +62,65 @@
   </style>
 </head>
 <body data-page="investments">
-  <div class="layout">
+  <div class="app-shell">
     <aside class="sidebar">
       <div class="sidebar__header"><span class="sidebar__emoji">🧭</span><span class="sidebar__brand">LifeOS</span></div>
       <nav class="sidebar__nav">
         <ul class="sidebar__list">
-          <li class="sidebar__item"><a class="sidebar__link" href="index.html" data-page="dashboard"><span class="sidebar__icon">📊</span><span class="sidebar__label">Dashboard</span></a></li>
-          <li class="sidebar__item"><a class="sidebar__link" href="budget.html" data-page="budget"><span class="sidebar__icon">💰</span><span class="sidebar__label">Budżet</span></a></li>
-          <li class="sidebar__item"><a class="sidebar__link" href="tasks.html" data-page="tasks"><span class="sidebar__icon">✅</span><span class="sidebar__label">Zadania</span></a></li>
-          <li class="sidebar__item"><a class="sidebar__link" href="trainings.html" data-page="trainings"><span class="sidebar__icon">💪</span><span class="sidebar__label">Progres</span></a></li>
-          <li class="sidebar__item"><a class="sidebar__link" href="fuel.html" data-page="fuel"><span class="sidebar__icon">⛽</span><span class="sidebar__label">Paliwo</span></a></li>
-          <li class="sidebar__item"><a class="sidebar__link" href="loan.html" data-page="loan"><span class="sidebar__icon">🏦</span><span class="sidebar__label">Kredyt</span></a></li>
-          <li class="sidebar__item"><a class="sidebar__link" href="inventory.html" data-page="inventory"><span class="sidebar__icon">📦</span><span class="sidebar__label">Magazyn</span></a></li>
-          <li class="sidebar__item"><a class="sidebar__link" href="house.html" data-page="house"><span class="sidebar__icon">🏠</span><span class="sidebar__label">Budowa</span></a></li>
-          <li class="sidebar__item"><a class="sidebar__link active" href="investments.html" data-page="investments"><span class="sidebar__icon">📈</span><span class="sidebar__label">Inwestycje</span></a></li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="index.html" data-page="dashboard">
+              <span class="material-symbols-outlined">dashboard</span>
+              <span class="sidebar__label">Dashboard</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="budget.html" data-page="budget">
+              <span class="material-symbols-outlined">payments</span>
+              <span class="sidebar__label">Budżet</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="tasks.html" data-page="tasks">
+              <span class="material-symbols-outlined">assignment</span>
+              <span class="sidebar__label">Zadania</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="trainings.html" data-page="trainings">
+              <span class="material-symbols-outlined">trending_up</span>
+              <span class="sidebar__label">Progres</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="fuel.html" data-page="fuel">
+              <span class="material-symbols-outlined">local_gas_station</span>
+              <span class="sidebar__label">Paliwo</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="loan.html" data-page="loan">
+              <span class="material-symbols-outlined">credit_card</span>
+              <span class="sidebar__label">Kredyt</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="inventory.html" data-page="inventory">
+              <span class="material-symbols-outlined">inventory_2</span>
+              <span class="sidebar__label">Magazyn</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="house.html" data-page="house">
+              <span class="material-symbols-outlined">construction</span>
+              <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link sidebar__link--active" href="investments.html" data-page="investments">
+              <span class="material-symbols-outlined">show_chart</span>
+              <span class="sidebar__label">Inwestycje</span>
+            </a>
+          </li>
         </ul>
       </nav>
       <div class="sidebar__footer"><strong>Twój cyfrowy dom</strong></div>

--- a/investments.html
+++ b/investments.html
@@ -12,18 +12,13 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="chart-defaults.js" defer></script>
   <style>
-    /* Minimalny, arkuszowy wygląd */
-    .sheet-card { border: 1px solid var(--line); border-radius: 14px; background: var(--card); box-shadow: 0 10px 30px rgba(15,23,42,0.05); }
-    .sheet-card h3 { margin: 0 0 8px; }
-    .kpi-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; }
-    .kpi { padding: 16px; border-radius: 12px; border: 1px solid var(--line); background: linear-gradient(120deg, rgba(59,130,246,0.05), rgba(16,185,129,0.05)); }
-    .kpi .value { font-size: 26px; font-weight: 800; }
-    .kpi .label { color: var(--muted); font-size: 13px; }
+    /* Investments layout */
+    body[data-page="investments"] .content { grid-template-columns: 1fr; }
 
     .table-toolbar { display: flex; flex-wrap: wrap; gap: 8px; justify-content: space-between; align-items: center; margin-bottom: 8px; }
     .filter-tabs { display: flex; gap: 6px; flex-wrap: wrap; }
     .filter-tabs button { border-radius: 10px; border: 1px solid var(--line); background: var(--surface); padding: 8px 12px; cursor: pointer; }
-    .filter-tabs button.active { background: var(--primary-light); color: var(--primary); border-color: var(--primary); }
+    .filter-tabs button.active { background: var(--accent-weak); color: var(--accent); border-color: var(--accent); }
 
     .sheet-table { width: 100%; border-collapse: collapse; }
     .sheet-table th, .sheet-table td { border: 1px solid #e2e8f0; padding: 10px; background: white; }
@@ -41,7 +36,6 @@
     .badge { display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px; border-radius: 10px; background: #f1f5f9; border: 1px solid var(--line); font-size: 12px; }
 
     .chart-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; }
-    .chart-box { padding: 16px; border-radius: 12px; border: 1px solid var(--line); background: white; min-height: 260px; }
 
     .snapshot-row { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; justify-content: space-between; }
     .snapshot-list { display: flex; gap: 8px; flex-wrap: wrap; }
@@ -130,56 +124,54 @@
       <header class="page-header">
         <div class="page-header__top">
           <span class="page-overline">Finanse</span>
-          <h1 class="page-title"><span class="page-title__icon">📈</span><span class="page-title__text">Arkusz inwestycji</span></h1>
+          <h1 class="page-title"><span class="material-symbols-outlined page-title__icon">show_chart</span><span class="page-title__text">Inwestycje</span></h1>
         </div>
         <div class="page-header__actions">
-          <button class="btn" id="snapshot-btn">💾 Zapisz snapshot</button>
-          <button class="btn soft" id="reset-btn">🧹 Wyczyść dane</button>
+          <button class="btn" id="snapshot-btn"><span class="material-symbols-outlined">save</span>Zapisz snapshot</button>
+          <button class="btn soft" id="reset-btn"><span class="material-symbols-outlined">delete_sweep</span>Wyczyść dane</button>
         </div>
       </header>
 
       <div class="content">
         <main class="page-content stack" style="gap: 14px;">
-          <section class="sheet-card" style="padding: 16px;">
-            <div class="kpi-grid">
-              <div class="kpi">
-                <div class="label">Wartość portfela</div>
-                <div class="value" id="kpi-value">0 zł</div>
-                <div class="muted" id="kpi-pnl">PnL: 0 zł</div>
-              </div>
-              <div class="kpi">
-                <div class="label">Wpłaty (BUY)</div>
-                <div class="value" id="kpi-inflows">0 zł</div>
-                <div class="muted">Suma wszystkich zakupów</div>
-              </div>
-              <div class="kpi">
-                <div class="label">Aktywa w portfelu</div>
-                <div class="value" id="kpi-assets">0</div>
-                <div class="muted" id="kpi-activity">Transakcje w tym miesiącu: 0</div>
-              </div>
+          <div class="kpi-grid">
+            <div class="kpi-tile">
+              <div class="kpi-tile__overline">Wartość portfela</div>
+              <div class="kpi-tile__value" id="kpi-value">0 zł</div>
+              <div class="kpi-tile__note" id="kpi-pnl">PnL: 0 zł</div>
             </div>
-          </section>
+            <div class="kpi-tile">
+              <div class="kpi-tile__overline">Wpłaty (BUY)</div>
+              <div class="kpi-tile__value" id="kpi-inflows">0 zł</div>
+              <div class="kpi-tile__note">Suma wszystkich zakupów</div>
+            </div>
+            <div class="kpi-tile">
+              <div class="kpi-tile__overline">Aktywa w portfelu</div>
+              <div class="kpi-tile__value" id="kpi-assets">0</div>
+              <div class="kpi-tile__note" id="kpi-activity">Transakcje w tym miesiącu: 0</div>
+            </div>
+          </div>
 
-          <section class="chart-grid">
-            <div class="chart-box">
+          <div class="chart-grid">
+            <div class="chart-card">
               <div class="snapshot-row">
                 <h3>Historia wartości</h3>
                 <span class="muted">Twórz snapshoty, aby śledzić progres</span>
               </div>
               <canvas id="valueChart" height="160"></canvas>
             </div>
-            <div class="chart-box">
+            <div class="chart-card">
               <h3>Alokacja wg typu</h3>
               <canvas id="allocationChart" height="160"></canvas>
               <div id="top-allocation" class="muted" style="margin-top: 10px;"></div>
             </div>
-            <div class="chart-box">
+            <div class="chart-card">
               <h3>Wpłaty miesięczne</h3>
               <canvas id="inflowChart" height="160"></canvas>
             </div>
-          </section>
+          </div>
 
-          <section class="sheet-card" style="padding: 16px;">
+          <section class="card" style="padding: 16px;">
             <div class="table-toolbar">
               <div class="filter-tabs">
                 <button data-filter="all" class="active">Wszystko</button>

--- a/loan.html
+++ b/loan.html
@@ -173,9 +173,9 @@
     }
 
     .loan-tab-btn.active {
-      background: var(--ink);
-      color: var(--card);
-      border-color: transparent;
+      background: var(--accent-weak);
+      color: var(--accent);
+      border-color: var(--accent);
     }
 
     .loan-tab-panels {
@@ -1081,9 +1081,9 @@
     }
 
     .loan-tab-btn.active {
-      color: #1d4ed8;
-      background: linear-gradient(180deg, rgba(255,255,255,1), rgba(247,250,255,0.96));
-      box-shadow: 0 16px 32px rgba(37,99,235,0.12);
+      color: var(--accent);
+      background: var(--accent-weak);
+      box-shadow: 0 4px 12px rgba(0,87,192,0.12);
       transform: translateY(-1px);
     }
 

--- a/loan.html
+++ b/loan.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
+  <script src="chart-defaults.js"></script>
   <style>
     .grid { display: grid; gap: 14px; }
     .g-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -725,17 +726,14 @@
       background: transparent;
     }
 
-    body[data-page="loan"] .site-header {
-      position: sticky;
-      top: 0;
-      z-index: 20;
+    body[data-page="loan"] .page-header {
       backdrop-filter: blur(16px);
       background: rgba(247, 249, 255, 0.78);
       border-bottom: 1px solid rgba(148, 163, 184, 0.14);
     }
 
-    body[data-page="loan"] .site-header__title {
-      font-size: 1.8rem;
+    body[data-page="loan"] .page-title {
+      font-size: clamp(22px, 3vw, 30px);
       letter-spacing: -0.04em;
     }
 
@@ -1526,6 +1524,8 @@
       color: #94a3b8;
       padding: 2px 0;
     }
+
+    .fintech-rate-inline-badge {
       font-size: 9px;
       font-weight: 800;
       letter-spacing: 0.08em;
@@ -1701,46 +1701,44 @@
       }
     }
 
-  </style>
 
-<style id="loan-v3-overrides">
-  body[data-page="loan"] .loan-chart-grid {
-    grid-template-columns: minmax(0, 1.62fr) minmax(360px, 1.08fr);
-    gap: 20px;
-    align-items: stretch;
-  }
-
-  body[data-page="loan"] .loan-chart-area,
-  body[data-page="loan"] .loan-donut-area {
-    background: linear-gradient(180deg, rgba(255,255,255,0.96) 0%, rgba(248,250,252,0.92) 100%);
-    border: 1px solid rgba(226,232,240,0.9);
-    border-radius: 28px;
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.8);
-  }
-
-  body[data-page="loan"] .loan-chart-area {
-    padding: 18px 18px 10px;
-  }
-
-  body[data-page="loan"] .loan-donut-area {
-    min-height: 318px;
-    padding: 14px;
-  }
-
-  body[data-page="loan"] .loan-donut-area canvas {
-    max-width: 100%;
-  }
-
-  @media (max-width: 1200px) {
     body[data-page="loan"] .loan-chart-grid {
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1.62fr) minmax(360px, 1.08fr);
+      gap: 20px;
+      align-items: stretch;
+    }
+
+    body[data-page="loan"] .loan-chart-area,
+    body[data-page="loan"] .loan-donut-area {
+      background: linear-gradient(180deg, rgba(255,255,255,0.96) 0%, rgba(248,250,252,0.92) 100%);
+      border: 1px solid rgba(226,232,240,0.9);
+      border-radius: 28px;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.8);
+    }
+
+    body[data-page="loan"] .loan-chart-area {
+      padding: 18px 18px 10px;
     }
 
     body[data-page="loan"] .loan-donut-area {
-      min-height: 300px;
+      min-height: 318px;
+      padding: 14px;
     }
-  }
-</style>
+
+    body[data-page="loan"] .loan-donut-area canvas {
+      max-width: 100%;
+    }
+
+    @media (max-width: 1200px) {
+      body[data-page="loan"] .loan-chart-grid {
+        grid-template-columns: 1fr;
+      }
+      body[data-page="loan"] .loan-donut-area {
+        min-height: 300px;
+      }
+    }
+
+  </style>
 
 </head>
 <body data-page="loan">
@@ -1815,19 +1813,18 @@
     </aside>
 
     <div class="main">
-      <header class="site-header" role="banner">
-        <div class="site-header__left">
-          <div class="site-header__greeting">
-            <h1 class="site-header__title">Kredyt</h1>
-          </div>
-          <div class="live-badge">
-            <span class="live-dot"></span>
-            Monitoring spłaty kredytu
-          </div>
+      <header class="page-header">
+        <div class="page-header__top">
+          <span class="page-overline">Finanse</span>
+          <h1 class="page-title">
+            <span class="material-symbols-outlined page-title__icon">credit_card</span>
+            <span class="page-title__text">Kredyt</span>
+          </h1>
         </div>
-        <div class="site-header__right" aria-label="Akcje strony">
-          <button class="btn soft" id="settings-btn" style="display: none;">⚙️ Ustawienia</button>
-          <button class="btn primary" id="add-payment-btn" style="display: none;">+ Dodaj spłatę</button>
+        <div class="page-header__actions">
+          <div class="live-badge"><span class="live-dot"></span>Monitoring spłaty</div>
+          <button class="btn soft" id="settings-btn" style="display: none;"><span class="material-symbols-outlined">settings</span>Ustawienia</button>
+          <button class="btn primary" id="add-payment-btn" style="display: none;"><span class="material-symbols-outlined">add</span>Dodaj spłatę</button>
         </div>
       </header>
 

--- a/loan.html
+++ b/loan.html
@@ -1745,7 +1745,7 @@
 </head>
 <body data-page="loan">
 
-  <div class="layout">
+  <div class="app-shell">
     <aside class="sidebar" aria-label="Główna nawigacja">
       <div class="sidebar__header">
         <span class="sidebar__emoji">🧭</span>
@@ -1799,6 +1799,12 @@
             <a class="sidebar__link" href="house.html" data-page="house">
               <span class="material-symbols-outlined">construction</span>
               <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="investments.html" data-page="investments">
+              <span class="material-symbols-outlined">show_chart</span>
+              <span class="sidebar__label">Inwestycje</span>
             </a>
           </li>
         </ul>

--- a/styles.css
+++ b/styles.css
@@ -3197,3 +3197,168 @@ tbody tr:hover {
   display: flex;
   align-items: center;
 }
+
+/* ============================================================
+   UNIFIED COMPONENTS — LifeOS Design System
+   Dodane w ramach unifikacji UI (Faza 0)
+   ============================================================ */
+
+/* ── Module Tabs (sticky tab bar dla każdej zakładki) ──────── */
+.module-tabs {
+  position: sticky;
+  top: 0;
+  z-index: 8;
+  background: var(--bg);
+  padding: 0;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 0;
+  /* Nadpisuje domyślny .tabs który nie jest sticky */
+}
+
+/* ── KPI Grid + Tile ───────────────────────────────────────── */
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.kpi-tile {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition);
+}
+
+.kpi-tile:hover {
+  box-shadow: var(--shadow);
+}
+
+.kpi-tile__overline {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+}
+
+.kpi-tile__value {
+  font-size: 26px;
+  font-weight: 800;
+  color: var(--ink);
+  line-height: 1.1;
+}
+
+.kpi-tile__value--sm {
+  font-size: 20px;
+}
+
+.kpi-tile__note {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.kpi-tile__note .up   { color: var(--green); font-weight: 600; }
+.kpi-tile__note .down { color: var(--red);   font-weight: 600; }
+
+/* Wariant akcentowany (ciemne tło) */
+.kpi-tile--accent {
+  background: var(--accent);
+  border-color: transparent;
+  box-shadow: 0 4px 16px hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.28);
+}
+
+.kpi-tile--accent .kpi-tile__overline,
+.kpi-tile--accent .kpi-tile__note { color: rgba(255, 255, 255, 0.65); }
+
+.kpi-tile--accent .kpi-tile__value { color: #fff; }
+
+/* Wariant z kolorowym lewym bordem */
+.kpi-tile--green  { border-left: 3px solid var(--green); }
+.kpi-tile--red    { border-left: 3px solid var(--red); }
+.kpi-tile--orange { border-left: 3px solid var(--orange); }
+
+/* ── Chart Card ────────────────────────────────────────────── */
+.chart-card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  transition: box-shadow var(--transition);
+}
+
+.chart-card:hover {
+  box-shadow: var(--shadow);
+}
+
+.chart-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.chart-card__title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin: 0;
+}
+
+.chart-card__subtitle {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--ink);
+  margin: 2px 0 0;
+}
+
+.chart-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.chart-card__canvas-wrap {
+  position: relative;
+  min-height: 220px;
+}
+
+/* ── Dashboard Section (wrapper dla dashboard tab) ─────────── */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 14px;
+}
+
+.dash-col-8  { grid-column: span 8; }
+.dash-col-6  { grid-column: span 6; }
+.dash-col-4  { grid-column: span 4; }
+.dash-col-12 { grid-column: span 12; }
+
+@media (max-width: 1100px) {
+  .dash-col-8, .dash-col-6 { grid-column: span 12; }
+  .dash-col-4 { grid-column: span 6; }
+}
+
+@media (max-width: 700px) {
+  .dash-col-4 { grid-column: span 12; }
+  .kpi-grid   { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* ── Tab panel visibility (shared JS convention) ───────────── */
+.tab-panel          { display: none; }
+.tab-panel.is-active { display: block; }
+.tab-panel--flex.is-active { display: flex; flex-direction: column; gap: 16px; }

--- a/tasks.html
+++ b/tasks.html
@@ -11,70 +11,54 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <style>
-    /* ═══════════════════════════════════════════════════════
-       FINTECH DESIGN SYSTEM — LifeOS Work Hub
-       Inspired by Editorial CRM palette & layout patterns
-    ═══════════════════════════════════════════════════════ */
+    /* ── Work Hub: lokalne tokeny uzupełniające globalny design system ──────────
+       Globalne tokeny (--accent, --bg, --card, --ink, --muted, --line,
+       --green, --red, --purple, --shadow-*, --radius-*) dziedziczone ze styles.css.
+       Tu definiujemy TYLKO to, czego w globalnym systemie nie ma.
+    ─────────────────────────────────────────────────────────────────────────── */
     :root {
-      /* === BRAND PALETTE (from Editorial CRM) === */
-      --blue:        #0057c0;
-      --blue-dim:    #004ba9;
-      --blue-bg:     #bfd1ff;
-      --blue-tint:   #f0f4ff;
-      --purple:      #5f2bf2;
-      --purple-bg:   #b5a4ff;
-      --purple-tint: #f6f3ff;
-      --red:         #b31b25;
-      --red-bg:      #ffe3e2;
-      --red-tint:    #fff0f0;
-      --green:       #0a7c52;
-      --green-bg:    #d1f5e8;
-      --green-tint:  #edfaf4;
-      --amber:       #a05c00;
-      --amber-bg:    #ffe8b5;
-      --amber-tint:  #fff8e8;
+      /* Aliasy → globalne tokeny (dla kompatybilności z istniejącym kodem) */
+      --blue:       var(--accent);
+      --blue-dim:   var(--primary-dark);
+      --red-bg:     var(--red-soft);
 
-      /* === SURFACE SYSTEM === */
-      --bg:      #f5f6f8;
-      --card:    #ffffff;
-      --surf-lo: #eff1f3;
+      /* Warianty kolorów nieuznane globalnie */
+      --blue-bg:    hsl(214 100% 87%);
+      --blue-tint:  hsl(214 100% 97%);
+      --purple-bg:  hsl(265 100% 80%);
+      --purple-tint:#f6f3ff;
+      --red-tint:   #fff0f0;
+      --green-bg:   #d1f5e8;
+      --green-tint: #edfaf4;
+      --amber:      #a05c00;
+      --amber-bg:   #ffe8b5;
+      --amber-tint: #fff8e8;
+
+      /* Powierzchnie → aliasy globalne */
+      --surf-lo: var(--surface);
       --surf:    #e6e8eb;
-      --surf-hi: #dadde0;
-      --line:    #e0e3e5;
+      --surf-hi: var(--line);
       --line2:   #c8cdd2;
-      --outline: #757779;
+      --muted2:  #888b8d;
+      --ink2:    var(--ink);
 
-      /* === TEXT === */
-      --ink:    #2c2f31;
-      --ink2:   #1a1d1f;
-      --muted:  #595c5e;
-      --muted2: #888b8d;
+      /* Priorytety */
+      --prio-high-bg: var(--red-soft);   --prio-high-c: var(--red);
+      --prio-med-bg:  var(--amber-bg);   --prio-med-c:  var(--amber);
+      --prio-low-bg:  var(--surface);    --prio-low-c:  var(--muted);
 
-      /* === SEMANTIC === */
-      --accent:      var(--blue);
-      --accent-h:214; --accent-s:93%; --accent-l:37%;
-      --prio-high-bg: var(--red-bg);   --prio-high-c: var(--red);
-      --prio-med-bg:  var(--amber-bg); --prio-med-c:  var(--amber);
-      --prio-low-bg:  var(--surf-lo);  --prio-low-c:  var(--muted);
+      /* Cienie → globalne tokeny */
+      --sh-xs: var(--shadow-sm);
+      --sh-sm: var(--shadow-sm);
+      --sh:    var(--shadow);
+      --sh-md: var(--shadow-md);
 
-      /* === SHADOWS === */
-      --sh-xs: 0 1px 3px rgb(0 0 0/.06);
-      --sh-sm: 0 2px 8px -1px rgb(0 0 0/.08), 0 0 1px rgb(0 0 0/.04);
-      --sh:    0 4px 20px -4px rgb(0 0 0/.12), 0 0 1px rgb(0 0 0/.06);
-      --sh-md: 0 12px 40px -8px rgb(0 0 0/.18), 0 0 1px rgb(0 0 0/.08);
-
-      /* === RADII === */
-      --r-xs: 6px; --r-sm: 10px; --r: 14px; --r-lg: 20px; --r-xl: 24px;
-    }
-
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      background: var(--bg);
-      color: var(--ink);
-      font-family: 'Inter', system-ui, sans-serif;
-      font-size: 13px;
-      line-height: 1.5;
-      -webkit-font-smoothing: antialiased;
+      /* Promienie → globalne tokeny */
+      --r-xs: 6px;
+      --r-sm: 10px;
+      --r:    var(--radius);
+      --r-lg: var(--radius-lg);
+      --r-xl: var(--radius-xl);
     }
 
     /* ── LAYOUT FIXES ── */
@@ -93,34 +77,12 @@
     .muted { color: var(--muted); }
     .small { font-size: 11px; }
 
-    /* ── CARD ── */
-    .card {
-      background: var(--card);
-      border-radius: var(--r-xl);
-      border: 1px solid var(--line);
-      box-shadow: var(--sh-sm);
-    }
-
-    /* ── BUTTONS ── */
-    .btn {
-      display: inline-flex; align-items: center; justify-content: center; gap: 6px;
-      border-radius: var(--r-sm); padding: 8px 16px;
-      border: 1.5px solid var(--line2);
-      background: var(--card); color: var(--ink);
-      cursor: pointer; font-weight: 700; font-size: 11px; letter-spacing: .3px;
-      font-family: inherit; white-space: nowrap; user-select: none;
-      transition: background .15s, transform .12s, box-shadow .15s, border-color .15s;
-    }
-    .btn:hover { background: var(--surf-lo); transform: translateY(-1px); box-shadow: var(--sh-xs); }
-    .btn:active { transform: translateY(0); }
-    .btn.primary { background: var(--blue); color: #fff; border-color: transparent; box-shadow: 0 2px 10px rgb(0 87 192/.3); }
-    .btn.primary:hover { background: var(--blue-dim); box-shadow: 0 4px 16px rgb(0 87 192/.38); }
-    .btn.ghost { background: transparent; border-color: transparent; color: var(--muted); }
-    .btn.ghost:hover { background: var(--surf-lo); border-color: var(--line); color: var(--ink); }
-    .btn.danger { background: var(--red-tint); border-color: var(--red-bg); color: var(--red); }
-    .btn.danger:hover { background: var(--red-bg); }
-    .btn.sm { padding: 5px 11px; font-size: 10px; border-radius: var(--r-xs); }
-    .btn.xs { padding: 3px 7px; font-size: 9px; border-radius: 5px; }
+    /* ── BUTTONS: tylko rozszerzenia globalne ── */
+    /* (.btn, .btn.primary, .btn.ghost — z styles.css) */
+    .btn.danger { background: var(--red-tint); border-color: var(--red-soft); color: var(--red); }
+    .btn.danger:hover { background: var(--red-soft); }
+    .btn.sm { padding: 5px 11px; font-size: 11px; border-radius: var(--r-xs); }
+    .btn.xs { padding: 3px 7px;  font-size: 9px;  border-radius: 5px; }
 
     /* ── ICON BADGE ── */
     .ib { width:36px; height:36px; border-radius:var(--r-sm); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
@@ -597,7 +559,7 @@
   </style>
 </head>
 <body data-page="tasks">
-<div class="layout">
+<div class="app-shell">
   <aside class="sidebar">
     <div class="sidebar__header"><span class="sidebar__emoji">🧭</span><span class="sidebar__brand">LifeOS</span></div>
     <nav class="sidebar__nav"><ul class="sidebar__list">
@@ -615,14 +577,16 @@
   </aside>
 
   <div class="main">
-    <header class="site-header">
-      <div class="site-header__left">
-        <div class="site-header__greeting">
-          <h1 class="site-header__title">Work Hub</h1>
-        </div>
-        <div class="live-badge"><span class="live-dot"></span>Live</div>
+    <header class="page-header">
+      <div class="page-header__top">
+        <span class="page-overline">Praca</span>
+        <h1 class="page-title">
+          <span class="material-symbols-outlined page-title__icon">assignment</span>
+          <span class="page-title__text">Work Hub</span>
+        </h1>
       </div>
-      <div class="site-header__right">
+      <div class="page-header__actions">
+        <div class="live-badge"><span class="live-dot"></span>Live</div>
         <button class="btn primary" id="btn-add">
           <span class="material-symbols-outlined" style="font-size:15px">add</span>Dodaj
         </button>

--- a/tasks.html
+++ b/tasks.html
@@ -61,10 +61,12 @@
       --r-xl: var(--radius-xl);
     }
 
-    /* ── LAYOUT FIXES ── */
-    .main { flex: 1; min-width: 0; width: 0; }
-    .content { width: 100%; max-width: 100%; }
-    .page-content { width: 100%; max-width: 100% !important; }
+    /* ── LAYOUT FIXES ──
+       .main  → globalny (flex column, bez width:0)
+       .content → override dwukolumnowego gridu; tasks używa pełnej szerokości
+    */
+    .content { grid-template-columns: 1fr; }
+    .page-content { width: 100%; }
 
     /* ── ANIMATIONS ── */
     @keyframes fadeUp  { from { opacity:0; transform:translateY(14px) } to { opacity:1; transform:translateY(0) } }

--- a/tasks.html
+++ b/tasks.html
@@ -136,25 +136,27 @@
     .seg-item:hover { color:var(--ink); }
     .seg-item.active { background:var(--card); color:var(--ink); box-shadow:var(--sh-xs); }
 
-    /* ── MODULE NAV — pill style ── */
+    /* ── MODULE NAV — flat underline tabs ── */
     .module-nav {
-      display:flex; gap:3px; padding:5px;
+      display:flex; gap:2px;
+      border-bottom:1px solid var(--line);
       margin-bottom:24px;
-      background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl);
-      box-shadow:var(--sh-sm);
-      position:sticky; top:0; z-index:100; overflow-x:auto;
+      background:transparent;
+      position:sticky; top:64px; z-index:100; overflow-x:auto;
+      background:var(--bg);
     }
     .mod-tab {
       display:flex; align-items:center; gap:6px;
-      padding:9px 18px; border-radius:16px;
-      cursor:pointer; font-weight:800; font-size:10px; letter-spacing:.5px; text-transform:uppercase;
-      color:var(--muted2); background:transparent; border:1.5px solid transparent;
-      transition:all .18s ease; white-space:nowrap; flex-shrink:0;
+      padding:10px 16px 11px;
+      cursor:pointer; font-weight:700; font-size:12px; letter-spacing:.2px;
+      color:var(--muted2); background:transparent; border:none;
+      border-bottom:2px solid transparent; margin-bottom:-1px;
+      transition:color .15s, border-color .15s; white-space:nowrap; flex-shrink:0;
     }
     .mod-tab .material-symbols-outlined { font-size:16px; line-height:1; }
-    .mod-tab:hover { background:var(--surf-lo); color:var(--ink); }
-    .mod-tab.active { background:var(--blue); color:#fff; box-shadow:0 3px 12px rgb(0 87 192/.28); }
-    .mod-tab.active .material-symbols-outlined { color:#fff; }
+    .mod-tab:hover { color:var(--ink); }
+    .mod-tab.active { color:var(--blue); border-bottom-color:var(--blue); font-weight:800; }
+    .mod-tab.active .material-symbols-outlined { color:var(--blue); }
     .module { display:none; }
     .module.active { display:block; animation:fadeUp .22s ease-out; }
 
@@ -169,27 +171,6 @@
     .ov-grid { display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:16px; }
     @media(max-width:900px){.ov-grid{grid-template-columns:1fr}}
 
-    /* Stats bento — like Editorial CRM */
-    .bento-row { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:14px; margin-bottom:20px; }
-    @media(max-width:1100px){.bento-row{grid-template-columns:repeat(2,1fr)}}
-    .bento {
-      background:var(--card); border-radius:var(--r-xl); padding:22px;
-      border:1px solid var(--line); box-shadow:var(--sh-sm);
-      transition:transform .2s, box-shadow .2s; position:relative; overflow:hidden;
-    }
-    .bento:hover { transform:translateY(-3px); box-shadow:var(--sh); }
-    .bento-top { display:flex; align-items:flex-start; justify-content:space-between; margin-bottom:18px; }
-    .bento-val { font-size:34px; font-weight:900; line-height:1; letter-spacing:-2px; font-variant-numeric:tabular-nums; }
-    .bento-lbl { font-size:10px; font-weight:800; text-transform:uppercase; letter-spacing:.8px; color:var(--muted2); margin-top:7px; }
-    .bento-sub { font-size:11px; font-weight:700; display:flex; align-items:center; gap:4px; margin-top:10px; color:var(--muted2); }
-    .bento.compact { padding:12px 14px; border-radius:18px; }
-    .bento.compact .bento-top { margin-bottom:8px; }
-    .bento.compact .ib { width:28px; height:28px; border-radius:8px; }
-    .bento.compact .ib .material-symbols-outlined { font-size:15px; }
-    .bento.compact .pill { font-size:8px!important; padding:1px 6px!important; }
-    .bento.compact .bento-val { font-size:22px; letter-spacing:-1px; }
-    .bento.compact .bento-lbl { margin-top:3px; font-size:9px; letter-spacing:.6px; }
-    .bento.compact .bento-sub { margin-top:4px; font-size:10px; }
 
     /* Section card */
     .sec {
@@ -631,50 +612,50 @@
       <!-- ═══════════════════ OVERVIEW ═══════════════════ -->
       <div id="mod-overview" class="module active">
 
-        <!-- BENTO KPI ROW — Editorial CRM style -->
-        <div class="bento-row">
-          <div class="bento compact">
-            <div class="bento-top">
-              <div class="ib blue"><span class="material-symbols-outlined">task_alt</span></div>
-              <span class="pill blue" style="font-size:9px;padding:2px 7px">Aktywne</span>
+        <!-- KPI ROW -->
+        <div class="kpi-grid" style="margin-bottom:20px">
+          <div class="kpi-tile">
+            <div class="kpi-tile__overline">
+              <span class="material-symbols-outlined" style="font-size:14px;vertical-align:-3px;color:var(--accent)">task_alt</span>
+              Otwarte taski
             </div>
-            <div class="bento-val" id="ov-total-open">0</div>
-            <div class="bento-lbl">Otwarte taski</div>
-            <div class="bento-sub">
-              <span class="material-symbols-outlined" style="font-size:13px">group</span>Cały zespół
-            </div>
-          </div>
-          <div class="bento compact">
-            <div class="bento-top">
-              <div class="ib red"><span class="material-symbols-outlined">timer_off</span></div>
-              <span class="pill red" style="font-size:9px;padding:2px 7px">Pilne</span>
-            </div>
-            <div class="bento-val" style="color:var(--red)" id="ov-overdue">0</div>
-            <div class="bento-lbl">Po terminie</div>
-            <div class="bento-sub" style="color:var(--red)">
-              <span class="material-symbols-outlined" style="font-size:13px">warning</span>Wymaga uwagi
+            <div class="kpi-tile__value" id="ov-total-open">0</div>
+            <div class="kpi-tile__note">
+              <span class="material-symbols-outlined" style="font-size:12px;vertical-align:-2px">group</span>
+              Cały zespół
             </div>
           </div>
-          <div class="bento compact">
-            <div class="bento-top">
-              <div class="ib amber"><span class="material-symbols-outlined">event_upcoming</span></div>
-              <span class="pill amber" style="font-size:9px;padding:2px 7px">7 dni</span>
+          <div class="kpi-tile kpi-tile--red">
+            <div class="kpi-tile__overline">
+              <span class="material-symbols-outlined" style="font-size:14px;vertical-align:-3px;color:var(--red)">timer_off</span>
+              Po terminie
             </div>
-            <div class="bento-val" style="color:var(--amber)" id="ov-week">0</div>
-            <div class="bento-lbl">Deadline w tygodniu</div>
-            <div class="bento-sub">
-              <span class="material-symbols-outlined" style="font-size:13px">calendar_today</span>Nadchodzące
+            <div class="kpi-tile__value" style="color:var(--red)" id="ov-overdue">0</div>
+            <div class="kpi-tile__note" style="color:var(--red)">
+              <span class="material-symbols-outlined" style="font-size:12px;vertical-align:-2px">warning</span>
+              Wymaga uwagi
             </div>
           </div>
-          <div class="bento compact">
-            <div class="bento-top">
-              <div class="ib green"><span class="material-symbols-outlined">note_alt</span></div>
-              <span class="pill green" style="font-size:9px;padding:2px 7px">14 dni</span>
+          <div class="kpi-tile kpi-tile--orange">
+            <div class="kpi-tile__overline">
+              <span class="material-symbols-outlined" style="font-size:14px;vertical-align:-3px;color:var(--orange)">event_upcoming</span>
+              Deadline w tygodniu
             </div>
-            <div class="bento-val" style="color:var(--green)" id="ov-notes">0</div>
-            <div class="bento-lbl">Notatki (14 dni)</div>
-            <div class="bento-sub">
-              <span class="material-symbols-outlined" style="font-size:13px">edit_note</span>Wszystkie
+            <div class="kpi-tile__value" style="color:var(--orange)" id="ov-week">0</div>
+            <div class="kpi-tile__note">
+              <span class="material-symbols-outlined" style="font-size:12px;vertical-align:-2px">calendar_today</span>
+              Nadchodzące · 7 dni
+            </div>
+          </div>
+          <div class="kpi-tile kpi-tile--green">
+            <div class="kpi-tile__overline">
+              <span class="material-symbols-outlined" style="font-size:14px;vertical-align:-3px;color:var(--green)">note_alt</span>
+              Notatki (14 dni)
+            </div>
+            <div class="kpi-tile__value" style="color:var(--green)" id="ov-notes">0</div>
+            <div class="kpi-tile__note">
+              <span class="material-symbols-outlined" style="font-size:12px;vertical-align:-2px">edit_note</span>
+              Wszystkie notatki
             </div>
           </div>
         </div>

--- a/tasks.html
+++ b/tasks.html
@@ -155,8 +155,8 @@
     }
     .mod-tab .material-symbols-outlined { font-size:16px; line-height:1; }
     .mod-tab:hover { color:var(--ink); }
-    .mod-tab.active { color:var(--blue); border-bottom-color:var(--blue); font-weight:800; }
-    .mod-tab.active .material-symbols-outlined { color:var(--blue); }
+    .mod-tab.active { color:var(--accent); border-bottom-color:var(--accent); font-weight:800; }
+    .mod-tab.active .material-symbols-outlined { color:var(--accent); }
     .module { display:none; }
     .module.active { display:block; animation:fadeUp .22s ease-out; }
 

--- a/tasks.html
+++ b/tasks.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="pl">
+<html lang="pl" data-theme="light">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -609,6 +609,7 @@
       <li class="sidebar__item"><a class="sidebar__link" href="loan.html" data-page="loan"><span class="material-symbols-outlined">credit_card</span><span class="sidebar__label">Kredyt</span></a></li>
       <li class="sidebar__item"><a class="sidebar__link" href="inventory.html" data-page="inventory"><span class="material-symbols-outlined">inventory_2</span><span class="sidebar__label">Magazyn</span></a></li>
       <li class="sidebar__item"><a class="sidebar__link" href="house.html" data-page="house"><span class="material-symbols-outlined">construction</span><span class="sidebar__label">Budowa</span></a></li>
+      <li class="sidebar__item"><a class="sidebar__link" href="investments.html" data-page="investments"><span class="material-symbols-outlined">show_chart</span><span class="sidebar__label">Inwestycje</span></a></li>
     </ul></nav>
     <div class="sidebar__footer"><strong>Twoje centrum dowodzenia życiem.</strong></div>
   </aside>

--- a/trainings.html
+++ b/trainings.html
@@ -1,6 +1,6 @@
 
 <!doctype html>
-<html lang="pl">
+<html lang="pl" data-theme="light">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -1610,6 +1610,12 @@
             <a class="sidebar__link" href="house.html" data-page="house">
               <span class="material-symbols-outlined">construction</span>
               <span class="sidebar__label">Budowa</span>
+            </a>
+          </li>
+          <li class="sidebar__item">
+            <a class="sidebar__link" href="investments.html" data-page="investments">
+              <span class="material-symbols-outlined">show_chart</span>
+              <span class="sidebar__label">Inwestycje</span>
             </a>
           </li>
         </ul>

--- a/trainings.html
+++ b/trainings.html
@@ -10,8 +10,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet">
-  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script src="chart-defaults.js"></script>
   <style>
 :root {
   --bg-alt: var(--surface);
@@ -27,9 +27,6 @@
   --danger-border: #fecaca;
   --warning-soft: #fffbeb;
   --warning-border: #fde68a;
-  --shadow-sm: 0 12px 30px rgba(15, 23, 42, 0.08);
-  --shadow-lg: 0 28px 60px rgba(15, 23, 42, 0.12);
-  --transition: all .2s ease;
   --gym-color: hsl(265, 65%, 48%);
   --run-color: var(--green);
   --read-color: var(--accent);
@@ -78,8 +75,7 @@
 }
 
 .icon-btn .icon {
-  width: 18px;
-  height: 18px;
+  font-size: 20px;
 }
 
 .icon-btn:hover {
@@ -95,11 +91,10 @@
 }
 
 .btn.icon-btn .icon {
-  width: 18px;
-  height: 18px;
+  font-size: 20px;
 }
 
-.icon { width: 16px; height: 16px; }
+.icon { font-size: 18px; line-height: 1; vertical-align: middle; }
 
 .month-chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; background: var(--primary-soft); color: var(--accent); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; }
 
@@ -266,7 +261,7 @@
   height: 100%;
   color: var(--muted);
 }
-.day-detail-placeholder .icon { width: 40px; height: 40px; color: rgba(148, 163, 184, 0.4); }
+.day-detail-placeholder .icon { font-size: 44px; color: rgba(148, 163, 184, 0.4); }
 
 .day-detail-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
 .day-detail-title h3 { font-size: 18px; font-weight: 700; }
@@ -295,7 +290,7 @@
   border-radius: 12px;
   padding: 10px 12px;
 }
-.vacation-note .icon { width: 18px; height: 18px; color: var(--vacation-color); }
+.vacation-note .icon { font-size: 20px; color: var(--vacation-color); }
 
 .detail-block { display: flex; flex-direction: column; gap: 10px; }
 .detail-block-header { 
@@ -356,7 +351,7 @@
   flex-shrink: 0;
   font-size: 18px;
 }
-.detail-icon .icon { width: 18px; height: 18px; }
+.detail-icon .icon { font-size: 20px; }
 .detail-icon.gym { background: rgba(167, 139, 250, 0.2); color: var(--gym-color); }
 .detail-icon.running { background: rgba(110, 231, 183, 0.3); color: var(--run-color); }
 .detail-icon.reading { background: rgba(147, 197, 253, 0.3); color: var(--read-color); }
@@ -380,7 +375,7 @@
   align-items: center;
   justify-content: center;
 }
-.action-btn .icon { width: 14px; height: 14px; }
+.action-btn .icon { font-size: 16px; }
 .action-btn.primary { background: var(--primary); color: #fff; border-color: var(--primary); }
 .action-btn.success { background: var(--success); color: #fff; border-color: var(--success); }
 .action-btn.danger { background: #fff5f5; color: var(--danger); border-color: transparent; }
@@ -404,7 +399,7 @@
 .planning-banner-info { display: flex; align-items: center; gap: 8px; }
 .planning-banner-info strong { display: block; font-size: 12px; font-weight: 700; color: var(--primary); }
 .planning-banner-info span { display: block; font-size: 11px; color: var(--muted); }
-.planning-banner .icon { color: var(--primary); }
+.planning-banner .icon { color: var(--primary); font-size: 20px; }
 .btn.small { padding: 6px 12px; font-size: 11px; border-radius: 10px; }
 
 
@@ -712,7 +707,7 @@
   background: var(--primary-soft);
 }
 
-.bm-form-toggle .icon { width: 16px; height: 16px; }
+.bm-form-toggle .icon { font-size: 18px; }
 
 .bm-form-toggle.is-open {
   border-color: var(--primary-border);
@@ -827,7 +822,7 @@
   gap: 8px;
 }
 
-.bm-chart-header h4 .icon { width: 18px; height: 18px; color: var(--accent); }
+.bm-chart-header h4 .icon { font-size: 20px; color: var(--accent); }
 
 .bm-chart-toggles {
   display: flex;
@@ -883,7 +878,7 @@
   gap: 8px;
 }
 
-.bm-chart-empty .icon { width: 32px; height: 32px; opacity: 0.3; }
+.bm-chart-empty .icon { font-size: 36px; opacity: 0.3; }
 
 /* Analytics Grid (Insights + Table) */
 .bm-analytics-grid {
@@ -908,7 +903,7 @@
   gap: 8px;
 }
 
-.bm-insights-column > h4 .icon { width: 16px; height: 16px; color: var(--accent); }
+.bm-insights-column > h4 .icon { font-size: 18px; color: var(--accent); }
 
 .bm-insights-list {
   display: flex;
@@ -987,7 +982,7 @@
   gap: 8px;
 }
 
-.bm-table-column > h4 .icon { width: 16px; height: 16px; color: var(--accent); }
+.bm-table-column > h4 .icon { font-size: 18px; color: var(--accent); }
 
 .bm-table-wrapper {
   border: 1px solid var(--line);
@@ -1090,7 +1085,7 @@
   color: #dc2626;
 }
 
-.bm-table .bm-table-actions button .icon { width: 13px; height: 13px; }
+.bm-table .bm-table-actions button .icon { font-size: 15px; }
 
 /* Progress Summary Bar */
 .bm-progress-bar {
@@ -1300,41 +1295,46 @@
   .bm-chart-container { height: 220px; }
 }
 
-/* Sub navigation */
+/* Sub navigation — flat underline tabs */
 .subnav {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin: 8px 0 20px;
+  gap: 2px;
+  border-bottom: 1px solid var(--line);
+  margin: 0 0 24px;
+  background: var(--bg);
+  position: sticky;
+  top: 64px;
+  z-index: 100;
+  overflow-x: auto;
 }
 
 .subnav button {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: var(--surface);
+  padding: 10px 16px 11px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  background: transparent;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 700;
+  letter-spacing: .2px;
   color: var(--muted);
   cursor: pointer;
-  transition: var(--transition);
+  transition: color .15s, border-color .15s;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .subnav button:hover {
-  color: var(--accent);
-  border-color: var(--primary-border);
-  box-shadow: var(--shadow-sm);
+  color: var(--ink);
 }
 
 .subnav button.is-active {
   color: var(--accent);
-  background: var(--primary-soft);
-  border-color: var(--primary-border);
-  box-shadow: var(--shadow-sm);
+  border-bottom-color: var(--accent);
+  font-weight: 800;
 }
 
 .section-panel {
@@ -1418,7 +1418,7 @@
     font-weight: 700;
     font-size: 15px;
 }
-.analytics-title .icon { color: var(--primary); width: 18px; height: 18px; }
+.analytics-title .icon { color: var(--primary); font-size: 20px; }
 
 .analytics-subtitle {
   font-size: 11px;
@@ -1556,7 +1556,7 @@
   </style>
 </head>
 <body data-page="trainings">
-  <div class="layout">
+  <div class="app-shell">
     <aside class="sidebar" aria-label="Główna nawigacja">
       <div class="sidebar__header">
         <span class="sidebar__emoji">🧭</span>
@@ -1626,33 +1626,34 @@
     </aside>
 
     <div class="main">
-      <header class="site-header" role="banner">
-        <div class="site-header__left">
-          <div class="site-header__greeting">
-            <h1 class="site-header__title">Treningi</h1>
-          </div>
-          <div class="live-badge">
-            <span class="live-dot"></span>
-            Progres treningowy
-          </div>
+      <header class="page-header">
+        <div class="page-header__top">
+          <span class="page-overline">Zdrowie</span>
+          <h1 class="page-title">
+            <span class="material-symbols-outlined page-title__icon">trending_up</span>
+            <span class="page-title__text">Progress Hub</span>
+          </h1>
         </div>
-        <div class="site-header__right month-switcher" aria-label="Akcje strony">
-          <button id="prev-month-btn" class="btn ghost icon-btn" aria-label="Poprzedni miesiąc"><i data-lucide="chevron-left" class="icon"></i></button>
-          <div class="month-labels">
-            <span class="month-label" id="current-month-label">--</span>
-            <span class="tiny muted" id="current-month-range">--</span>
+        <div class="page-header__actions">
+          <div class="live-badge"><span class="live-dot"></span>Live</div>
+          <div class="month-switcher" aria-label="Nawigacja miesięczna">
+            <button id="prev-month-btn" class="btn ghost icon-btn" aria-label="Poprzedni miesiąc"><span class="material-symbols-outlined icon">chevron_left</span></button>
+            <div class="month-labels">
+              <span class="month-label" id="current-month-label">--</span>
+              <span class="tiny muted" id="current-month-range">--</span>
+            </div>
+            <span class="chip" id="header-month-chip">--</span>
+            <button id="next-month-btn" class="btn ghost icon-btn" aria-label="Następny miesiąc"><span class="material-symbols-outlined icon">chevron_right</span></button>
+            <button id="today-month-btn" class="btn soft"><span class="material-symbols-outlined icon">today</span>Dzisiaj</button>
           </div>
-          <span class="chip" id="header-month-chip">--</span>
-          <button id="next-month-btn" class="btn ghost icon-btn" aria-label="Następny miesiąc"><i data-lucide="chevron-right" class="icon"></i></button>
-          <button id="today-month-btn" class="btn soft"><i data-lucide="calendar" class="icon"></i>Dzisiaj</button>
         </div>
       </header>
 
       <nav class="subnav" aria-label="Podmenu sekcji">
-        <button type="button" class="is-active" data-section-target="activity-hub"><i data-lucide="calendar-days" class="icon"></i>Dziennik</button>
-        <button type="button" data-section-target="activity-heatmap"><i data-lucide="flame" class="icon"></i>Historia</button>
-        <button type="button" data-section-target="body-metrics"><i data-lucide="activity" class="icon"></i>Log wagi</button>
-        <button type="button" data-section-target="analytics"><i data-lucide="pie-chart" class="icon"></i>Analityka</button>
+        <button type="button" class="is-active" data-section-target="activity-hub"><span class="material-symbols-outlined icon">calendar_month</span>Dziennik</button>
+        <button type="button" data-section-target="activity-heatmap"><span class="material-symbols-outlined icon">local_fire_department</span>Historia</button>
+        <button type="button" data-section-target="body-metrics"><span class="material-symbols-outlined icon">monitor_weight</span>Log wagi</button>
+        <button type="button" data-section-target="analytics"><span class="material-symbols-outlined icon">pie_chart</span>Analityka</button>
       </nav>
 
       <div class="content">
@@ -1676,13 +1677,13 @@
               <div id="calendar-grid" class="calendar-grid"></div>
               <div class="planning-banner" id="planning-banner" aria-live="polite">
                 <div class="planning-banner-info">
-                  <i data-lucide="mouse-pointer-click" class="icon"></i>
+                  <span class="material-symbols-outlined icon">ads_click</span>
                   <div>
                     <strong id="planning-banner-title">Tryb planowania</strong>
                     <span id="planning-banner-meta">Klikaj dni, by dodać ten trening.</span>
                   </div>
                 </div>
-                <button id="stop-planning-btn" class="btn soft small"><i data-lucide="check" class="icon"></i>Zakończ</button>
+                <button id="stop-planning-btn" class="btn soft small"><span class="material-symbols-outlined icon">check</span>Zakończ</button>
               </div>
             </div>
 
@@ -1739,7 +1740,7 @@
             <!-- Collapsible Form -->
             <div class="bm-form-section">
               <button class="bm-form-toggle" id="bm-form-toggle" type="button">
-                <i data-lucide="plus-circle" class="icon"></i>
+                <span class="material-symbols-outlined icon">add_circle</span>
                 Zaloguj dzisiejszy pomiar
               </button>
               <div class="bm-form-content" id="bm-form-content">
@@ -1768,8 +1769,8 @@
                     </label>
                   </div>
                   <div class="bm-form-actions">
-                    <button class="btn" type="submit"><i data-lucide="save" class="icon"></i>Zapisz pomiar</button>
-                    <button class="btn soft" type="button" id="metrics-clear-btn"><i data-lucide="rotate-ccw" class="icon"></i>Wyczysc</button>
+                    <button class="btn" type="submit"><span class="material-symbols-outlined icon">save</span>Zapisz pomiar</button>
+                    <button class="btn soft" type="button" id="metrics-clear-btn"><span class="material-symbols-outlined icon">undo</span>Wyczysc</button>
                   </div>
                 </form>
                 <div id="metrics-feedback" class="metrics-feedback" role="status">Ważysz się codziennie? Idealnie! Wyciągamy tygodniową średnią automatycznie.</div>
@@ -1780,7 +1781,7 @@
             <div class="bm-chart-section">
               <div class="bm-chart-wrapper">
                 <div class="bm-chart-header">
-                  <h4><i data-lucide="trending-up" class="icon"></i>Trend skladu ciala</h4>
+                  <h4><span class="material-symbols-outlined icon">trending_up</span>Trend skladu ciala</h4>
                   <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
                     <div class="bm-chart-toggles" id="bm-chart-toggles"></div>
                     <button type="button" class="bm-chart-toggle" id="bm-normalize-btn" title="Pokaż zmianę nominalną od wartości bazowej">
@@ -1803,12 +1804,12 @@
             <!-- Insights + Table Grid -->
             <div class="bm-analytics-grid">
               <div class="bm-insights-column">
-                <h4><i data-lucide="lightbulb" class="icon"></i>Insighty & Analiza</h4>
+                <h4><span class="material-symbols-outlined icon">lightbulb</span>Insighty & Analiza</h4>
                 <div id="bm-insights-list" class="bm-insights-list"></div>
               </div>
               <div class="bm-table-column">
                 <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">
-                  <h4><i data-lucide="table" class="icon"></i>Historia pomiarow</h4>
+                  <h4><span class="material-symbols-outlined icon">table</span>Historia pomiarow</h4>
                   <div class="bm-table-view-tabs" id="bm-table-view-tabs">
                     <button type="button" class="bm-table-view-tab is-active" data-view="weekly">Śr. tygodniowe</button>
                     <button type="button" class="bm-table-view-tab" data-view="daily">Dziennik</button>
@@ -1871,7 +1872,7 @@
                     <div class="analytics-card">
                         <div class="analytics-card-header">
                             <div class="analytics-title">
-                                <i data-lucide="trending-up" class="icon"></i>
+                                <span class="material-symbols-outlined icon">trending_up</span>
                                 Trend 12 Tygodni
                             </div>
                             <span class="analytics-subtitle">Konsekwencja</span>
@@ -1891,7 +1892,7 @@
                     <div class="analytics-card">
                         <div class="analytics-card-header">
                             <div class="analytics-title">
-                                <i data-lucide="zap" class="icon"></i>
+                                <span class="material-symbols-outlined icon">bolt</span>
                                 Bieżący Tydzień
                             </div>
                             <span class="analytics-subtitle">Balans</span>
@@ -1911,7 +1912,7 @@
                      <div class="analytics-card">
                         <div class="analytics-card-header">
                             <div class="analytics-title">
-                                <i data-lucide="bar-chart-2" class="icon"></i>
+                                <span class="material-symbols-outlined icon">bar_chart</span>
                                 Dyscyplina Miesięczna
                             </div>
                             <span class="analytics-subtitle">Tygodnie Idealne</span>
@@ -1932,7 +1933,7 @@
                     <div class="analytics-card">
                         <div class="analytics-card-header">
                             <div class="analytics-title">
-                                <i data-lucide="calendar-clock" class="icon"></i>
+                                <span class="material-symbols-outlined icon">event</span>
                                 Rytm Tygodnia
                             </div>
                             <span class="analytics-subtitle">Dni Aktywne</span>
@@ -2566,7 +2567,6 @@ function render() {
   if (document.getElementById('analytics').classList.contains('is-active')) {
       renderNewAnalytics();
   }
-  lucide.createIcons();
 }
 
 function renderHeader(monthStats, weekStats, yearStats) {
@@ -2756,11 +2756,10 @@ function renderDayDetail() {
   const container = document.getElementById('day-detail-container');
   if (!selectedDate) {
     container.innerHTML = `<div class="day-detail-placeholder">
-      <i data-lucide="calendar-days" class="icon"></i>
+      <span class="material-symbols-outlined icon">calendar_month</span>
       <strong>Wybierz dzień</strong>
       <p class="muted tiny">Kliknij w datę na kalendarzu, aby zobaczyć szczegóły i zarządzać planem.</p>
     </div>`;
-    lucide.createIcons();
     return;
   }
   ensureDay(selectedDate);
@@ -2777,16 +2776,16 @@ function renderDayDetail() {
           <p id="selected-day-summary"></p>
         </div>
         <div class="day-detail-meta">
-          <button id="plan-vacation-range-btn" class="btn ghost small" title="Zaplanuj dłuższy urlop"><i data-lucide="calendar-plus" class="icon"></i></button>
+          <button id="plan-vacation-range-btn" class="btn ghost small" title="Zaplanuj dłuższy urlop"><span class="material-symbols-outlined icon">calendar_add_on</span></button>
           <button id="toggle-vacation-btn" class="btn ghost small" title="${vacationDay ? 'Usuń urlop' : 'Oznacz jako urlop'}">
-            <i data-lucide="${vacationDay ? 'sun' : 'plane'}" class="icon"></i>
+            <span class="material-symbols-outlined icon">${vacationDay ? 'sunny' : 'flight'}</span>
           </button>
         </div>
       </div>
       <div class="day-detail-body">
         ${vacationDay ? `
           <div id="vacation-note" class="vacation-note">
-            <i data-lucide="plane" class="icon"></i>
+            <span class="material-symbols-outlined icon">flight</span>
             <span>Dzień oznaczony jako urlop — bez oczekiwań treningowych.</span>
           </div>` : ''}
 
@@ -2806,8 +2805,8 @@ function renderDayDetail() {
         </div>
       </div>
       <div class="day-detail-actions">
-        <button id="add-training-btn" class="btn"><i data-lucide="plus" class="icon"></i>Zaplanuj trening</button>
-        <button id="add-extra-btn" class="btn soft"><i data-lucide="sparkles" class="icon"></i>Dodaj aktywność</button>
+        <button id="add-training-btn" class="btn"><span class="material-symbols-outlined icon">add</span>Zaplanuj trening</button>
+        <button id="add-extra-btn" class="btn soft"><span class="material-symbols-outlined icon">auto_awesome</span>Dodaj aktywność</button>
       </div>
     </div>`;
 
@@ -2821,7 +2820,6 @@ function renderDayDetail() {
   document.getElementById('toggle-vacation-btn').addEventListener('click', () => toggleVacationDay(selectedDate));
   document.getElementById('plan-vacation-range-btn').addEventListener('click', showVacationRangeModal);
   document.getElementById('manage-predefined-btn').addEventListener('click', showManagePredefinedExtrasModal);
-  lucide.createIcons();
 }
 
 function updateDaySummary(){
@@ -2871,11 +2869,11 @@ function renderDayActivities(activities) {
         </div>
       </div>
       <div class="detail-actions-inline">
-        ${activity.completed 
-          ? `<button class="action-btn" title="Cofnij ukończenie" data-action="undo-activity"><i data-lucide="rotate-ccw" class="icon"></i></button>` 
-          : `<button class="action-btn success" title="Oznacz jako wykonane" data-action="complete-activity"><i data-lucide="check" class="icon"></i></button>`}
-        ${activity.type !== 'gym' ? `<button class="action-btn" title="Edytuj wynik" data-action="edit-activity"><i data-lucide="edit-3" class="icon"></i></button>` : ''}
-        <button class="action-btn danger" title="Usuń" data-action="delete-activity"><i data-lucide="trash-2" class="icon"></i></button>
+        ${activity.completed
+          ? `<button class="action-btn" title="Cofnij ukończenie" data-action="undo-activity"><span class="material-symbols-outlined icon">undo</span></button>`
+          : `<button class="action-btn success" title="Oznacz jako wykonane" data-action="complete-activity"><span class="material-symbols-outlined icon">check</span></button>`}
+        ${activity.type !== 'gym' ? `<button class="action-btn" title="Edytuj wynik" data-action="edit-activity"><span class="material-symbols-outlined icon">edit</span></button>` : ''}
+        <button class="action-btn danger" title="Usuń" data-action="delete-activity"><span class="material-symbols-outlined icon">delete</span></button>
       </div>
     `;
     item.querySelector('[data-action="complete-activity"]')?.addEventListener('click', () => completeActivity(selectedDate, activity.id));
@@ -2886,7 +2884,6 @@ function renderDayActivities(activities) {
     enableDrag(item, { itemType: 'activity', id: activity.id, sourceDate: selectedDate });
     list.appendChild(item);
   });
-  lucide.createIcons();
 }
 
 function renderDayExtras(extras) {
@@ -2910,9 +2907,9 @@ function renderDayExtras(extras) {
       </div>
       <div class="detail-actions-inline">
         <button class="action-btn ${extra.completed ? '' : 'success'}" title="${extra.completed ? 'Cofnij' : 'Zakończ'}" data-action="toggle-extra">
-            <i data-lucide="${extra.completed ? 'rotate-ccw' : 'check'}" class="icon"></i>
+            <span class="material-symbols-outlined icon">${extra.completed ? 'undo' : 'check'}</span>
         </button>
-        <button class="action-btn danger" title="Usuń" data-action="delete-extra"><i data-lucide="trash-2" class="icon"></i></button>
+        <button class="action-btn danger" title="Usuń" data-action="delete-extra"><span class="material-symbols-outlined icon">delete</span></button>
       </div>
     `;
     item.querySelector('[data-action="toggle-extra"]')?.addEventListener('click', () => toggleExtra(selectedDate, extra.id));
@@ -2921,7 +2918,6 @@ function renderDayExtras(extras) {
     enableDrag(item, { itemType: 'extra', id: extra.id, sourceDate: selectedDate });
     list.appendChild(item);
   });
-  lucide.createIcons();
 }
 
 function renderQuickAddButtons() {
@@ -3229,7 +3225,6 @@ function renderBodyMetrics() {
   renderBMProgressSummary(filtered);
   renderBMInsights(filtered);
   renderBMTable(filtered);
-  lucide.createIcons();
 }
 
 function getMetricStats(entries, key) {
@@ -3343,7 +3338,6 @@ function renderBMChartToggles() {
       if (!anyActive) { bmActiveMetrics[key] = true; return; }
       const filtered = getMetricsForCut(selectedCut);
       renderBMMainChart(filtered);
-      lucide.createIcons();
     });
     container.appendChild(btn);
   });
@@ -3361,7 +3355,6 @@ function renderBMMainChart(filtered) {
       bmNormalized = !bmNormalized;
       const filtered2 = getMetricsForCut(selectedCut);
       renderBMMainChart(filtered2);
-      lucide.createIcons();
     };
   }
 
@@ -3374,7 +3367,7 @@ function renderBMMainChart(filtered) {
     if (bmMainChart) { bmMainChart.destroy(); bmMainChart = null; }
     const canvas = document.getElementById('bm-main-chart');
     if (canvas) canvas.style.display = 'none';
-    container.innerHTML = `<div class="bm-chart-empty"><i data-lucide="bar-chart-3" class="icon"></i><span>Dodaj pomiary z co najmniej 2 tygodni, aby zobaczyc wykres</span></div>`;
+    container.innerHTML = `<div class="bm-chart-empty"><span class="material-symbols-outlined icon">bar_chart</span><span>Dodaj pomiary z co najmniej 2 tygodni, aby zobaczyc wykres</span></div>`;
     return;
   }
 
@@ -3790,8 +3783,8 @@ function renderBMTableDaily(filtered, tbody, thead) {
       <td>${Number.isFinite(fatMass) ? fatMass.toFixed(1) + ' kg' : '--'}</td>
       <td>${Number.isFinite(entry.muscle) ? entry.muscle.toFixed(1) : '--'}</td>
       <td class="bm-table-actions">
-        <button title="Edytuj" data-bm-edit="${entry.id}"><i data-lucide="edit-3" class="icon"></i></button>
-        <button class="danger" title="Usun" data-bm-delete="${entry.id}"><i data-lucide="trash-2" class="icon"></i></button>
+        <button title="Edytuj" data-bm-edit="${entry.id}"><span class="material-symbols-outlined icon">edit</span></button>
+        <button class="danger" title="Usun" data-bm-delete="${entry.id}"><span class="material-symbols-outlined icon">delete</span></button>
       </td>
     </tr>`;
   }).join('');
@@ -4438,7 +4431,7 @@ function showManagePredefinedExtrasModal() {
         
         const deleteBtn = document.createElement('button');
         deleteBtn.className = 'btn ghost';
-        deleteBtn.innerHTML = `<i data-lucide="trash-2" class="icon"></i>`;
+        deleteBtn.innerHTML = `<span class="material-symbols-outlined icon">delete</span>`;
         deleteBtn.style.padding = '4px';
         deleteBtn.style.height = 'auto';
         deleteBtn.onclick = () => {
@@ -4449,7 +4442,6 @@ function showManagePredefinedExtrasModal() {
             const modalInput = document.getElementById('modal-input-container');
             modalInput.innerHTML = '';
             modalInput.appendChild(newContainer);
-            lucide.createIcons();
         };
         item.appendChild(deleteBtn);
         container.appendChild(item);
@@ -4465,10 +4457,7 @@ function showManagePredefinedExtrasModal() {
         customHTML: container,
         buttons: [
             { text: 'Zamknij', class: 'btn', action: 'close' }
-        ],
-        onShow: () => {
-          lucide.createIcons();
-        }
+        ]
     });
     return container;
 }
@@ -4770,7 +4759,6 @@ function setupEventListeners() {
       bmTableView = tab.dataset.view;
       document.querySelectorAll('.bm-table-view-tab').forEach(t => t.classList.toggle('is-active', t === tab));
       renderBMTable(getMetricsForCut(selectedCut));
-      lucide.createIcons();
     });
   });
 


### PR DESCRIPTION
## Summary
Refactor the LifeOS design system to use centralized global design tokens from `styles.css` instead of duplicating token definitions across pages. Modernize component styling with flat underline tabs, updated KPI tiles, and chart card components. Add `chart-defaults.js` for unified Chart.js configuration across all pages.

## Key Changes

### Design System Consolidation
- **tasks.html, trainings.html, investments.html**: Remove duplicate CSS custom properties (colors, shadows, radii) and alias them to global tokens (`--accent`, `--bg`, `--card`, `--ink`, `--muted`, `--line`, `--shadow-*`, `--radius-*`)
- **styles.css**: Add unified component library with `.kpi-grid`, `.kpi-tile`, `.chart-card`, `.module-tabs`, and `.dashboard-grid` classes
- Add `data-theme="light"` attribute to all HTML root elements for theme support

### Component Modernization
- **Module/Sub Navigation**: Replace pill-style buttons with flat underline tabs (border-bottom indicator, sticky positioning at `top: 64px`)
- **KPI Tiles**: Introduce new `.kpi-tile` component with variants (`.kpi-tile--accent`, `.kpi-tile--red`, `.kpi-tile--orange`) replacing old "bento" card pattern
- **Chart Cards**: New `.chart-card` wrapper with header, title, subtitle, and actions slots
- **Page Headers**: Standardize to `.page-header` with `.page-overline`, `.page-title`, and `.page-header__actions` structure

### Chart Configuration
- **chart-defaults.js** (new): Centralized Chart.js defaults for typography, colors, legend, tooltip, axes, and animations
- Export `LIFEOS_CHART_COLORS` palette globally for consistent chart coloring
- Applied to trainings.html and investments.html

### Navigation Updates
- Add "Inwestycje" (Investments) link to sidebar in all pages (tasks, trainings, fuel, house, inventory, loan, budget, index)
- Update sidebar icons from emoji to Material Symbols Outlined
- Rename header from "site-header" to "page-header" for semantic clarity
- Change layout wrapper from `.layout` to `.app-shell`

### Layout Fixes
- Override `.content` grid to single column for full-width task/training pages
- Remove redundant width constraints on `.main`, `.content`, `.page-content`
- Sticky tab positioning adjusted to account for 64px header height

## Implementation Details
- All color aliases maintain backward compatibility with existing component code
- Global tokens inherit from centralized `styles.css` (no duplication)
- Tab styling uses CSS transitions for smooth color/border changes
- KPI grid uses `auto-fit` with 180px minimum for responsive layouts
- Chart defaults use `easeOutQuart` animation for polished feel

https://claude.ai/code/session_01HSpbwQqQKoNnMphwm2Qoth