### PR TITLE
Harmonize UI tokens and layout across LifeOS pages

### DIFF
--- a/house.html
+++ b/house.html
@@ -1228,7 +1228,7 @@
     <header class="site-header">
       <div class="site-header__left">
         <div class="site-header__greeting">
-          <h2 class="site-header__title">BuildMaster Pro</h2>
+          <h2 class="site-header__title">Budowa</h2>
           <p style="margin:0;font-size:12px;color:var(--muted);">
             <small style="font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--accent);">Projekt budowlany</small>
             <span id="bm-project-display-name" style="display:block;margin-top:2px;">Budowa Domu</span>

--- a/house.html
+++ b/house.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="pl" data-theme="dark">
+<html lang="pl" data-theme="light">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>BuildMaster Pro — Centrum Zarządzania Budową</title>
+  <title>LifeOS — Budowa</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
@@ -15,39 +15,39 @@
        BUILD MASTER — DESIGN SYSTEM (Blueprint Noir)
     ======================================================== */
     :root {
-      --bm-bg:          #070C15;
-      --bm-surface:     #0D1524;
-      --bm-card:        #111D2E;
-      --bm-card-hi:     #162234;
-      --bm-border:      #1C2D44;
-      --bm-border-dim:  #152030;
+      --bm-bg:          var(--bg);
+      --bm-surface:     var(--card);
+      --bm-card:        var(--card);
+      --bm-card-hi:     var(--surface);
+      --bm-border:      var(--line);
+      --bm-border-dim:  var(--line);
 
-      --bm-orange:      #F97316;
-      --bm-orange-dim:  rgba(249,115,22,.13);
-      --bm-orange-glow: 0 0 24px rgba(249,115,22,.35);
+      --bm-orange:      var(--accent);
+      --bm-orange-dim:  hsl(214 70% 94%);
+      --bm-orange-glow: 0 0 0 rgba(0,0,0,0);
 
-      --bm-blue:        #60A5FA;
-      --bm-blue-dim:    rgba(96,165,250,.12);
+      --bm-blue:        var(--blue);
+      --bm-blue-dim:    var(--blue-soft);
 
-      --bm-teal:        #2DD4BF;
-      --bm-teal-dim:    rgba(45,212,191,.12);
+      --bm-teal:        #0f766e;
+      --bm-teal-dim:    #ccfbf1;
 
-      --bm-green:       #34D399;
-      --bm-green-dim:   rgba(52,211,153,.12);
+      --bm-green:       var(--green);
+      --bm-green-dim:   var(--green-soft);
 
-      --bm-red:         #F87171;
-      --bm-red-dim:     rgba(248,113,113,.12);
+      --bm-red:         var(--red);
+      --bm-red-dim:     var(--red-soft);
 
-      --bm-yellow:      #FBBF24;
-      --bm-yellow-dim:  rgba(251,191,36,.12);
+      --bm-yellow:      #ca8a04;
+      --bm-yellow-dim:  #fef9c3;
 
-      --bm-purple:      #A78BFA;
-      --bm-purple-dim:  rgba(167,139,250,.12);
+      --bm-purple:      var(--purple);
+      --bm-purple-dim:  #ede9fe;
 
-      --bm-ink:         #E2E8F0;
-      --bm-ink-2:       #94A3B8;
-      --bm-ink-3:       #475569;
-      --bm-ink-4:       #2D3F55;
+      --bm-ink:         var(--ink);
+      --bm-ink-2:       var(--muted);
+      --bm-ink-3:       #64748b;
+      --bm-ink-4:       #cbd5e1;
 
       --bm-head:        'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       --bm-body:        'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -56,31 +56,9 @@
       --bm-r-lg:        12px;
       --bm-r-xl:        18px;
 
-      --bm-shadow:      0 4px 16px rgba(0,0,0,.45);
-      --bm-shadow-lg:   0 12px 40px rgba(0,0,0,.55);
+      --bm-shadow:      var(--shadow-sm);
+      --bm-shadow-lg:   var(--shadow);
       --bm-transition:  all .2s cubic-bezier(.4,0,.2,1);
-    }
-
-    [data-theme="light"] {
-      --bm-bg:          #F0F4F8;
-      --bm-surface:     #FFFFFF;
-      --bm-card:        #FFFFFF;
-      --bm-card-hi:     #F8FAFC;
-      --bm-border:      #E2E8F0;
-      --bm-border-dim:  #F1F5F9;
-      --bm-orange-dim:  rgba(249,115,22,.08);
-      --bm-blue-dim:    rgba(96,165,250,.08);
-      --bm-teal-dim:    rgba(45,212,191,.08);
-      --bm-green-dim:   rgba(52,211,153,.08);
-      --bm-red-dim:     rgba(248,113,113,.08);
-      --bm-yellow-dim:  rgba(251,191,36,.08);
-      --bm-purple-dim:  rgba(167,139,250,.08);
-      --bm-ink:         #0F172A;
-      --bm-ink-2:       #334155;
-      --bm-ink-3:       #64748B;
-      --bm-ink-4:       #CBD5E1;
-      --bm-shadow:      0 2px 8px rgba(0,0,0,.08);
-      --bm-shadow-lg:   0 8px 24px rgba(0,0,0,.12);
     }
 
     /* ── Reset & Base ─────────────────────────────────── */

--- a/styles.css
+++ b/styles.css
@@ -3311,6 +3311,93 @@ tbody tr:hover {
   box-shadow: var(--shadow-sm) !important;
 }
 
+/* global header contract across modules */
+.site-header,
+.page-header,
+.bm-topbar {
+  min-height: var(--topbar-height) !important;
+  padding-top: 10px !important;
+  padding-bottom: 10px !important;
+  border-bottom: 1px solid var(--line) !important;
+  background: var(--card) !important;
+}
+
+/* global table design layer (shared across module-specific table classes) */
+table,
+.table-modern,
+.table-compact,
+.sheet-table,
+.t-table,
+.bm-table,
+.ctbl,
+.inv-hub-table,
+.inv-hub-monthly-table {
+  width: 100% !important;
+  border-collapse: collapse !important;
+  background: var(--card) !important;
+}
+
+thead th,
+.table-modern thead th,
+.table-compact thead th,
+.sheet-table thead th,
+.t-table th,
+.bm-table th,
+.ctbl th,
+.inv-hub-table th,
+.inv-hub-monthly-table th {
+  background: var(--surface) !important;
+  color: var(--muted) !important;
+  font-size: 11px !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.05em !important;
+  text-transform: uppercase !important;
+  border-bottom: 1px solid var(--line) !important;
+}
+
+tbody td,
+.table-modern td,
+.table-compact td,
+.sheet-table td,
+.t-table td,
+.bm-table td,
+.ctbl td,
+.inv-hub-table td,
+.inv-hub-monthly-table td {
+  border-bottom: 1px solid var(--line) !important;
+  color: var(--ink) !important;
+  background: var(--card) !important;
+}
+
+tbody tr:nth-child(even) td,
+.table-modern tbody tr:nth-child(even) td,
+.sheet-table tbody tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--surface) 60%, white 40%) !important;
+}
+
+/* chart containers & card shells */
+.chart-box,
+.fc,
+.loan-chart-area,
+.bm-chart-wrapper,
+.inv-hub-chart-card,
+.loan-progress-card,
+.loan-charts-card,
+.loan-table-card,
+.sheet-card {
+  background: var(--card) !important;
+  border: 1px solid var(--line) !important;
+  border-radius: var(--radius) !important;
+  box-shadow: var(--shadow-sm) !important;
+}
+
+.chart-box canvas,
+.chart-area canvas,
+.loan-chart-area canvas,
+.bm-chart-container canvas {
+  width: 100% !important;
+}
+
 .card,
 .panel,
 .stat-card,

--- a/styles.css
+++ b/styles.css
@@ -3259,6 +3259,58 @@ tbody tr:hover {
   box-shadow: var(--shadow-sm);
 }
 
+/* force-unify module switchers even when page-level <style> defines custom variants */
+.tabs,
+.subnav,
+.bm-tabs-bar,
+.loan-tab-nav,
+.filter-tabs {
+  display: flex !important;
+  align-items: center !important;
+  gap: 10px !important;
+  flex-wrap: wrap !important;
+  border-bottom: 1px solid var(--line) !important;
+  padding: 8px 0 12px !important;
+  margin: 0 0 20px 0 !important;
+}
+
+.tabs .tab,
+.subnav button,
+.bm-tab,
+.loan-tab-btn,
+.filter-tabs button {
+  padding: 8px 14px !important;
+  border-radius: 10px !important;
+  border: 1px solid transparent !important;
+  background: transparent !important;
+  color: var(--muted) !important;
+  font-size: 13px !important;
+  font-weight: 600 !important;
+  line-height: 1.2 !important;
+  cursor: pointer !important;
+  transition: background var(--transition), color var(--transition), border-color var(--transition), box-shadow var(--transition) !important;
+}
+
+.tabs .tab:hover,
+.subnav button:hover,
+.bm-tab:hover,
+.loan-tab-btn:hover,
+.filter-tabs button:hover {
+  background: var(--surface) !important;
+  color: var(--ink) !important;
+}
+
+.tabs .tab.active,
+.subnav button.is-active,
+.bm-tab.active,
+.loan-tab-btn.active,
+.filter-tabs button.active {
+  background: var(--card) !important;
+  border-color: var(--line) !important;
+  color: var(--ink) !important;
+  box-shadow: var(--shadow-sm) !important;
+}
+
 .card,
 .panel,
 .stat-card,

--- a/styles.css
+++ b/styles.css
@@ -3221,9 +3221,42 @@ tbody tr:hover {
 .content,
 .page-content {
   width: 100%;
-  max-width: 1280px;
-  margin: 0 auto;
+  max-width: none;
+  margin: 0;
   padding-inline: clamp(16px, 2.5vw, 28px);
+}
+
+/* unify sub-module tab bars between screens */
+.subnav {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--line);
+  padding: 8px 20px 12px;
+  margin-bottom: 20px;
+}
+
+.subnav button {
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.subnav button:hover {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.subnav button.is-active {
+  background: var(--card);
+  border-color: var(--line);
+  color: var(--ink);
+  box-shadow: var(--shadow-sm);
 }
 
 .card,

--- a/styles.css
+++ b/styles.css
@@ -3197,3 +3197,96 @@ tbody tr:hover {
   display: flex;
   align-items: center;
 }
+
+/* ====================================================
+   UI HARMONIZATION (global cross-module consistency)
+   ==================================================== */
+.layout,
+.app-shell {
+  min-height: 100vh;
+}
+
+.main,
+.app-main {
+  background: var(--bg);
+}
+
+.site-header,
+.page-header {
+  background: var(--card);
+  border-bottom: 1px solid var(--line);
+  min-height: var(--topbar-height);
+}
+
+.content,
+.page-content {
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding-inline: clamp(16px, 2.5vw, 28px);
+}
+
+.card,
+.panel,
+.stat-card,
+.kpi-card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.title,
+h1, h2, h3, h4 {
+  letter-spacing: -0.01em;
+}
+
+.muted,
+.hint,
+.tiny {
+  color: var(--muted);
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  background: var(--card);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 8px 10px;
+  transition: border-color var(--transition), box-shadow var(--transition), background-color var(--transition);
+}
+
+input:hover,
+select:hover,
+textarea:hover {
+  border-color: color-mix(in srgb, var(--line) 60%, var(--accent) 40%);
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: color-mix(in srgb, var(--accent) 80%, white 20%);
+  box-shadow: 0 0 0 3px hsl(var(--accent-h) 90% 70% / 0.2);
+  outline: none;
+}
+
+table {
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+thead th {
+  background: var(--surface);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}


### PR DESCRIPTION
### Motivation
- The project had visual drift across pages and sub-modules (different palettes, spacing, form styles and widths), so the goal is to create a single, modern, consistent UI layer used everywhere. 
- Align typography, card surfaces, spacing and interactive control behavior to reduce cognitive friction and make components interchangeable across pages. 
- Bring the `house.html` module back into the main LifeOS design system so it no longer looks like a separate product skin.

### Description
- Added a global UI harmonization block to `styles.css` that normalizes layout containers (`.layout`, `.app-shell`, `.content`, `.page-content`), max widths, padding and header heights. 
- Standardized shared surface tokens for cards and panels (`.card`, `.panel`, `.kpi-card`, `.stat-card`) and unified box-shadows/borders using existing CSS tokens. 
- Unified form control appearance and behavior (`input`, `select`, `textarea`, `button`) including background, border, radius, hover and focus states and consistent focus ring; also aligned table header styling (`thead th`). 
- Refactored `house.html` to consume the global LifeOS tokens (`--bg`, `--card`, `--line`, `--ink`, etc.), switched its `data-theme` to `light`, and updated the page title to `LifeOS — Budowa` to match the app naming and visual palette.

### Testing
- Ran `git diff --check` which completed successfully. 
- Created a commit (`Harmonize global UI styles across modules`) which succeeded (files changed: `styles.css`, `house.html`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab0a1a0788331bcdbd7da2763aa65)