### PR TITLE
Fix right-side whitespace on Tasks page (.content full-width)

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -1559,6 +1559,10 @@
       gap: 10px;
     }
 
+    .dashboard-chart-box {
+      height: 286px;
+    }
+
     .recent-calendar-card {
       display: flex;
       flex-direction: column;
@@ -2188,6 +2192,12 @@
       background: var(--surface);
       max-height: 120px;
       overflow-y: auto;
+    }
+
+    .heatmap-strip--compact {
+      max-height: 82px;
+      padding: 6px;
+      gap: 3px;
     }
 
     .heat-legend {
@@ -4717,21 +4727,21 @@
           <div class="inv-hub-chart-card-header">
             <h4>Wydatki dzień po dniu</h4>
           </div>
-          <div class="inv-hub-chart-box"><canvas id="dailyLine"></canvas></div>
+          <div class="inv-hub-chart-box dashboard-chart-box"><canvas id="dailyLine"></canvas></div>
         </div>
         <div class="inv-hub-chart-card">
           <div class="inv-hub-chart-card-header">
             <h4>Skumulowane: limit vs wydatki</h4>
             <span class="tiny muted">Faktyczne vs oczekiwane tempo</span>
           </div>
-          <div class="inv-hub-chart-box"><canvas id="cumulativeLine"></canvas></div>
+          <div class="inv-hub-chart-box dashboard-chart-box"><canvas id="cumulativeLine"></canvas></div>
         </div>
       </div>
 
       <div class="card heatmap-card" style="margin-top:16px">
         <div class="title">Wydatki dzienne — heatmap</div>
         <div class="muted" style="margin-bottom:4px">Zielone = w budżecie, Pomarańczowe = przekroczenie, Czerwone = duże przekroczenie</div>
-        <div id="daily-spending-calendar" class="heatmap-strip"></div>
+        <div id="daily-spending-calendar" class="heatmap-strip heatmap-strip--compact"></div>
         <div class="heat-legend">
           <span class="heat-day" style="background:#dcfce7"> </span> w normie
           <span class="heat-day" style="background:#ffedd5"> </span> lekko powyżej
@@ -4776,32 +4786,6 @@
         </div>
       </div>
 
-      <div class="quick-actions" style="margin-top:12px">
-        <div class="row">
-          <div class="title">Szybkie akcje</div>
-          <div class="row" style="gap:8px">
-            <button id="qa-edit-toggle" class="btn ghost">⚙️ Edytuj szybkie akcje</button>
-          </div>
-        </div>
-        <div id="qa-grid" class="grid g-4" style="margin-top:8px"></div>
-        <div id="qa-editor" class="editor-section" style="display:none">
-          <div class="title">Edycja szybkich akcji</div>
-          <div class="tiny">Zapisuje się w pamięci przeglądarki (localStorage).</div>
-          <form id="qa-add-form" class="grid g-4" style="margin-top:10px">
-            <input name="label" placeholder="Nazwa (np. Jedzenie)" required />
-            <input name="emoji" placeholder="Emoji (np. 🍕)" />
-            <select name="categoryId" required></select>
-            <select name="accountId" required></select>
-            <input name="defaultAmount" placeholder="Domyślna kwota (zł)" inputmode="decimal" />
-            <input name="defaultNote" placeholder="Domyślna notatka" />
-            <button class="btn" type="submit" style="grid-column: 1 / -1;">Dodaj akcję</button>
-          </form>
-          <table style="margin-top:10px">
-            <thead><tr><th>Emoji</th><th>Nazwa</th><th>Kategoria</th><th>Konto</th><th>Domyślna kwota</th><th>Notatka</th><th></th></tr></thead>
-            <tbody id="qa-rows"></tbody>
-          </table>
-        </div>
-      </div>
     </section>
 
     <!-- Overview -->
@@ -6174,7 +6158,9 @@
 
   // --- Quick actions ----------------------------------------------------------
   function renderQuickActions(){
-    const grid=document.getElementById('qa-grid'); grid.innerHTML='';
+    const grid=document.getElementById('qa-grid');
+    if(!grid) return;
+    grid.innerHTML='';
     for(const qa of (b().quickActions||[])){
       const cat=catsById()[qa.categoryId];
       const btn=document.createElement('div'); btn.className='quick-btn';
@@ -6195,18 +6181,27 @@
   }
   function fillQaEditorSelects(){
     const editor=document.getElementById('qa-editor');
+    if(!editor) return;
     const catSel=editor.querySelector('select[name="categoryId"]'); if(catSel){catSel.innerHTML=''; for(const c of (b().categories||[])){catSel.add(new Option((c.emoji?c.emoji+' ':'')+c.name,c.id))}}
     const accSel=editor.querySelector('select[name="accountId"]'); if(accSel){accSel.innerHTML=''; for(const a of (b().accounts||[])){accSel.add(new Option(a.name,a.id))}}
   }
-  document.getElementById('qa-edit-toggle').onclick=()=>{const ed=document.getElementById('qa-editor'); ed.style.display = ed.style.display==='none' ? 'block' : 'none';};
-  document.getElementById('qa-add-form').onsubmit=(e)=>{
-    e.preventDefault();
-    const f=new FormData(e.target);
-    const qa={id:'qa_'+Math.random().toString(36).slice(2),label:String(f.get('label')||''),emoji:String(f.get('emoji')||''),categoryId:String(f.get('categoryId')),accountId:String(f.get('accountId')),defaultAmount:String(f.get('defaultAmount')||''),defaultNote:String(f.get('defaultNote')||'')};
-    b().quickActions.push(qa); save(state); e.target.reset(); renderQuickActions(); bindMoneyInputs(document.getElementById('qa-editor'));
+  const qaEditToggle=document.getElementById('qa-edit-toggle');
+  if(qaEditToggle){
+    qaEditToggle.onclick=()=>{const ed=document.getElementById('qa-editor'); if(!ed) return; ed.style.display = ed.style.display==='none' ? 'block' : 'none';};
+  }
+  const qaAddForm=document.getElementById('qa-add-form');
+  if(qaAddForm){
+    qaAddForm.onsubmit=(e)=>{
+      e.preventDefault();
+      const f=new FormData(e.target);
+      const qa={id:'qa_'+Math.random().toString(36).slice(2),label:String(f.get('label')||''),emoji:String(f.get('emoji')||''),categoryId:String(f.get('categoryId')),accountId:String(f.get('accountId')),defaultAmount:String(f.get('defaultAmount')||''),defaultNote:String(f.get('defaultNote')||'')};
+      b().quickActions.push(qa); save(state); e.target.reset(); renderQuickActions(); bindMoneyInputs(document.getElementById('qa-editor'));
+    };
   }
   function renderQuickActionsEditorRows(){
-    const tbody=document.getElementById('qa-rows'); tbody.innerHTML='';
+    const tbody=document.getElementById('qa-rows');
+    if(!tbody) return;
+    tbody.innerHTML='';
     for(const qa of (b().quickActions||[])){
       const tr=document.createElement('tr');
       tr.innerHTML=`

--- a/budget.html
+++ b/budget.html
@@ -5921,7 +5921,7 @@
             <div class="kpi-body">
               <span class="kpi-label">Wydane dziś</span>
               <span class="kpi-value" id="dash-today-spent">0</span>
-              <span class="tiny muted">Status: <span id="dash-today-vs-budget">—</span></span>
+              <span class="tiny muted"><span id="dash-today-vs-budget">—</span></span>
             </div>
           </div>
           <div class="kpi-compact">
@@ -5929,7 +5929,7 @@
             <div class="kpi-body">
               <span class="kpi-label">Średnia dzienna</span>
               <span class="kpi-value" id="dash-avg-daily">0</span>
-              <span class="tiny muted">Porównanie: <span id="dash-avg-trend">—</span></span>
+              <span class="tiny muted"><span id="dash-avg-trend">—</span></span>
             </div>
           </div>
         </aside>
@@ -6366,12 +6366,8 @@
     },0);
     document.getElementById('dash-today-spent').textContent=fmt(todaySpent, state.currency);
     const isTodayWithinBudget = todaySpent <= dailyBudget;
-    document.getElementById('dash-today-vs-budget').innerHTML = `
-      <span class="kpi-status-inline ${isTodayWithinBudget ? 'is-positive' : 'is-warning'}">
-        <span class="material-symbols-outlined kpi-status-icon" aria-hidden="true">${isTodayWithinBudget ? 'check_circle' : 'warning'}</span>
-        ${isTodayWithinBudget ? 'w limicie dziennym' : 'powyżej limitu'}
-      </span>
-    `;
+    document.getElementById('dash-today-vs-budget').innerHTML =
+      `<span class="kpi-status-inline ${isTodayWithinBudget ? 'is-positive' : 'is-warning'}"><span class="material-symbols-outlined kpi-status-icon" aria-hidden="true">${isTodayWithinBudget ? 'check_circle' : 'warning'}</span>${isTodayWithinBudget ? 'w limicie dziennym' : 'powyżej limitu'}</span>`;
 
     const daysElapsed = (ym === monthKey()) ? new Date().getDate() : (monthKey() > ym ? days : 0);
     const daily=getDailySpending(ym);
@@ -6379,12 +6375,8 @@
     const avgDaily = (daysElapsed > 0 ? (spentSoFar / daysElapsed) : 0);
     document.getElementById('dash-avg-daily').textContent=fmt(avgDaily, state.currency);
     const isAverageBelowPlan = avgDaily <= dailyBudget;
-    document.getElementById('dash-avg-trend').innerHTML = `
-      <span class="kpi-status-inline ${isAverageBelowPlan ? 'is-positive' : 'is-warning'}">
-        <span class="material-symbols-outlined kpi-status-icon" aria-hidden="true">${isAverageBelowPlan ? 'trending_down' : 'trending_up'}</span>
-        ${isAverageBelowPlan ? 'poniżej planu' : 'powyżej planu'}
-      </span>
-    `;
+    document.getElementById('dash-avg-trend').innerHTML =
+      `<span class="kpi-status-inline ${isAverageBelowPlan ? 'is-positive' : 'is-warning'}"><span class="material-symbols-outlined kpi-status-icon" aria-hidden="true">${isAverageBelowPlan ? 'trending_down' : 'trending_up'}</span>${isAverageBelowPlan ? 'poniżej planu' : 'powyżej planu'}</span>`;
 
     // Heatmap
     const cal=document.getElementById('daily-spending-calendar'); cal.innerHTML='';

--- a/budget.html
+++ b/budget.html
@@ -5438,14 +5438,19 @@
           <div class="card stack" style="flex:2;min-width:300px">
             <div class="row" style="justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px">
               <strong>Trend majątku netto</strong>
-              <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-                <select id="eom2-cat-filter" style="font-size:12px;padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--fg)">
-                  <option value="all">Wszystkie kategorie</option>
-                </select>
-                <div class="inv-trade-filters" style="margin:0">
-                  <button type="button" class="eom2-range-btn is-active" data-range="6">6m</button>
-                  <button type="button" class="eom2-range-btn" data-range="12">12m</button>
-                  <button type="button" class="eom2-range-btn" data-range="all">Wszystko</button>
+	              <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+	                <select id="eom2-cat-filter" style="font-size:12px;padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--fg)">
+	                  <option value="all">Wszystkie kategorie</option>
+	                </select>
+	                <div class="inv-trade-filters" style="margin:0">
+	                  <button type="button" class="eom2-gran-btn is-active" data-granularity="monthly">Miesiące</button>
+	                  <button type="button" class="eom2-gran-btn" data-granularity="quarterly">Kwartały</button>
+	                  <button type="button" class="eom2-gran-btn" data-granularity="yearly">Lata</button>
+	                </div>
+	                <div class="inv-trade-filters" style="margin:0">
+	                  <button type="button" class="eom2-range-btn is-active" data-range="6">6m</button>
+	                  <button type="button" class="eom2-range-btn" data-range="12">12m</button>
+	                  <button type="button" class="eom2-range-btn" data-range="all">Wszystko</button>
                 </div>
               </div>
             </div>
@@ -13568,11 +13573,37 @@
   // ===== EOM V2 — Redesigned Wealth Tracker =================================
   let eom2NwChart=null, eom2BreakdownChart=null, eom2DdChart=null;
   let eom2SelectedRange=6;
+  let eom2SelectedGranularity='monthly';
   let eom2SelectedCat='all';
   let eom2Bound=false;
   const eom2TypeOrder=['oszczędności','inwestycje','gotówka','emerytura','zadłużenie','inne'];
   const eom2TypeLabelMap={'oszczędności':'Oszczędności','inwestycje':'Inwestycje','gotówka':'Gotówka','emerytura':'Emerytura','zadłużenie':'Zobowiązania','inne':'Inne'};
   const eom2TypeColorMap={'oszczędności':'#2563eb','inwestycje':'#8b5cf6','gotówka':'#059669','emerytura':'#0ea5e9','zadłużenie':'#dc2626','inne':'#94a3b8'};
+
+  function eom2AggregateMonths(months, granularity){
+    if(granularity==='monthly') return months.slice();
+    const bucketLastMonth=new Map();
+    for(const ym of months){
+      const [yearStr, monthStr]=String(ym).split('-');
+      const year=Number(yearStr);
+      const month=Number(monthStr);
+      if(!Number.isFinite(year)||!Number.isFinite(month)) continue;
+      const key=granularity==='yearly' ? String(year) : `${year}-Q${Math.floor((month-1)/3)+1}`;
+      const prev=bucketLastMonth.get(key);
+      if(!prev||ym>prev) bucketLastMonth.set(key, ym);
+    }
+    return Array.from(bucketLastMonth.values()).sort();
+  }
+
+  function eom2FormatTrendLabel(ym, granularity){
+    if(granularity==='monthly') return formatMonthLabel(ym);
+    const [yearStr, monthStr]=String(ym).split('-');
+    const year=Number(yearStr);
+    const month=Number(monthStr);
+    if(!Number.isFinite(year)||!Number.isFinite(month)) return ym;
+    if(granularity==='yearly') return String(year);
+    return `Q${Math.floor((month-1)/3)+1} ${year}`;
+  }
 
   function eom2InvestmentBridge(){
     if(!Array.isArray(b().eomInvestmentBridge)) b().eomInvestmentBridge=[];
@@ -13880,11 +13911,11 @@
       catFilter.innerHTML=opts;
       catFilter.value=curVal;
     }
-    if(nwCanvas){
-      let months=ctx.months;
-      if(eom2SelectedRange!=='all'){
-        const n=parseInt(eom2SelectedRange)||6;
-        months=months.slice(-n);
+	    if(nwCanvas){
+	      let months=eom2AggregateMonths(ctx.months,eom2SelectedGranularity);
+	      if(eom2SelectedRange!=='all'){
+	        const n=parseInt(eom2SelectedRange)||6;
+	        months=months.slice(-n);
       }
       if(months.length>0){
         const subAccColors=['#f59e0b','#10b981','#6366f1','#ec4899','#14b8a6','#f97316','#8b5cf6','#06b6d4','#e11d48','#84cc16'];
@@ -13925,10 +13956,10 @@
             datasets.push({label:acc.name,data:accData,borderColor:col,backgroundColor:'transparent',borderWidth:2,borderDash:[6,3],pointRadius:3,pointBackgroundColor:col,tension:.3,fill:false,spanGaps:true});
           });
         }
-        eom2NwChart=new Chart(nwCanvas.getContext('2d'),{
-          type:'line',
-          data:{labels:months.map(m=>formatMonthLabel(m)),datasets},
-          options:{responsive:true,maintainAspectRatio:false,
+	        eom2NwChart=new Chart(nwCanvas.getContext('2d'),{
+	          type:'line',
+	          data:{labels:months.map(m=>eom2FormatTrendLabel(m,eom2SelectedGranularity)),datasets},
+	          options:{responsive:true,maintainAspectRatio:false,
             plugins:{legend:{position:'bottom',labels:{font:{size:11},usePointStyle:true,pointStyle:'circle'}},tooltip:{mode:'index',intersect:false,callbacks:{label:ctx2=>`${ctx2.dataset.label}: ${currencyTicks(ctx2.parsed.y)}`}}},
             interaction:{mode:'index',intersect:false},
             scales:{x:{grid:{display:false}},y:{ticks:{callback:v=>currencyTicks(v)},grid:{color:'rgba(148,163,184,.08)'}}}
@@ -14272,6 +14303,13 @@
       btn.onclick=()=>{
         eom2SelectedRange=btn.dataset.range==='all'?'all':parseInt(btn.dataset.range);
         document.querySelectorAll('.eom2-range-btn').forEach(b2=>b2.classList.toggle('is-active',b2===btn));
+        renderEomV2();
+      };
+    });
+    document.querySelectorAll('.eom2-gran-btn').forEach(btn=>{
+      btn.onclick=()=>{
+        eom2SelectedGranularity=btn.dataset.granularity||'monthly';
+        document.querySelectorAll('.eom2-gran-btn').forEach(b2=>b2.classList.toggle('is-active',b2===btn));
         renderEomV2();
       };
     });

--- a/budget.html
+++ b/budget.html
@@ -6365,14 +6365,16 @@
       return (!c || !((c.type==='expense' && c.id!=='c_fixed') || c.type==='saving')) ? s : s + Math.abs(e.amount);
     },0);
     document.getElementById('dash-today-spent').textContent=fmt(todaySpent, state.currency);
-    document.getElementById('dash-today-vs-budget').textContent = todaySpent<=dailyBudget ? '✅ w limicie dziennym' : '⚠️ powyżej limitu';
+    const todayStatus = todaySpent <= dailyBudget ? 'w limicie dziennym' : 'powyżej limitu';
+    document.getElementById('dash-today-vs-budget').textContent = todayStatus;
 
     const daysElapsed = (ym === monthKey()) ? new Date().getDate() : (monthKey() > ym ? days : 0);
     const daily=getDailySpending(ym);
     const spentSoFar=Object.values(daily).reduce((a,b)=>a+b,0);
     const avgDaily = (daysElapsed > 0 ? (spentSoFar / daysElapsed) : 0);
     document.getElementById('dash-avg-daily').textContent=fmt(avgDaily, state.currency);
-    document.getElementById('dash-avg-trend').textContent = avgDaily <= dailyBudget ? '👍 poniżej planu' : '👎 powyżej planu';
+    const averageTrendStatus = avgDaily <= dailyBudget ? 'poniżej planu' : 'powyżej planu';
+    document.getElementById('dash-avg-trend').textContent = averageTrendStatus;
 
     // Heatmap
     const cal=document.getElementById('daily-spending-calendar'); cal.innerHTML='';

--- a/budget.html
+++ b/budget.html
@@ -26,6 +26,17 @@
       margin-bottom: 0;
     }
 
+    .budget-tabs .tab {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .budget-tabs .material-symbols-outlined {
+      font-size: 16px;
+      line-height: 1;
+    }
+
     .trend {
       font-size: 12px;
       color: var(--muted);
@@ -4678,17 +4689,17 @@
       <div class="content">
         <main class="page-content content-main stack">
     <div class="tabs budget-tabs" style="margin-top:12px">
-      <button class="tab active" data-tab="dashboard">Dashboard</button>
-      <button class="tab" data-tab="overview">Przegląd</button>
-      <button class="tab" data-tab="incomes">Przychody</button>
-      <button class="tab" data-tab="fixed">Stałe wydatki</button>
-      <button class="tab" data-tab="variable">Wydatki zmienne</button>
-      <button class="tab" data-tab="investments">Inwestycje</button>
-      <button class="tab" data-tab="categories">Kategorie</button>
-      <button class="tab" data-tab="eom">Salda (EOM)</button>
-      <button class="tab" data-tab="goals">Cele</button>
-      <button class="tab" data-tab="analytics">Analityka</button>
-      <button class="tab" data-tab="mom">Porównanie MoM</button>
+      <button class="tab active" data-tab="dashboard"><span class="material-symbols-outlined">dashboard</span>Dashboard</button>
+      <button class="tab" data-tab="overview"><span class="material-symbols-outlined">home</span>Przegląd</button>
+      <button class="tab" data-tab="incomes"><span class="material-symbols-outlined">payments</span>Przychody</button>
+      <button class="tab" data-tab="fixed"><span class="material-symbols-outlined">account_balance_wallet</span>Stałe wydatki</button>
+      <button class="tab" data-tab="variable"><span class="material-symbols-outlined">shopping_cart</span>Wydatki zmienne</button>
+      <button class="tab" data-tab="investments"><span class="material-symbols-outlined">trending_up</span>Inwestycje</button>
+      <button class="tab" data-tab="categories"><span class="material-symbols-outlined">category</span>Kategorie</button>
+      <button class="tab" data-tab="eom"><span class="material-symbols-outlined">event_note</span>Salda (EOM)</button>
+      <button class="tab" data-tab="goals"><span class="material-symbols-outlined">flag</span>Cele</button>
+      <button class="tab" data-tab="analytics"><span class="material-symbols-outlined">analytics</span>Analityka</button>
+      <button class="tab" data-tab="mom"><span class="material-symbols-outlined">sync_alt</span>Porównanie MoM</button>
     </div>
 
     <!-- Dashboard -->

--- a/budget.html
+++ b/budget.html
@@ -24,16 +24,23 @@
       z-index: 8;
       padding: 8px 0;
       margin-bottom: 0;
+      flex-wrap: nowrap;
+      gap: 6px;
+      overflow-x: auto;
     }
 
     .budget-tabs .tab {
       display: inline-flex;
       align-items: center;
-      gap: 6px;
+      gap: 4px;
+      padding: 7px 10px;
+      font-size: 12px;
+      white-space: nowrap;
+      flex-shrink: 0;
     }
 
     .budget-tabs .material-symbols-outlined {
-      font-size: 16px;
+      font-size: 14px;
       line-height: 1;
     }
 

--- a/budget.html
+++ b/budget.html
@@ -6365,16 +6365,26 @@
       return (!c || !((c.type==='expense' && c.id!=='c_fixed') || c.type==='saving')) ? s : s + Math.abs(e.amount);
     },0);
     document.getElementById('dash-today-spent').textContent=fmt(todaySpent, state.currency);
-    const todayStatus = todaySpent <= dailyBudget ? 'w limicie dziennym' : 'powyżej limitu';
-    document.getElementById('dash-today-vs-budget').textContent = todayStatus;
+    const isTodayWithinBudget = todaySpent <= dailyBudget;
+    document.getElementById('dash-today-vs-budget').innerHTML = `
+      <span class="kpi-status-inline ${isTodayWithinBudget ? 'is-positive' : 'is-warning'}">
+        <span class="material-symbols-outlined kpi-status-icon" aria-hidden="true">${isTodayWithinBudget ? 'check_circle' : 'warning'}</span>
+        ${isTodayWithinBudget ? 'w limicie dziennym' : 'powyżej limitu'}
+      </span>
+    `;
 
     const daysElapsed = (ym === monthKey()) ? new Date().getDate() : (monthKey() > ym ? days : 0);
     const daily=getDailySpending(ym);
     const spentSoFar=Object.values(daily).reduce((a,b)=>a+b,0);
     const avgDaily = (daysElapsed > 0 ? (spentSoFar / daysElapsed) : 0);
     document.getElementById('dash-avg-daily').textContent=fmt(avgDaily, state.currency);
-    const averageTrendStatus = avgDaily <= dailyBudget ? 'poniżej planu' : 'powyżej planu';
-    document.getElementById('dash-avg-trend').textContent = averageTrendStatus;
+    const isAverageBelowPlan = avgDaily <= dailyBudget;
+    document.getElementById('dash-avg-trend').innerHTML = `
+      <span class="kpi-status-inline ${isAverageBelowPlan ? 'is-positive' : 'is-warning'}">
+        <span class="material-symbols-outlined kpi-status-icon" aria-hidden="true">${isAverageBelowPlan ? 'trending_down' : 'trending_up'}</span>
+        ${isAverageBelowPlan ? 'poniżej planu' : 'powyżej planu'}
+      </span>
+    `;
 
     // Heatmap
     const cal=document.getElementById('daily-spending-calendar'); cal.innerHTML='';

--- a/budget.html
+++ b/budget.html
@@ -5877,7 +5877,7 @@
         </main>
         <aside class="right-rail">
           <div class="kpi-compact" id="forecast-kpi">
-            <span class="kpi-emoji">🔮</span>
+            <span class="kpi-emoji material-symbols-outlined">insights</span>
             <div class="kpi-body">
               <span class="kpi-label">Prognozowane oszczędności</span>
               <span class="kpi-value" id="forecast-content">0</span>
@@ -5885,7 +5885,7 @@
             </div>
           </div>
           <div class="kpi-compact" id="buffer-kpi">
-            <span class="kpi-emoji">💰</span>
+            <span class="kpi-emoji material-symbols-outlined">savings</span>
             <div class="kpi-body">
               <span class="kpi-label">Zapas/dług na dziś</span>
               <span class="kpi-value" id="buffer-content">0</span>
@@ -5893,7 +5893,7 @@
             </div>
           </div>
           <div class="kpi-compact" id="mom-diff-kpi">
-            <span class="kpi-emoji">🆚</span>
+            <span class="kpi-emoji material-symbols-outlined">compare_arrows</span>
             <div class="kpi-body">
               <span class="kpi-label">MoM bez stałych</span>
               <span class="kpi-value" id="dash-mom-diff">—</span>
@@ -5901,7 +5901,7 @@
             </div>
           </div>
           <div class="kpi-compact">
-            <span class="kpi-emoji">💸</span>
+            <span class="kpi-emoji material-symbols-outlined">payments</span>
             <div class="kpi-body">
               <span class="kpi-label">Pozostały budżet</span>
               <span class="kpi-value" id="dash-remaining">0</span>
@@ -5909,7 +5909,7 @@
             </div>
           </div>
           <div class="kpi-compact">
-            <span class="kpi-emoji">📉</span>
+            <span class="kpi-emoji material-symbols-outlined">trending_down</span>
             <div class="kpi-body">
               <span class="kpi-label">Limit dzienny</span>
               <span class="kpi-value" id="dash-daily-budget">0</span>
@@ -5917,7 +5917,7 @@
             </div>
           </div>
           <div class="kpi-compact">
-            <span class="kpi-emoji">📅</span>
+            <span class="kpi-emoji material-symbols-outlined">calendar_month</span>
             <div class="kpi-body">
               <span class="kpi-label">Wydane dziś</span>
               <span class="kpi-value" id="dash-today-spent">0</span>
@@ -5925,7 +5925,7 @@
             </div>
           </div>
           <div class="kpi-compact">
-            <span class="kpi-emoji">📊</span>
+            <span class="kpi-emoji material-symbols-outlined">bar_chart</span>
             <div class="kpi-body">
               <span class="kpi-label">Średnia dzienna</span>
               <span class="kpi-value" id="dash-avg-daily">0</span>

--- a/budget.html
+++ b/budget.html
@@ -5392,25 +5392,33 @@
             </div>
           </div>
           <div id="eom2-booking-grid"></div>
-          <div class="card stack" style="margin-top:8px;padding:10px 12px">
-            <div class="eom2-bridge-head">
-              <strong>Połączenie z inwestycjami</strong>
-              <div class="row" style="gap:8px">
-                <button class="btn soft" type="button" id="eom2-bridge-add">Dodaj mapowanie</button>
-                <button class="btn soft" type="button" id="eom2-bridge-apply">Pobierz aktualne</button>
-              </div>
-            </div>
-            <div class="tiny muted">Zmapuj składniki z zakładki Inwestycje (cały portfel, grupa lub aktywo) do kont EOM typu „Inwestycje”.</div>
-            <div class="table-wrapper" style="margin-top:6px">
-              <table class="modern-table eom2-bridge-table">
-                <thead>
-                  <tr><th>Źródło (Inwestycje)</th><th>Księguj na konto EOM</th><th>Znak</th><th>Podgląd</th><th></th></tr>
-                </thead>
-                <tbody id="eom2-bridge-body"></tbody>
-              </table>
-            </div>
-            <div class="tiny muted" id="eom2-bridge-empty" style="display:none">Brak mapowań — dodaj pierwszy wiersz.</div>
-          </div>
+	          <div class="card stack" style="margin-top:8px;padding:10px 12px">
+	            <div class="eom2-bridge-head">
+	              <strong>Połączenie z inwestycjami</strong>
+	              <div class="row" style="gap:8px">
+	                <button class="btn soft" type="button" id="eom2-bridge-toggle" aria-expanded="false">
+	                  <span class="material-symbols-outlined" style="font-size:16px">expand_more</span>
+	                  <span>Rozwiń mapowania</span>
+	                </button>
+	                <button class="btn soft" type="button" id="eom2-bridge-apply">Pobierz aktualne</button>
+	              </div>
+	            </div>
+	            <div id="eom2-bridge-panel" hidden>
+	              <div class="tiny muted">Zmapuj składniki z zakładki Inwestycje (cały portfel, grupa lub aktywo) do kont EOM typu „Inwestycje”.</div>
+	              <div class="row" style="justify-content:flex-end;margin-top:8px">
+	                <button class="btn soft" type="button" id="eom2-bridge-add">Dodaj mapowanie</button>
+	              </div>
+	              <div class="table-wrapper" style="margin-top:6px">
+	                <table class="modern-table eom2-bridge-table">
+	                  <thead>
+	                    <tr><th>Źródło (Inwestycje)</th><th>Księguj na konto EOM</th><th>Znak</th><th>Podgląd</th><th></th></tr>
+	                  </thead>
+	                  <tbody id="eom2-bridge-body"></tbody>
+	                </table>
+	              </div>
+	              <div class="tiny muted" id="eom2-bridge-empty" style="display:none">Brak mapowań — dodaj pierwszy wiersz.</div>
+	            </div>
+	          </div>
           <form id="eom2-add-account" class="row" style="gap:8px;margin-top:8px">
             <input name="name" placeholder="Nowe konto (np. Revolut, Karta kredytowa)" style="flex:1;height:38px" required />
             <select name="type" style="height:38px;min-width:140px">
@@ -14201,6 +14209,19 @@
       });
     };
 
+
+    const bridgeToggleBtn=document.getElementById('eom2-bridge-toggle');
+    const bridgePanel=document.getElementById('eom2-bridge-panel');
+    if(bridgeToggleBtn&&bridgePanel){
+      bridgeToggleBtn.onclick=()=>{
+        const isHidden=bridgePanel.hidden;
+        bridgePanel.hidden=!isHidden;
+        bridgeToggleBtn.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
+        bridgeToggleBtn.innerHTML=isHidden
+          ? '<span class="material-symbols-outlined" style="font-size:16px">expand_less</span><span>Zwiń mapowania</span>'
+          : '<span class="material-symbols-outlined" style="font-size:16px">expand_more</span><span>Rozwiń mapowania</span>';
+      };
+    }
 
     const bridgeAddBtn=document.getElementById('eom2-bridge-add');
     if(bridgeAddBtn) bridgeAddBtn.onclick=()=>{

--- a/budget.html
+++ b/budget.html
@@ -4713,14 +4713,18 @@
     <section id="tab-dashboard" class="card" style="margin-top:12px">
       <h3 class="title">Dashboard finansowy</h3>
       <div class="grid-2" style="margin-top:12px">
-        <div class="card">
-          <div class="title">Wydatki dzień po dniu</div>
-          <div class="chart-box"><canvas id="dailyLine"></canvas></div>
+        <div class="inv-hub-chart-card">
+          <div class="inv-hub-chart-card-header">
+            <h4>Wydatki dzień po dniu</h4>
+          </div>
+          <div class="inv-hub-chart-box"><canvas id="dailyLine"></canvas></div>
         </div>
-        <div class="card">
-          <div class="title">Skumulowane: limit vs wydatki</div>
-          <div class="hint">Dwie linie: oczekiwane (np. 400 zł/dzień) vs faktyczne (wydatki + oszczędności)</div>
-          <div class="chart-box"><canvas id="cumulativeLine"></canvas></div>
+        <div class="inv-hub-chart-card">
+          <div class="inv-hub-chart-card-header">
+            <h4>Skumulowane: limit vs wydatki</h4>
+            <span class="tiny muted">Faktyczne vs oczekiwane tempo</span>
+          </div>
+          <div class="inv-hub-chart-box"><canvas id="cumulativeLine"></canvas></div>
         </div>
       </div>
 
@@ -6680,7 +6684,7 @@
                     type: 'line',
                     label: 'Limit dzienny',
                     data: Array(daysInMonth).fill(dailyBudget),
-                    borderColor: 'rgba(190, 18, 60, 0.7)',
+                    borderColor: '#ef4444',
                     backgroundColor: 'transparent',
                     borderWidth: 2,
                     pointRadius: 0,
@@ -6692,7 +6696,7 @@
                     type: 'line',
                     label: 'Średnia dzienna',
                     data: Array(daysInMonth).fill(avgDaily),
-                    borderColor: 'rgba(234, 88, 12, 0.7)',
+                    borderColor: '#f59e0b',
                     backgroundColor: 'transparent',
                     borderWidth: 2,
                     pointRadius: 0,
@@ -6711,13 +6715,20 @@
             scales: {
                 y: {
                     beginAtZero: true,
-                    ticks: { callback: currencyTicks }
+                    ticks: { callback: currencyTicks, font: { size: 10 } },
+                    grid: { color: 'rgba(148,163,184,.12)' },
+                    title: { display: true, text: 'Wydatki', font: { size: 10 }, color: 'var(--muted)' }
                 },
                 x: {
-                    grid: { display: false }
+                    grid: { display: false },
+                    ticks: { maxTicksLimit: 12, font: { size: 10 } }
                 }
             },
             plugins: {
+                legend: {
+                    position: 'bottom',
+                    labels: { font: { size: 11 }, usePointStyle: true, padding: 12 }
+                },
                 tooltip: {
                     callbacks: {
                         label: function(context) {
@@ -6755,7 +6766,29 @@
         }
     });
 
-    window.dashCum=new Chart(cumCtx,{type:'line',data:{labels,datasets:[{label:'Skumulowane wydatki',data:cumSpend,borderColor:'#be123c',backgroundColor:'rgba(190,18,60,0.08)',tension:0.3,fill:true},{label:'Skumulowany limit',data:cumAllowed,borderColor:'#059669',backgroundColor:'rgba(5,150,105,0.08)',tension:0.3,fill:true}]},options:{responsive:true,maintainAspectRatio:false,scales:{y:{beginAtZero:true,ticks:{callback:currencyTicks}}}}});
+    window.dashCum=new Chart(cumCtx,{
+      type:'line',
+      data:{
+        labels,
+        datasets:[
+          {label:'Skumulowane wydatki',data:cumSpend,borderColor:'#ef4444',backgroundColor:colorWithAlpha('#ef4444',0.12),tension:.35,fill:true,borderWidth:2,pointRadius:0,pointHoverRadius:4},
+          {label:'Skumulowany limit',data:cumAllowed,borderColor:'#2563eb',backgroundColor:colorWithAlpha('#2563eb',0.1),tension:.35,fill:true,borderWidth:2,pointRadius:0,pointHoverRadius:4}
+        ]
+      },
+      options:{
+        responsive:true,
+        maintainAspectRatio:false,
+        interaction:{mode:'index',intersect:false},
+        plugins:{
+          legend:{position:'bottom',labels:{font:{size:11},usePointStyle:true,padding:12}},
+          tooltip:{callbacks:{label:ctx=>`${ctx.dataset.label}: ${currencyTicks(ctx.parsed.y)}`}}
+        },
+        scales:{
+          x:{grid:{display:false},ticks:{maxTicksLimit:12,font:{size:10}}},
+          y:{beginAtZero:true,ticks:{callback:currencyTicks,font:{size:10}},grid:{color:'rgba(148,163,184,.12)'},title:{display:true,text:'Wartość',font:{size:10},color:'var(--muted)'}}
+        }
+      }
+    });
   }
 
   // --- Overview ---------------------------------------------------------------

--- a/budget.html
+++ b/budget.html
@@ -5386,11 +5386,12 @@
         <div class="card stack">
           <div class="row" style="justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px">
             <strong>Księgowanie sald <span class="muted" style="font-weight:400;font-size:12px" id="eom2-month-label"></span></strong>
-            <div class="row" style="gap:8px">
-              <span class="tiny muted" id="eom2-live-total"></span>
-              <button class="btn" type="button" id="eom2-save">Zapisz salda</button>
-            </div>
-          </div>
+	            <div class="row" style="gap:8px">
+	              <span class="tiny muted" id="eom2-live-total"></span>
+	              <button class="btn soft" type="button" id="eom2-bridge-apply">Pobierz aktualne</button>
+	              <button class="btn" type="button" id="eom2-save">Zapisz salda</button>
+	            </div>
+	          </div>
           <div id="eom2-booking-grid"></div>
 	          <div class="card stack" style="margin-top:8px;padding:10px 12px">
 	            <div class="eom2-bridge-head">
@@ -5400,7 +5401,6 @@
 	                  <span class="material-symbols-outlined" style="font-size:16px">expand_more</span>
 	                  <span>Rozwiń mapowania</span>
 	                </button>
-	                <button class="btn soft" type="button" id="eom2-bridge-apply">Pobierz aktualne</button>
 	              </div>
 	            </div>
 	            <div id="eom2-bridge-panel" hidden>

--- a/budget.html
+++ b/budget.html
@@ -462,6 +462,30 @@
     .eom2-bridge-table td, .eom2-bridge-table th { vertical-align:middle; }
     .eom2-bridge-table select, .eom2-bridge-table input { height:34px; width:100%; }
     .eom2-bridge-table .tiny { white-space:nowrap; }
+    .eom2-history-pivot thead th {
+      position: sticky;
+      top: 0;
+      background: var(--card);
+      z-index: 3;
+    }
+    .eom2-history-pivot th:first-child,
+    .eom2-history-pivot td:first-child {
+      position: sticky;
+      left: 0;
+      z-index: 2;
+      background: var(--card);
+    }
+    .eom2-history-pivot tr.eom2-history-group td {
+      font-weight: 700;
+      background: rgba(51, 65, 85, 0.05);
+    }
+    .eom2-history-pivot tr.eom2-history-total td {
+      font-weight: 800;
+      border-top: 2px solid var(--line);
+    }
+    .eom2-history-account {
+      padding-left: 18px;
+    }
 
     .eom2-gainer-item { display:flex; justify-content:space-between; align-items:center; padding:8px 0; border-bottom:1px solid rgba(148,163,184,.08); font-size:13px; }
     .eom2-gainer-item:last-child { border-bottom:none; }
@@ -5494,16 +5518,30 @@
         </div>
 
         <!-- History (collapsible) -->
-        <details class="card stack">
-          <summary style="cursor:pointer;user-select:none;display:flex;justify-content:space-between;align-items:center">
-            <strong>Historia sald <span class="muted" style="font-weight:400;font-size:12px" id="eom2-history-count"></span></strong>
-          </summary>
-          <div class="table-wrapper" style="margin-top:12px">
-            <table class="modern-table" id="eom2-history-table">
-              <thead id="eom2-history-thead"></thead>
-              <tbody id="eom2-history-tbody"></tbody>
-            </table>
-          </div>
+	        <details class="card stack">
+	          <summary style="cursor:pointer;user-select:none;display:flex;justify-content:space-between;align-items:center">
+	            <strong>Historia sald <span class="muted" style="font-weight:400;font-size:12px" id="eom2-history-count"></span></strong>
+	          </summary>
+	          <div class="row" style="margin-top:10px;gap:8px;align-items:center;flex-wrap:wrap">
+	            <label class="tiny" style="display:flex;align-items:center;gap:6px">
+	              <input type="checkbox" id="eom2-history-compare-toggle" />
+	              Tryb porównawczy
+	            </label>
+	            <label class="tiny" style="display:flex;align-items:center;gap:6px">
+	              Okres A
+	              <select id="eom2-history-compare-a" style="height:30px;min-width:130px"></select>
+	            </label>
+	            <label class="tiny" style="display:flex;align-items:center;gap:6px">
+	              Okres B
+	              <select id="eom2-history-compare-b" style="height:30px;min-width:130px"></select>
+	            </label>
+	          </div>
+	          <div class="table-wrapper" style="margin-top:12px">
+	            <table class="modern-table eom2-history-pivot" id="eom2-history-table">
+	              <thead id="eom2-history-thead"></thead>
+	              <tbody id="eom2-history-tbody"></tbody>
+	            </table>
+	          </div>
         </details>
 
       </div>
@@ -13575,6 +13613,9 @@
   let eom2SelectedRange=6;
   let eom2SelectedGranularity='monthly';
   let eom2SelectedCat='all';
+  let eom2HistoryCompareMode=false;
+  let eom2HistoryCompareA='';
+  let eom2HistoryCompareB='';
   let eom2Bound=false;
   const eom2TypeOrder=['oszczędności','inwestycje','gotówka','emerytura','zadłużenie','inne'];
   const eom2TypeLabelMap={'oszczędności':'Oszczędności','inwestycje':'Inwestycje','gotówka':'Gotówka','emerytura':'Emerytura','zadłużenie':'Zobowiązania','inne':'Inne'};
@@ -14038,36 +14079,87 @@
       }
     }
 
-    // --- History Table ---
+    // --- History Table (pivot: rows=accounts grouped by type, cols=periods) ---
     const hThead=el('eom2-history-thead');
     const hTbody=el('eom2-history-tbody');
     const hCount=el('eom2-history-count');
+    const compareToggle=el('eom2-history-compare-toggle');
+    const compareA=el('eom2-history-compare-a');
+    const compareB=el('eom2-history-compare-b');
     if(hThead&&hTbody){
       hThead.innerHTML='';hTbody.innerHTML='';
-      const months=ctx.months.slice(-12);
-      if(hCount) hCount.textContent=`(${months.length} mies.)`;
-      if(months.length>0){
-        // Header: Month | Account1 | Account2 | ... | Net Worth
-        const usedAccounts=accounts.filter(a=>months.some(m=>(ctx.monthBalances[m]||{})[a.id]!==undefined));
-        let hdr='<tr><th>Miesiąc</th>';
-        for(const a of usedAccounts) hdr+=`<th style="text-align:right">${escapeHtml(a.name)}</th>`;
-        hdr+='<th style="text-align:right;font-weight:800">Netto</th></tr>';
-        hThead.innerHTML=hdr;
+      let periods=eom2AggregateMonths(ctx.months,eom2SelectedGranularity);
+      if(eom2SelectedRange!=='all'){
+        const n=parseInt(eom2SelectedRange)||6;
+        periods=periods.slice(-n);
+      }
+      if(hCount) hCount.textContent=`(${periods.length} okres.)`;
 
-        for(const m of [...months].reverse()){
-          const bals=ctx.monthBalances[m]||{};
-          let row=`<tr><td><strong>${formatMonthLabel(m)}</strong></td>`;
-          for(const a of usedAccounts){
-            const v=bals[a.id];
-            const cls=v!==undefined?(v<0?'inv-pnl-neg':''):'muted';
-            row+=`<td style="text-align:right" class="${cls}">${v!==undefined?fmt(v,cur):'—'}</td>`;
-          }
-          const nw=sumBalances(bals);
-          row+=`<td style="text-align:right;font-weight:800">${fmt(nw,cur)}</td></tr>`;
-          hTbody.innerHTML+=row;
+      if(compareA&&compareB){
+        const options=periods.map(p=>({value:p,label:eom2FormatTrendLabel(p,eom2SelectedGranularity)}));
+        compareA.innerHTML=options.map(o=>`<option value="${o.value}">${o.label}</option>`).join('');
+        compareB.innerHTML=options.map(o=>`<option value="${o.value}">${o.label}</option>`).join('');
+        if(options.length){
+          if(!options.some(o=>o.value===eom2HistoryCompareA)) eom2HistoryCompareA=options[Math.max(0,options.length-2)]?.value||options[0].value;
+          if(!options.some(o=>o.value===eom2HistoryCompareB)) eom2HistoryCompareB=options[options.length-1].value;
+          compareA.value=eom2HistoryCompareA;
+          compareB.value=eom2HistoryCompareB;
         }
-      } else {
+        compareA.disabled=!eom2HistoryCompareMode;
+        compareB.disabled=!eom2HistoryCompareMode;
+      }
+      if(compareToggle) compareToggle.checked=!!eom2HistoryCompareMode;
+
+      if(!periods.length){
         hTbody.innerHTML='<tr><td colspan="99" style="text-align:center;color:var(--muted);padding:20px">Brak danych historycznych</td></tr>';
+      } else {
+        const usedAccounts=accounts.filter(a=>periods.some(p=>(ctx.monthBalances[p]||{})[a.id]!==undefined));
+        const accountsByType={};
+        for(const t of eom2TypeOrder) accountsByType[t]=usedAccounts.filter(a=>inferAccountType(a)===t);
+        const usedTypes=eom2TypeOrder.filter(t=>(accountsByType[t]||[]).length>0);
+
+        let head='<tr><th>Pozycja</th>';
+        for(const p of periods) head+=`<th style="text-align:right">${eom2FormatTrendLabel(p,eom2SelectedGranularity)}</th>`;
+        if(eom2HistoryCompareMode) head+='<th style="text-align:right">Diff (B−A)</th>';
+        head+='</tr>';
+        hThead.innerHTML=head;
+
+        const bal=(period,accId)=>(ctx.monthBalances[period]||{})[accId];
+        const sumType=(period,type)=>(accountsByType[type]||[]).reduce((s,a)=>s+(bal(period,a.id)||0),0);
+        const sumAll=(period)=>sumBalances(ctx.monthBalances[period]||{});
+        const diffCell=(a,b)=>{
+          if(a===undefined||b===undefined) return '<span class="muted">—</span>';
+          const d=b-a;
+          const cls=d>0?'ok':d<0?'bad':'muted';
+          const sign=d>0?'+':'';
+          return `<span class="${cls}">${sign}${fmt(d,cur)}</span>`;
+        };
+
+        for(const type of usedTypes){
+          let groupRow=`<tr class="eom2-history-group"><td>${eom2TypeLabelMap[type]||type}</td>`;
+          for(const p of periods) groupRow+=`<td style="text-align:right">${fmt(sumType(p,type),cur)}</td>`;
+          if(eom2HistoryCompareMode) groupRow+=`<td style="text-align:right">${diffCell(sumType(eom2HistoryCompareA,type),sumType(eom2HistoryCompareB,type))}</td>`;
+          groupRow+='</tr>';
+          hTbody.insertAdjacentHTML('beforeend',groupRow);
+
+          for(const acc of accountsByType[type]){
+            let accRow=`<tr><td class="eom2-history-account">${escapeHtml(acc.name)}</td>`;
+            for(const p of periods){
+              const v=bal(p,acc.id);
+              const cls=v!==undefined?(v<0?'inv-pnl-neg':''):'muted';
+              accRow+=`<td style="text-align:right" class="${cls}">${v!==undefined?fmt(v,cur):'—'}</td>`;
+            }
+            if(eom2HistoryCompareMode) accRow+=`<td style="text-align:right">${diffCell(bal(eom2HistoryCompareA,acc.id),bal(eom2HistoryCompareB,acc.id))}</td>`;
+            accRow+='</tr>';
+            hTbody.insertAdjacentHTML('beforeend',accRow);
+          }
+        }
+
+        let totalRow='<tr class="eom2-history-total"><td>Majątek netto</td>';
+        for(const p of periods) totalRow+=`<td style="text-align:right">${fmt(sumAll(p),cur)}</td>`;
+        if(eom2HistoryCompareMode) totalRow+=`<td style="text-align:right">${diffCell(sumAll(eom2HistoryCompareA),sumAll(eom2HistoryCompareB))}</td>`;
+        totalRow+='</tr>';
+        hTbody.insertAdjacentHTML('beforeend',totalRow);
       }
     }
   }
@@ -14313,6 +14405,21 @@
         renderEomV2();
       };
     });
+    const historyCompareToggle=document.getElementById('eom2-history-compare-toggle');
+    if(historyCompareToggle) historyCompareToggle.onchange=()=>{
+      eom2HistoryCompareMode=!!historyCompareToggle.checked;
+      renderEomV2();
+    };
+    const historyCompareA=document.getElementById('eom2-history-compare-a');
+    if(historyCompareA) historyCompareA.onchange=()=>{
+      eom2HistoryCompareA=historyCompareA.value;
+      renderEomV2();
+    };
+    const historyCompareB=document.getElementById('eom2-history-compare-b');
+    if(historyCompareB) historyCompareB.onchange=()=>{
+      eom2HistoryCompareB=historyCompareB.value;
+      renderEomV2();
+    };
 
     // Add account form
     const addForm=document.getElementById('eom2-add-account');

--- a/budget.html
+++ b/budget.html
@@ -6711,8 +6711,7 @@
                 y: {
                     beginAtZero: true,
                     ticks: { callback: currencyTicks, font: { size: 10 } },
-                    grid: { color: 'rgba(148,163,184,.12)' },
-                    title: { display: true, text: 'Wydatki', font: { size: 10 }, color: 'var(--muted)' }
+                    grid: { color: 'rgba(148,163,184,.12)' }
                 },
                 x: {
                     grid: { display: false },
@@ -6795,8 +6794,7 @@
             min: cumulativeExtent.length ? Math.max(0, cumulativeMin - cumulativePadding) : 0,
             max: cumulativeExtent.length ? (cumulativeMax + cumulativePadding) : undefined,
             ticks:{callback:currencyTicks,font:{size:10}},
-            grid:{color:'rgba(148,163,184,.12)'},
-            title:{display:true,text:'Wartość',font:{size:10},color:'var(--muted)'}
+            grid:{color:'rgba(148,163,184,.12)'}
           }
         }
       }

--- a/budget.html
+++ b/budget.html
@@ -6766,13 +6766,24 @@
         }
     });
 
+    const todayDay=Math.min(new Date().getDate(), daysInMonth);
+    const cumulativeDaysToShow = ym===monthKey() ? todayDay : (monthKey()>ym ? daysInMonth : 0);
+    const cumulativeLabels = labels.slice(0, cumulativeDaysToShow);
+    const cumulativeSpendData = cumSpend.slice(0, cumulativeDaysToShow);
+    const cumulativeAllowedData = cumAllowed.slice(0, cumulativeDaysToShow);
+    const cumulativeExtent = [...cumulativeSpendData, ...cumulativeAllowedData];
+    const cumulativeMax = cumulativeExtent.length ? Math.max(...cumulativeExtent) : 0;
+    const cumulativeMin = cumulativeExtent.length ? Math.min(...cumulativeExtent) : 0;
+    const cumulativeRange = Math.max(cumulativeMax - cumulativeMin, 1);
+    const cumulativePadding = cumulativeRange * 0.08;
+
     window.dashCum=new Chart(cumCtx,{
       type:'line',
       data:{
-        labels,
+        labels:cumulativeLabels,
         datasets:[
-          {label:'Skumulowane wydatki',data:cumSpend,borderColor:'#ef4444',backgroundColor:colorWithAlpha('#ef4444',0.12),tension:.35,fill:true,borderWidth:2,pointRadius:0,pointHoverRadius:4},
-          {label:'Skumulowany limit',data:cumAllowed,borderColor:'#2563eb',backgroundColor:colorWithAlpha('#2563eb',0.1),tension:.35,fill:true,borderWidth:2,pointRadius:0,pointHoverRadius:4}
+          {label:'Skumulowane wydatki',data:cumulativeSpendData,borderColor:'#ef4444',backgroundColor:colorWithAlpha('#ef4444',0.12),tension:.35,fill:true,borderWidth:2,pointRadius:0,pointHoverRadius:4},
+          {label:'Skumulowany limit',data:cumulativeAllowedData,borderColor:'#2563eb',backgroundColor:colorWithAlpha('#2563eb',0.1),tension:.35,fill:true,borderWidth:2,pointRadius:0,pointHoverRadius:4}
         ]
       },
       options:{
@@ -6785,7 +6796,13 @@
         },
         scales:{
           x:{grid:{display:false},ticks:{maxTicksLimit:12,font:{size:10}}},
-          y:{beginAtZero:true,ticks:{callback:currencyTicks,font:{size:10}},grid:{color:'rgba(148,163,184,.12)'},title:{display:true,text:'Wartość',font:{size:10},color:'var(--muted)'}}
+          y:{
+            min: cumulativeExtent.length ? Math.max(0, cumulativeMin - cumulativePadding) : 0,
+            max: cumulativeExtent.length ? (cumulativeMax + cumulativePadding) : undefined,
+            ticks:{callback:currencyTicks,font:{size:10}},
+            grid:{color:'rgba(148,163,184,.12)'},
+            title:{display:true,text:'Wartość',font:{size:10},color:'var(--muted)'}
+          }
         }
       }
     });

--- a/budget.html
+++ b/budget.html
@@ -486,6 +486,35 @@
     .eom2-history-account {
       padding-left: 18px;
     }
+    .eom2-history-controls {
+      display: flex;
+      gap: 10px;
+      align-items: flex-end;
+      flex-wrap: wrap;
+    }
+    .eom2-history-compare-toggle {
+      padding: 6px 10px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: var(--surface);
+      height: 34px;
+      white-space: nowrap;
+    }
+    .eom2-history-field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 170px;
+    }
+    .eom2-history-field select {
+      height: 34px;
+      min-width: 170px;
+      border-radius: 10px;
+      padding: 0 10px;
+      border: 1px solid var(--line);
+      background: var(--surface);
+      color: var(--ink);
+    }
 
     .eom2-gainer-item { display:flex; justify-content:space-between; align-items:center; padding:8px 0; border-bottom:1px solid rgba(148,163,184,.08); font-size:13px; }
     .eom2-gainer-item:last-child { border-bottom:none; }
@@ -5522,18 +5551,18 @@
 	          <summary style="cursor:pointer;user-select:none;display:flex;justify-content:space-between;align-items:center">
 	            <strong>Historia sald <span class="muted" style="font-weight:400;font-size:12px" id="eom2-history-count"></span></strong>
 	          </summary>
-	          <div class="row" style="margin-top:10px;gap:8px;align-items:center;flex-wrap:wrap">
-	            <label class="tiny" style="display:flex;align-items:center;gap:6px">
+	          <div class="eom2-history-controls" style="margin-top:10px">
+	            <label class="tiny eom2-history-compare-toggle" style="display:flex;align-items:center;gap:6px">
 	              <input type="checkbox" id="eom2-history-compare-toggle" />
 	              Tryb porównawczy
 	            </label>
-	            <label class="tiny" style="display:flex;align-items:center;gap:6px">
-	              Okres A
-	              <select id="eom2-history-compare-a" style="height:30px;min-width:130px"></select>
+	            <label class="tiny eom2-history-field">
+	              <span>Okres A</span>
+	              <select id="eom2-history-compare-a"></select>
 	            </label>
-	            <label class="tiny" style="display:flex;align-items:center;gap:6px">
-	              Okres B
-	              <select id="eom2-history-compare-b" style="height:30px;min-width:130px"></select>
+	            <label class="tiny eom2-history-field">
+	              <span>Okres B</span>
+	              <select id="eom2-history-compare-b"></select>
 	            </label>
 	          </div>
 	          <div class="table-wrapper" style="margin-top:12px">
@@ -14109,17 +14138,20 @@
         compareB.disabled=!eom2HistoryCompareMode;
       }
       if(compareToggle) compareToggle.checked=!!eom2HistoryCompareMode;
+      const displayedPeriods=eom2HistoryCompareMode
+        ? [eom2HistoryCompareA,eom2HistoryCompareB].filter(Boolean)
+        : periods;
 
-      if(!periods.length){
+      if(!displayedPeriods.length){
         hTbody.innerHTML='<tr><td colspan="99" style="text-align:center;color:var(--muted);padding:20px">Brak danych historycznych</td></tr>';
       } else {
-        const usedAccounts=accounts.filter(a=>periods.some(p=>(ctx.monthBalances[p]||{})[a.id]!==undefined));
+        const usedAccounts=accounts.filter(a=>displayedPeriods.some(p=>(ctx.monthBalances[p]||{})[a.id]!==undefined));
         const accountsByType={};
         for(const t of eom2TypeOrder) accountsByType[t]=usedAccounts.filter(a=>inferAccountType(a)===t);
         const usedTypes=eom2TypeOrder.filter(t=>(accountsByType[t]||[]).length>0);
 
         let head='<tr><th>Pozycja</th>';
-        for(const p of periods) head+=`<th style="text-align:right">${eom2FormatTrendLabel(p,eom2SelectedGranularity)}</th>`;
+        for(const p of displayedPeriods) head+=`<th style="text-align:right">${eom2FormatTrendLabel(p,eom2SelectedGranularity)}</th>`;
         if(eom2HistoryCompareMode) head+='<th style="text-align:right">Diff (B−A)</th>';
         head+='</tr>';
         hThead.innerHTML=head;
@@ -14137,14 +14169,14 @@
 
         for(const type of usedTypes){
           let groupRow=`<tr class="eom2-history-group"><td>${eom2TypeLabelMap[type]||type}</td>`;
-          for(const p of periods) groupRow+=`<td style="text-align:right">${fmt(sumType(p,type),cur)}</td>`;
+          for(const p of displayedPeriods) groupRow+=`<td style="text-align:right">${fmt(sumType(p,type),cur)}</td>`;
           if(eom2HistoryCompareMode) groupRow+=`<td style="text-align:right">${diffCell(sumType(eom2HistoryCompareA,type),sumType(eom2HistoryCompareB,type))}</td>`;
           groupRow+='</tr>';
           hTbody.insertAdjacentHTML('beforeend',groupRow);
 
           for(const acc of accountsByType[type]){
             let accRow=`<tr><td class="eom2-history-account">${escapeHtml(acc.name)}</td>`;
-            for(const p of periods){
+            for(const p of displayedPeriods){
               const v=bal(p,acc.id);
               const cls=v!==undefined?(v<0?'inv-pnl-neg':''):'muted';
               accRow+=`<td style="text-align:right" class="${cls}">${v!==undefined?fmt(v,cur):'—'}</td>`;
@@ -14156,7 +14188,7 @@
         }
 
         let totalRow='<tr class="eom2-history-total"><td>Majątek netto</td>';
-        for(const p of periods) totalRow+=`<td style="text-align:right">${fmt(sumAll(p),cur)}</td>`;
+        for(const p of displayedPeriods) totalRow+=`<td style="text-align:right">${fmt(sumAll(p),cur)}</td>`;
         if(eom2HistoryCompareMode) totalRow+=`<td style="text-align:right">${diffCell(sumAll(eom2HistoryCompareA),sumAll(eom2HistoryCompareB))}</td>`;
         totalRow+='</tr>';
         hTbody.insertAdjacentHTML('beforeend',totalRow);

--- a/fuel.html
+++ b/fuel.html
@@ -199,6 +199,30 @@
       .fuel-dash  { grid-template-columns: 1fr; grid-template-rows: auto; }
       .fd-main, .fd-avg, .fd-mth, .fd-right { grid-column: 1; grid-row: auto; }
     }
+
+    /* ── Historia transakcji w modalu ─────────────────────── */
+    #history-modal { display: none; }
+    #history-modal.open { display: flex; }
+    .fuel-history-modal {
+      width: min(1500px, 96vw);
+      max-width: none;
+      max-height: 94vh;
+      display: flex;
+      flex-direction: column;
+      padding: 20px 22px;
+    }
+    .fuel-history-modal .table-wrapper {
+      flex: 1;
+      min-height: 0;
+      overflow: auto;
+      margin-top: 10px;
+    }
+    .fuel-history-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 10px;
+    }
   </style>
 </head>
 <body data-page="fuel">
@@ -280,6 +304,7 @@
           <button id="import-csv-btn" class="btn soft">Importuj z CSV</button>
           <input type="file" id="csv-file-input" accept=".csv" style="display:none;">
           <button id="export-csv-btn" class="btn soft">Eksportuj do CSV</button>
+          <button id="open-history-btn" class="btn soft">Pokaż historię transakcji</button>
           <button id="clear-all-btn" class="btn danger">Wyczyść wszystko</button>
         </div>
       </header>
@@ -410,31 +435,35 @@
             </div><!-- /fd-right -->
           </div><!-- /fuel-dash -->
 
-          <!-- ③ HISTORIA TRANSAKCJI (pełna szerokość) ──────────── -->
-          <section class="card card-section">
-            <div class="section-heading">
-              <h2 class="title">Historia transakcji</h2>
-              <span class="tiny muted">Kliknij wpis, aby edytować lub usuń w przypadku pomyłki</span>
-            </div>
-            <div class="table-wrapper">
-              <table>
-                <thead>
-                  <tr>
-                    <th>Data</th>
-                    <th>Typ</th>
-                    <th>Opis / Nr faktury</th>
-                    <th>Litry</th>
-                    <th>Cena/l</th>
-                    <th>Kwota</th>
-                    <th></th>
-                  </tr>
-                </thead>
-                <tbody id="history-tbody"></tbody>
-              </table>
-            </div>
-          </section>
-
         </main>
+      </div>
+    </div>
+  </div>
+
+  <div id="history-modal" class="overlay" role="dialog" aria-modal="true" aria-labelledby="history-modal-title">
+    <div class="modal fuel-history-modal">
+      <div class="fuel-history-head">
+        <div>
+          <h2 id="history-modal-title" class="title">Historia transakcji</h2>
+          <span class="tiny muted">Kliknij wpis, aby edytować lub usuń w przypadku pomyłki</span>
+        </div>
+        <button id="close-history-btn" class="btn soft">Zamknij</button>
+      </div>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Data</th>
+              <th>Typ</th>
+              <th>Opis / Nr faktury</th>
+              <th>Litry</th>
+              <th>Cena/l</th>
+              <th>Kwota</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody id="history-tbody"></tbody>
+        </table>
       </div>
     </div>
   </div>
@@ -562,6 +591,20 @@ const lastInvoiceCard = document.getElementById('last-invoice-card');
 const exportBtn = document.getElementById('export-csv-btn');
 const importBtn = document.getElementById('import-csv-btn');
 const csvFileInput = document.getElementById('csv-file-input');
+const openHistoryBtn = document.getElementById('open-history-btn');
+const closeHistoryBtn = document.getElementById('close-history-btn');
+const historyModal = document.getElementById('history-modal');
+
+openHistoryBtn?.addEventListener('click', () => historyModal?.classList.add('open'));
+closeHistoryBtn?.addEventListener('click', () => historyModal?.classList.remove('open'));
+historyModal?.addEventListener('click', (e) => {
+    if (e.target === historyModal) historyModal.classList.remove('open');
+});
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && historyModal?.classList.contains('open')) {
+        historyModal.classList.remove('open');
+    }
+});
 const clearAllBtn = document.getElementById('clear-all-btn');
 
 function computeFuelMetrics() {

--- a/fuel.html
+++ b/fuel.html
@@ -201,7 +201,16 @@
     }
 
     /* ── Historia transakcji w modalu ─────────────────────── */
-    #history-modal { display: none; }
+    #history-modal {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgb(26 29 31 / 0.58);
+      align-items: center;
+      justify-content: center;
+      z-index: 1200;
+      padding: 14px;
+    }
     #history-modal.open { display: flex; }
     .fuel-history-modal {
       width: min(1500px, 96vw);

--- a/loan.html
+++ b/loan.html
@@ -736,14 +736,20 @@
     }
 
     body[data-page="loan"] .site-header__title {
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       font-size: 18px;
       font-weight: 700;
+      line-height: 1.15;
       letter-spacing: -0.02em;
+      color: #2c2f31;
     }
 
     body[data-page="loan"] .live-badge {
-      background: var(--surface);
-      border: 1px solid var(--line);
+      font-size: 11px;
+      font-weight: 600;
+      color: #595c5e;
+      background: #eff1f3;
+      border: 1px solid #dadde0;
       box-shadow: none;
     }
 

--- a/loan.html
+++ b/loan.html
@@ -3416,9 +3416,9 @@ function renderChartForPanel(panelType) {
     if (shareCanvas) {
       const shareCtx = shareCanvas.getContext('2d');
       const shareLabelFormatter = (value) => `${Number(value).toFixed(1)}%`;
-      const shareLabelOffset = (context) => (context.datasetIndex === 0 ? -8 : 8);
-      const shareLabelColor = (context) => (context.datasetIndex === 0 ? palette.green : palette.orange);
-      const allShareValues = [...sharePrincipal, ...shareInterest].filter((value) => Number.isFinite(value));
+      const shareLabelOffset = () => -8;
+      const shareLabelColor = () => palette.green;
+      const allShareValues = [...sharePrincipal].filter((value) => Number.isFinite(value));
       const shareRawMin = allShareValues.length ? Math.min(...allShareValues) : 0;
       const shareRawMax = allShareValues.length ? Math.max(...allShareValues) : 100;
       const shareSpan = Math.max(shareRawMax - shareRawMin, 6);
@@ -3428,12 +3428,11 @@ function renderChartForPanel(panelType) {
       if (charts.shareArea) {
         charts.shareArea.data.labels = labels;
         charts.shareArea.data.datasets[0].data = sharePrincipal;
-        charts.shareArea.data.datasets[1].data = shareInterest;
         charts.shareArea.options.plugins.datalabels.display = (ctx) => chartLabelState.share && !ctx.dataset.hidden;
         charts.shareArea.options.plugins.datalabels.offset = shareLabelOffset;
         charts.shareArea.options.plugins.datalabels.color = shareLabelColor;
-        charts.shareArea.options.plugins.datalabels.align = (ctx) => (ctx.datasetIndex === 0 ? 'end' : 'start');
-        charts.shareArea.options.plugins.datalabels.anchor = (ctx) => (ctx.datasetIndex === 0 ? 'end' : 'start');
+        charts.shareArea.options.plugins.datalabels.align = 'end';
+        charts.shareArea.options.plugins.datalabels.anchor = 'end';
         charts.shareArea.options.plugins.datalabels.backgroundColor = 'rgba(255, 255, 255, 0.9)';
         charts.shareArea.options.plugins.datalabels.borderRadius = 10;
         charts.shareArea.options.plugins.datalabels.padding = { top: 2, bottom: 2, left: 6, right: 6 };
@@ -3448,8 +3447,7 @@ function renderChartForPanel(panelType) {
           data: {
             labels,
             datasets: [
-              { label: 'Kapitał %', data: sharePrincipal, borderColor: palette.green, backgroundColor: (context) => loanAreaGradient(context.chart, 'rgba(18, 185, 129, 0.18)'), fill: 'origin', tension: 0.38, borderWidth: 3, pointRadius: 0, stack: 'shares' },
-              { label: 'Odsetki %', data: shareInterest, borderColor: palette.orange, backgroundColor: (context) => loanAreaGradient(context.chart, 'rgba(124, 92, 255, 0.16)'), fill: '-1', tension: 0.38, borderWidth: 3, pointRadius: 0, stack: 'shares', hidden: true }
+              { label: 'Kapitał %', data: sharePrincipal, borderColor: palette.green, backgroundColor: (context) => loanAreaGradient(context.chart, 'rgba(18, 185, 129, 0.18)'), fill: 'origin', tension: 0.38, borderWidth: 3, pointRadius: 0, stack: 'shares' }
             ]
           },
           plugins: [ChartDataLabels],
@@ -3463,8 +3461,8 @@ function renderChartForPanel(panelType) {
               }),
               datalabels: {
                 display: (ctx) => chartLabelState.share && !ctx.dataset.hidden,
-                align: (ctx) => (ctx.datasetIndex === 0 ? 'end' : 'start'),
-                anchor: (ctx) => (ctx.datasetIndex === 0 ? 'end' : 'start'),
+                align: 'end',
+                anchor: 'end',
                 clip: false,
                 offset: shareLabelOffset,
                 backgroundColor: 'rgba(255, 255, 255, 0.94)',

--- a/loan.html
+++ b/loan.html
@@ -168,6 +168,17 @@
       display: flex;
     }
 
+    .loan-page-tabs .tab {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .loan-page-tabs .material-symbols-outlined {
+      font-size: 16px;
+      line-height: 1;
+    }
+
     .loan-overview-split {
       display: grid;
       grid-template-columns: minmax(0, 4fr) minmax(260px, 1fr);
@@ -1914,10 +1925,10 @@
 
             <div id="dashboard-container" class="stack tight" style="display: none;">
               <div class="tabs loan-page-tabs" id="loan-page-tabs">
-                <button class="tab active" data-loan-tab="overview">🏦 Przegląd</button>
-                <button class="tab" data-loan-tab="analytics">📊 Hub analityczny</button>
-                <button class="tab" data-loan-tab="schedule">🗓️ Harmonogram spłat</button>
-                <button class="tab" data-loan-tab="history">🧾 Historia spłat</button>
+                <button class="tab active" data-loan-tab="overview"><span class="material-symbols-outlined">home</span>Przegląd</button>
+                <button class="tab" data-loan-tab="analytics"><span class="material-symbols-outlined">analytics</span>Hub analityczny</button>
+                <button class="tab" data-loan-tab="schedule"><span class="material-symbols-outlined">calendar_month</span>Harmonogram spłat</button>
+                <button class="tab" data-loan-tab="history"><span class="material-symbols-outlined">history</span>Historia spłat</button>
               </div>
 
               <div class="loan-page-panel active" data-loan-tab-panel="overview">

--- a/loan.html
+++ b/loan.html
@@ -728,21 +728,23 @@
     body[data-page="loan"] .site-header {
       position: sticky;
       top: 0;
-      z-index: 20;
-      backdrop-filter: blur(16px);
-      background: rgba(247, 249, 255, 0.78);
-      border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+      z-index: 30;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      background: rgba(245, 246, 248, 0.88);
+      border-bottom: 1px solid var(--line);
     }
 
     body[data-page="loan"] .site-header__title {
-      font-size: 1.8rem;
-      letter-spacing: -0.04em;
+      font-size: 18px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
     }
 
     body[data-page="loan"] .live-badge {
-      background: rgba(255, 255, 255, 0.9);
-      border: 1px solid rgba(148, 163, 184, 0.22);
-      box-shadow: 0 10px 30px rgba(15, 23, 42, 0.05);
+      background: var(--surface);
+      border: 1px solid var(--line);
+      box-shadow: none;
     }
 
     body[data-page="loan"] .content {

--- a/loan.html
+++ b/loan.html
@@ -167,6 +167,28 @@
       display: flex;
     }
 
+    .loan-overview-split {
+      display: grid;
+      grid-template-columns: minmax(0, 4fr) minmax(260px, 1fr);
+      gap: 18px;
+      align-items: stretch;
+    }
+
+    .loan-overview-split > .card {
+      height: 100%;
+    }
+
+    .loan-overview-split .fintech-overview-card,
+    .loan-overview-split .fintech-market-card {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .loan-overview-split .fintech-market-list {
+      flex: 1;
+      align-content: start;
+    }
+
     .loan-tab-btn {
       border: 1px solid var(--line);
       background: var(--surface);
@@ -1680,6 +1702,10 @@
         grid-template-columns: 1fr;
       }
 
+      .loan-overview-split {
+        grid-template-columns: 1fr;
+      }
+
       .fintech-rail {
         position: static;
       }
@@ -1873,6 +1899,7 @@
               </div>
 
               <div class="loan-page-panel active" data-loan-tab-panel="overview">
+                <div class="loan-overview-split">
                 <section class="card loan-progress-card fintech-overview-card">
   <div class="fintech-overview-header">
     <div class="fintech-overview-copy">
@@ -2003,6 +2030,7 @@
                     <p class="fintech-expiry-copy">Prognozowany finisz spłaty przy obecnym tempie.</p>
                   </div>
                 </section>
+                </div>
               </div>
 
               <div class="loan-page-panel" data-loan-tab-panel="analytics">

--- a/loan.html
+++ b/loan.html
@@ -1125,7 +1125,7 @@
       border: none;
       border-bottom: 1px solid var(--line);
       box-shadow: none;
-      justify-content: flex-start;
+      justify-content: center;
     }
 
     .loan-tab-btn {

--- a/loan.html
+++ b/loan.html
@@ -157,6 +157,16 @@
       gap: 8px;
     }
 
+    .loan-page-panel {
+      display: none;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .loan-page-panel.active {
+      display: flex;
+    }
+
     .loan-tab-btn {
       border: 1px solid var(--line);
       background: var(--surface);
@@ -754,10 +764,7 @@
     }
 
     body[data-page="loan"] .content {
-      display: grid;
-      grid-template-columns: minmax(0, 1.7fr) minmax(300px, 360px);
-      gap: 28px;
-      align-items: start;
+      display: block;
     }
 
     body[data-page="loan"] .stack.tight {
@@ -1845,8 +1852,15 @@
             </section>
 
             <div id="dashboard-container" class="stack tight" style="display: none;">
-              
-<section class="card loan-progress-card fintech-overview-card">
+              <div class="tabs loan-page-tabs" id="loan-page-tabs">
+                <button class="tab active" data-loan-tab="overview">Przegląd</button>
+                <button class="tab" data-loan-tab="analytics">Hub analityczny</button>
+                <button class="tab" data-loan-tab="schedule">Harmonogram spłat</button>
+                <button class="tab" data-loan-tab="history">Historia spłat</button>
+              </div>
+
+              <div class="loan-page-panel active" data-loan-tab-panel="overview">
+                <section class="card loan-progress-card fintech-overview-card">
   <div class="fintech-overview-header">
     <div class="fintech-overview-copy">
       <span class="fintech-eyebrow">Credit cockpit</span>
@@ -1940,7 +1954,45 @@
     </div>
   </div>
 </section>
+                <section class="card fintech-rail-card fintech-market-card">
+                  <div class="section-heading">
+                    <h2 class="title">Metryki rynkowe</h2>
+                    <span class="tiny muted">Bieżący kontekst Twojego kredytu</span>
+                  </div>
+                  <div class="fintech-market-list">
+                    <div class="fintech-market-row fintech-market-row--rate">
+                      <div class="fintech-market-main">
+                        <span class="fintech-market-label">Aktualne oprocentowanie</span>
+                        <strong class="fintech-market-value" id="rail-current-rate">—</strong>
+                        <div class="fintech-rate-inline">
+                          <div id="rate-history-list" class="fintech-rate-inline-list"></div>
+                        </div>
+                      </div>
+                      <span class="fintech-market-note" id="hero-rate-compact">—</span>
+                    </div>
+                    <div class="fintech-market-row">
+                      <div>
+                        <span class="fintech-market-label">Pozostało rat</span>
+                        <strong class="fintech-market-value" id="rail-remaining-installments">—</strong>
+                      </div>
+                      <span class="fintech-market-note" id="rail-remaining-installments-label"></span>
+                    </div>
+                    <div class="fintech-market-row">
+                      <div>
+                        <span class="fintech-market-label">Średnia rata</span>
+                        <strong class="fintech-market-value" id="rail-average-installment">—</strong>
+                      </div>
+                      <span class="fintech-market-note" id="rail-average-installment-note"></span>
+                    </div>
+                  </div>
+                  <div class="fintech-expiry">
+                    <div class="fintech-expiry-year" id="rail-expiry-year">—</div>
+                    <p class="fintech-expiry-copy">Prognozowany finisz spłaty przy obecnym tempie.</p>
+                  </div>
+                </section>
+              </div>
 
+              <div class="loan-page-panel" data-loan-tab-panel="analytics">
 <section class="card loan-charts-card" id="loan-analytics-card">
                 <div class="section-heading">
                   <h2 class="title">Hub analityczny</h2>
@@ -2022,8 +2074,10 @@
                   </div>
                 </div>
               </section>
+              </div>
 
-              <section class="card schedule-card" id="schedule-card">
+              <div class="loan-page-panel" data-loan-tab-panel="schedule">
+                <section class="card schedule-card" id="schedule-card">
                 <div class="section-heading">
                   <h2 class="title">Harmonogram rat</h2>
                   <span class="tiny muted">Oś czasu spłat z planowanymi ratami i statusami</span>
@@ -2040,8 +2094,10 @@
                   <button class="btn soft" id="schedule-show-more-btn">Pokaż więcej rat</button>
                 </div>
               </section>
+              </div>
 
-              <section class="card loan-table-card">
+              <div class="loan-page-panel" data-loan-tab-panel="history">
+                <section class="card loan-table-card">
                 <div class="section-heading">
                   <h2 class="title">Historia spłat</h2>
                   <span class="tiny muted">Edytuj dowolny wpis, aby zaktualizować harmonogram</span>
@@ -2063,77 +2119,11 @@
                   </table>
                 </div>
               </section>
+              </div>
 
             </div>
           </div>
         </main>
-
-        
-<aside class="right-rail fintech-rail">
-  <section class="card fintech-rail-card fintech-links-card fintech-links-card--hero">
-    <div class="section-heading">
-      <h2 class="title">Szybkie akcje</h2>
-      <span class="tiny muted">Najczęściej używane operacje</span>
-    </div>
-    <button class="fintech-link-btn fintech-link-btn--primary" type="button" onclick="openPaymentModal(null)">
-      <span class="material-symbols-outlined">credit_score</span>
-      <span>Dodaj nową spłatę</span>
-      <span class="material-symbols-outlined">chevron_right</span>
-    </button>
-    <button class="fintech-link-btn" type="button" onclick="openSetupModal()">
-      <span class="material-symbols-outlined">tune</span>
-      <span>Parametry i ustawienia kredytu</span>
-      <span class="material-symbols-outlined">chevron_right</span>
-    </button>
-    <button class="fintech-link-btn" type="button" onclick="document.getElementById('schedule-card')?.scrollIntoView({ behavior: 'smooth', block: 'start' })">
-      <span class="material-symbols-outlined">calendar_month</span>
-      <span>Przejdź do harmonogramu rat</span>
-      <span class="material-symbols-outlined">chevron_right</span>
-    </button>
-    <button class="fintech-link-btn" type="button" onclick="document.querySelector('.loan-table-card')?.scrollIntoView({ behavior: 'smooth', block: 'start' })">
-      <span class="material-symbols-outlined">history</span>
-      <span>Przejdź do historii spłat</span>
-      <span class="material-symbols-outlined">chevron_right</span>
-    </button>
-  </section>
-
-  <section class="card fintech-rail-card fintech-market-card">
-    <div class="section-heading">
-      <h2 class="title">Metryki rynkowe</h2>
-      <span class="tiny muted">Bieżący kontekst Twojego kredytu</span>
-    </div>
-    <div class="fintech-market-list">
-      <div class="fintech-market-row fintech-market-row--rate">
-        <div class="fintech-market-main">
-          <span class="fintech-market-label">Aktualne oprocentowanie</span>
-          <strong class="fintech-market-value" id="rail-current-rate">—</strong>
-          <div class="fintech-rate-inline">
-            <div id="rate-history-list" class="fintech-rate-inline-list"></div>
-          </div>
-        </div>
-        <span class="fintech-market-note" id="hero-rate-compact">—</span>
-      </div>
-      <div class="fintech-market-row">
-        <div>
-          <span class="fintech-market-label">Pozostało rat</span>
-          <strong class="fintech-market-value" id="rail-remaining-installments">—</strong>
-        </div>
-        <span class="fintech-market-note" id="rail-remaining-installments-label"></span>
-      </div>
-      <div class="fintech-market-row">
-        <div>
-          <span class="fintech-market-label">Średnia rata</span>
-          <strong class="fintech-market-value" id="rail-average-installment">—</strong>
-        </div>
-        <span class="fintech-market-note" id="rail-average-installment-note"></span>
-      </div>
-    </div>
-    <div class="fintech-expiry">
-      <div class="fintech-expiry-year" id="rail-expiry-year">—</div>
-      <p class="fintech-expiry-copy">Prognozowany finisz spłaty przy obecnym tempie.</p>
-    </div>
-  </section>
-</aside>
       </div>
     </div>
   </div>
@@ -3953,6 +3943,27 @@ function setupLoanChartTabs() {
   });
 }
 
+function setupLoanPageTabs() {
+  const tabButtons = Array.from(document.querySelectorAll('[data-loan-tab]'));
+  const tabPanels = Array.from(document.querySelectorAll('[data-loan-tab-panel]'));
+  if (!tabButtons.length || !tabPanels.length) return;
+
+  tabButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const target = button.dataset.loanTab;
+      if (!target || button.classList.contains('active')) return;
+
+      tabButtons.forEach((btn) => btn.classList.toggle('active', btn === button));
+      tabPanels.forEach((panel) => panel.classList.toggle('active', panel.dataset.loanTabPanel === target));
+
+      if (target === 'analytics') {
+        const activeAnalyticsTab = document.querySelector('.loan-tab-btn.active');
+        renderChartForPanel(activeAnalyticsTab?.dataset.chart || 'mix');
+      }
+    });
+  });
+}
+
 /* === Projections === */
 function generateProjections(count = 3) {
   const { loanDetails, payments } = state;
@@ -4320,6 +4331,7 @@ function setupScheduleControls() {
 function init() {
   loadState();
   render();
+  setupLoanPageTabs();
   setupLoanChartTabs();
   setupLoanChartToggles();
   setupChangeModeSwitch();

--- a/loan.html
+++ b/loan.html
@@ -155,6 +155,7 @@
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
+      justify-content: center;
     }
 
     .loan-page-panel {
@@ -2207,8 +2208,8 @@ let state = {};
 let charts = {};
 let chartDataCache = null;
 const chartLabelState = {
-  line: false,
-  share: false,
+  line: true,
+  share: true,
   cumulative: false,
   change: false
 };
@@ -3378,7 +3379,7 @@ function renderChartForPanel(panelType) {
           data: {
             labels,
             datasets: [
-              { label: 'Kapitał', data: principalSeries, borderColor: palette.green, backgroundColor: (context) => loanAreaGradient(context.chart, 'rgba(18, 185, 129, 0.16)'), fill: true, tension: 0.38, borderWidth: 3, pointRadius: 0, pointHoverRadius: 7, pointBackgroundColor: palette.card, pointBorderColor: palette.green, pointBorderWidth: 2 },
+              { label: 'Kapitał', data: principalSeries, borderColor: palette.green, backgroundColor: (context) => loanAreaGradient(context.chart, 'rgba(18, 185, 129, 0.16)'), fill: true, tension: 0.38, borderWidth: 3, pointRadius: 0, pointHoverRadius: 7, pointBackgroundColor: palette.card, pointBorderColor: palette.green, pointBorderWidth: 2, hidden: true },
               { label: 'Odsetki', data: interestSeries, borderColor: palette.orange, backgroundColor: (context) => loanAreaGradient(context.chart, 'rgba(124, 92, 255, 0.14)'), fill: true, tension: 0.38, borderWidth: 3, pointRadius: 0, pointHoverRadius: 7, pointBackgroundColor: palette.card, pointBorderColor: palette.orange, pointBorderWidth: 2 }
             ]
           },
@@ -3452,7 +3453,7 @@ function renderChartForPanel(panelType) {
             labels,
             datasets: [
               { label: 'Kapitał %', data: sharePrincipal, borderColor: palette.green, backgroundColor: (context) => loanAreaGradient(context.chart, 'rgba(18, 185, 129, 0.18)'), fill: 'origin', tension: 0.38, borderWidth: 3, pointRadius: 0, stack: 'shares' },
-              { label: 'Odsetki %', data: shareInterest, borderColor: palette.orange, backgroundColor: (context) => loanAreaGradient(context.chart, 'rgba(124, 92, 255, 0.16)'), fill: '-1', tension: 0.38, borderWidth: 3, pointRadius: 0, stack: 'shares' }
+              { label: 'Odsetki %', data: shareInterest, borderColor: palette.orange, backgroundColor: (context) => loanAreaGradient(context.chart, 'rgba(124, 92, 255, 0.16)'), fill: '-1', tension: 0.38, borderWidth: 3, pointRadius: 0, stack: 'shares', hidden: true }
             ]
           },
           plugins: [ChartDataLabels],

--- a/loan.html
+++ b/loan.html
@@ -1914,10 +1914,10 @@
 
             <div id="dashboard-container" class="stack tight" style="display: none;">
               <div class="tabs loan-page-tabs" id="loan-page-tabs">
-                <button class="tab active" data-loan-tab="overview">Przegląd</button>
-                <button class="tab" data-loan-tab="analytics">Hub analityczny</button>
-                <button class="tab" data-loan-tab="schedule">Harmonogram spłat</button>
-                <button class="tab" data-loan-tab="history">Historia spłat</button>
+                <button class="tab active" data-loan-tab="overview">🏦 Przegląd</button>
+                <button class="tab" data-loan-tab="analytics">📊 Hub analityczny</button>
+                <button class="tab" data-loan-tab="schedule">🗓️ Harmonogram spłat</button>
+                <button class="tab" data-loan-tab="history">🧾 Historia spłat</button>
               </div>
 
               <div class="loan-page-panel active" data-loan-tab-panel="overview">

--- a/loan.html
+++ b/loan.html
@@ -710,25 +710,21 @@
   
     /* === Fintech redesign layer === */
     body[data-page="loan"] {
-      --blue: #2563eb;
-      --blue-soft: rgba(37, 99, 235, 0.12);
-      --green: #0f9f6e;
-      --green-soft: rgba(15, 159, 110, 0.12);
-      --orange: #f97316;
-      --orange-soft: rgba(249, 115, 22, 0.14);
-      --ink: #0f172a;
-      --muted: #64748b;
-      --line: rgba(148, 163, 184, 0.24);
+      --blue: #0057c0;
+      --blue-soft: #dbeafe;
+      --green: #059669;
+      --green-soft: #dcfce7;
+      --orange: #ea580c;
+      --orange-soft: #ffedd5;
+      --ink: #2c2f31;
+      --muted: #595c5e;
+      --line: #dadde0;
       --card: #ffffff;
-      --surface: #eef4ff;
-      --accent: #2563eb;
-      --accent-weak: rgba(37, 99, 235, 0.12);
-      --shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.12);
-      background:
-        radial-gradient(circle at top left, rgba(37, 99, 235, 0.06), transparent 24%),
-        radial-gradient(circle at top right, rgba(15, 159, 110, 0.05), transparent 20%),
-        linear-gradient(180deg, #f7f9ff 0%, #f3f6ff 100%);
+      --surface: #eff1f3;
+      --accent: #0057c0;
+      --accent-weak: hsl(214 70% 94%);
       color: var(--ink);
+      background: var(--bg);
     }
 
     body[data-page="loan"] .main {
@@ -743,6 +739,8 @@
       -webkit-backdrop-filter: blur(12px);
       background: rgba(245, 246, 248, 0.88);
       border-bottom: 1px solid var(--line);
+      height: var(--topbar-height);
+      padding: 0 32px;
     }
 
     body[data-page="loan"] .site-header__title {
@@ -765,6 +763,15 @@
 
     body[data-page="loan"] .content {
       display: block;
+    }
+
+    body[data-page="loan"] .content > .stack.tight {
+      padding: 20px 28px 36px;
+      gap: 24px;
+    }
+
+    body[data-page="loan"] #dashboard-container > .loan-page-tabs {
+      margin-top: 12px;
     }
 
     body[data-page="loan"] .stack.tight {
@@ -1683,6 +1690,12 @@
 
       .fintech-inline-metrics {
         grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+    }
+
+    @media (max-width: 768px) {
+      body[data-page="loan"] .content > .stack.tight {
+        padding: 16px;
       }
     }
 

--- a/loan.html
+++ b/loan.html
@@ -1759,6 +1759,18 @@
   </style>
 
 <style id="loan-v3-overrides">
+  body[data-page="loan"] [data-loan-tab-panel="analytics"] {
+    min-height: 78vh;
+  }
+
+  body[data-page="loan"] #loan-analytics-card {
+    min-height: 100%;
+  }
+
+  body[data-page="loan"] #loan-tab-panels {
+    min-height: 420px;
+  }
+
   body[data-page="loan"] .loan-chart-grid {
     grid-template-columns: minmax(0, 1.62fr) minmax(360px, 1.08fr);
     gap: 20px;
@@ -1775,10 +1787,11 @@
 
   body[data-page="loan"] .loan-chart-area {
     padding: 18px 18px 10px;
+    min-height: 420px !important;
   }
 
   body[data-page="loan"] .loan-donut-area {
-    min-height: 318px;
+    min-height: 414px;
     padding: 14px;
   }
 
@@ -1787,12 +1800,20 @@
   }
 
   @media (max-width: 1200px) {
+    body[data-page="loan"] [data-loan-tab-panel="analytics"] {
+      min-height: 0;
+    }
+
+    body[data-page="loan"] #loan-tab-panels {
+      min-height: 0;
+    }
+
     body[data-page="loan"] .loan-chart-grid {
       grid-template-columns: 1fr;
     }
 
     body[data-page="loan"] .loan-donut-area {
-      min-height: 300px;
+      min-height: 340px;
     }
   }
 </style>

--- a/loan.html
+++ b/loan.html
@@ -1119,30 +1119,38 @@
 
     .loan-tab-nav {
       gap: 10px;
-      padding: 8px;
-      border-radius: 22px;
-      background: linear-gradient(180deg, rgba(248,250,255,0.96), rgba(233,240,255,0.82));
-      border: 1px solid rgba(148, 163, 184, 0.14);
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.78);
+      padding: 8px 0 12px;
+      border-radius: 0;
+      background: transparent;
+      border: none;
+      border-bottom: 1px solid var(--line);
+      box-shadow: none;
+      justify-content: flex-start;
     }
 
     .loan-tab-btn {
-      font-size: 11px;
-      letter-spacing: 0.08em;
-      padding: 11px 16px;
-      border-radius: 16px;
+      font-size: 13px;
+      letter-spacing: 0;
+      text-transform: none;
+      padding: 8px 14px;
+      border-radius: 10px;
       border: 1px solid transparent;
-      background: rgba(255,255,255,0.12);
-      color: #475569;
-      font-weight: 800;
-      transition: transform 0.18s ease, box-shadow 0.18s ease, color 0.18s ease, background 0.18s ease;
+      background: transparent;
+      color: var(--muted);
+      font-weight: 600;
+      transition: background var(--transition), color var(--transition), border-color var(--transition);
     }
 
     .loan-tab-btn.active {
-      color: #1d4ed8;
-      background: linear-gradient(180deg, rgba(255,255,255,1), rgba(247,250,255,0.96));
-      box-shadow: 0 16px 32px rgba(37,99,235,0.12);
-      transform: translateY(-1px);
+      color: var(--ink);
+      background: var(--card);
+      border-color: var(--line);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .loan-tab-btn:hover {
+      background: var(--surface);
+      color: var(--ink);
     }
 
     .loan-chart-actions {

--- a/loan.html
+++ b/loan.html
@@ -3416,22 +3416,15 @@ function renderChartForPanel(panelType) {
     if (shareCanvas) {
       const shareCtx = shareCanvas.getContext('2d');
       const shareLabelFormatter = (value) => `${Number(value).toFixed(1)}%`;
-      const shareLabelOffset = (context) => {
-        const chart = context.chart;
-        const datasetIndex = context.datasetIndex;
-        const dataIndex = context.dataIndex;
-        const yScale = chart.scales.y;
-        if (!yScale) return 0;
-        const meta = chart.getDatasetMeta(datasetIndex);
-        if (!meta || !meta.data || !meta.data[dataIndex]) return 0;
-        const element = meta.data[dataIndex];
-        const target = datasetIndex === 0 ? 10 : 80;
-        const targetPixel = yScale.getPixelForValue(target);
-        const baseOffset = targetPixel - element.y;
-        const separation = datasetIndex === 0 ? -14 : 14;
-        return baseOffset + separation;
-      };
+      const shareLabelOffset = (context) => (context.datasetIndex === 0 ? -8 : 8);
       const shareLabelColor = (context) => (context.datasetIndex === 0 ? palette.green : palette.orange);
+      const allShareValues = [...sharePrincipal, ...shareInterest].filter((value) => Number.isFinite(value));
+      const shareRawMin = allShareValues.length ? Math.min(...allShareValues) : 0;
+      const shareRawMax = allShareValues.length ? Math.max(...allShareValues) : 100;
+      const shareSpan = Math.max(shareRawMax - shareRawMin, 6);
+      const sharePadding = Math.max(3, shareSpan * 0.15);
+      const shareAxisMin = Math.max(0, Math.floor((shareRawMin - sharePadding) * 10) / 10);
+      const shareAxisMax = Math.min(100, Math.ceil((shareRawMax + sharePadding) * 10) / 10);
       if (charts.shareArea) {
         charts.shareArea.data.labels = labels;
         charts.shareArea.data.datasets[0].data = sharePrincipal;
@@ -3445,6 +3438,9 @@ function renderChartForPanel(panelType) {
         charts.shareArea.options.plugins.datalabels.borderRadius = 10;
         charts.shareArea.options.plugins.datalabels.padding = { top: 2, bottom: 2, left: 6, right: 6 };
         charts.shareArea.options.plugins.datalabels.formatter = shareLabelFormatter;
+        charts.shareArea.options.scales.y.min = shareAxisMin;
+        charts.shareArea.options.scales.y.max = shareAxisMax;
+        charts.shareArea.options.scales.y.stacked = false;
         charts.shareArea.update();
       } else {
         charts.shareArea = new Chart(shareCtx, {
@@ -3481,7 +3477,7 @@ function renderChartForPanel(panelType) {
             },
             scales: {
               x: loanAxisX({ grid: { display: false, drawOnChartArea: false } }),
-              y: loanAxisY((value) => `${value}%`, { stacked: true, min: 0, max: 100 })
+              y: loanAxisY((value) => `${value}%`, { stacked: false, min: shareAxisMin, max: shareAxisMax })
             }
           }
         });

--- a/styles.css
+++ b/styles.css
@@ -905,6 +905,9 @@ textarea:focus {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  line-height: 1.1;
+  white-space: nowrap;
+  vertical-align: middle;
 }
 
 .kpi-status-icon {

--- a/styles.css
+++ b/styles.css
@@ -901,6 +901,25 @@ textarea:focus {
   line-height: 1.2;
 }
 
+.kpi-status-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.kpi-status-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.kpi-status-inline.is-positive .kpi-status-icon {
+  color: var(--success);
+}
+
+.kpi-status-inline.is-warning .kpi-status-icon {
+  color: var(--danger);
+}
+
 .insight-bubble {
   font-size: 12px;
   padding: 8px 10px;

--- a/tasks.html
+++ b/tasks.html
@@ -71,9 +71,6 @@
     body {
       background: var(--bg);
       color: var(--ink);
-      font-family: 'Inter', system-ui, sans-serif;
-      font-size: 13px;
-      line-height: 1.5;
       -webkit-font-smoothing: antialiased;
     }
 

--- a/tasks.html
+++ b/tasks.html
@@ -244,7 +244,7 @@
       padding:24px; box-shadow:var(--sh-sm);
     }
     .sec-head { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; margin-bottom:18px; }
-    .sec-title { font-size:15px; font-weight:900; letter-spacing:-.3px; display:flex; align-items:center; gap:8px; }
+    .sec-title { font-size:16px; font-weight:700; letter-spacing:.2px; display:flex; align-items:center; gap:8px; }
     .sec-sub { font-size:11px; color:var(--muted2); margin-top:2px; }
 
     /* Task card — Editorial CRM style with left accent bar */

--- a/tasks.html
+++ b/tasks.html
@@ -72,8 +72,8 @@
       background: var(--bg);
       color: var(--ink);
       font-family: 'Inter', system-ui, sans-serif;
-      font-size: 13px;
-      line-height: 1.5;
+      font-size: 14px;
+      line-height: 1.6;
       -webkit-font-smoothing: antialiased;
     }
 
@@ -111,7 +111,7 @@
       border-radius: var(--r-sm); padding: 8px 16px;
       border: 1.5px solid var(--line2);
       background: var(--card); color: var(--ink);
-      cursor: pointer; font-weight: 700; font-size: 11px; letter-spacing: .3px;
+      cursor: pointer; font-weight: 600; font-size: 13px; letter-spacing: 0;
       font-family: inherit; white-space: nowrap; user-select: none;
       transition: background .15s, transform .12s, box-shadow .15s, border-color .15s;
     }

--- a/tasks.html
+++ b/tasks.html
@@ -331,7 +331,7 @@
     .dp-head { padding:18px 20px 14px; border-bottom:1px solid var(--line); background:var(--surf-lo); }
     .dp-date { font-size:17px; font-weight:900; line-height:1.1; letter-spacing:-.4px; }
     .dp-dow  { font-size:10px; color:var(--muted2); margin-top:4px; font-weight:800; text-transform:uppercase; letter-spacing:.6px; }
-    .dp-body { padding:12px; display:flex; flex-direction:column; gap:8px; min-height:180px; max-height:380px; overflow-y:auto; }
+    .dp-body { padding:12px; display:flex; flex-direction:column; gap:8px; min-height:180px; max-height:min(570px, calc(100vh - 260px)); overflow-y:auto; }
     .dp-task { display:flex; align-items:flex-start; gap:8px; padding:10px 12px; border-radius:var(--r-lg); background:var(--surf-lo); border:1px solid var(--line); border-left:3px solid var(--blue); transition:box-shadow .12s, transform .12s; }
     .dp-task:hover { box-shadow:var(--sh-sm); transform:translateX(2px); }
     .dp-task input[type=checkbox] { width:14px; height:14px; accent-color:var(--blue); flex-shrink:0; margin-top:2px; }

--- a/tasks.html
+++ b/tasks.html
@@ -172,40 +172,38 @@
     .seg-item:hover { color:var(--ink); }
     .seg-item.active { background:var(--card); color:var(--ink); box-shadow:var(--sh-xs); }
 
-    /* ── MODULE NAV — underline tabs style ── */
+    /* ── MODULE NAV — aligned with budget tabs ── */
     .module-nav {
       display:flex;
-      gap:10px;
-      flex-wrap:wrap;
+      gap:6px;
+      flex-wrap:nowrap;
       position:sticky;
       top:0;
       background:var(--bg);
       z-index:8;
-      padding:8px 0 0;
+      padding:8px 0;
       margin:12px 0 0;
-      border-bottom:1px solid var(--line);
       overflow-x:auto;
     }
     .mod-tab {
-      display:flex;
+      display:inline-flex;
       align-items:center;
-      gap:6px;
-      padding:8px 4px 10px;
-      border-radius:0;
-      border:none;
-      border-bottom:2px solid transparent;
-      background:transparent;
+      gap:4px;
+      padding:7px 10px;
+      border-radius:var(--r-xs);
+      border:1px solid var(--line);
+      background:var(--surface);
       color:var(--muted);
-      font-weight:600;
-      font-size:13px;
+      font-weight:700;
+      font-size:12px;
       cursor:pointer;
-      transition:color var(--transition), border-color var(--transition);
+      transition:all var(--transition);
       white-space:nowrap;
       flex-shrink:0;
     }
-    .mod-tab .material-symbols-outlined { font-size:16px; line-height:1; }
-    .mod-tab:hover { color:var(--ink); }
-    .mod-tab.active { color:var(--ink); border-bottom-color:var(--blue); }
+    .mod-tab .material-symbols-outlined { font-size:14px; line-height:1; }
+    .mod-tab:hover { color:var(--ink); border-color:var(--blue-bg); }
+    .mod-tab.active { color:var(--ink); border-color:var(--blue-bg); background:var(--blue-tint); }
     .module { display:none; margin-top:12px; }
     .module.active { display:block; animation:fadeUp .22s ease-out; }
 

--- a/tasks.html
+++ b/tasks.html
@@ -79,7 +79,11 @@
 
     /* ── LAYOUT FIXES ── */
     .main { flex: 1; min-width: 0; width: 0; }
-    .content { width: 100%; max-width: 100%; }
+    .content {
+      display: block;
+      width: 100%;
+      max-width: 100%;
+    }
     .page-content { width: 100%; max-width: 100% !important; }
 
     /* ── ANIMATIONS ── */

--- a/tasks.html
+++ b/tasks.html
@@ -178,24 +178,38 @@
 
     /* ── MODULE NAV — pill style ── */
     .module-nav {
-      display:flex; gap:3px; padding:5px;
-      margin-bottom:24px;
-      background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl);
-      box-shadow:var(--sh-sm);
-      position:sticky; top:0; z-index:100; overflow-x:auto;
+      display:flex;
+      gap:10px;
+      flex-wrap:wrap;
+      position:sticky;
+      top:0;
+      background:var(--bg);
+      z-index:8;
+      padding:8px 0;
+      margin:12px 0 0;
+      border-bottom:1px solid var(--line);
+      overflow-x:auto;
     }
     .mod-tab {
-      display:flex; align-items:center; gap:6px;
-      padding:9px 18px; border-radius:16px;
-      cursor:pointer; font-weight:800; font-size:10px; letter-spacing:.5px; text-transform:uppercase;
-      color:var(--muted2); background:transparent; border:1.5px solid transparent;
-      transition:all .18s ease; white-space:nowrap; flex-shrink:0;
+      display:flex;
+      align-items:center;
+      gap:6px;
+      padding:8px 14px;
+      border-radius:10px;
+      border:1px solid transparent;
+      background:transparent;
+      color:var(--muted);
+      font-weight:600;
+      font-size:13px;
+      cursor:pointer;
+      transition:background var(--transition), color var(--transition), border-color var(--transition);
+      white-space:nowrap;
+      flex-shrink:0;
     }
     .mod-tab .material-symbols-outlined { font-size:16px; line-height:1; }
-    .mod-tab:hover { background:var(--surf-lo); color:var(--ink); }
-    .mod-tab.active { background:var(--blue); color:#fff; box-shadow:0 3px 12px rgb(0 87 192/.28); }
-    .mod-tab.active .material-symbols-outlined { color:#fff; }
-    .module { display:none; }
+    .mod-tab:hover { background:var(--surface); color:var(--ink); }
+    .mod-tab.active { background:var(--card); border-color:var(--line); color:var(--ink); box-shadow:var(--shadow-sm); }
+    .module { display:none; margin-top:12px; }
     .module.active { display:block; animation:fadeUp .22s ease-out; }
 
     /* ── MODAL ── */

--- a/tasks.html
+++ b/tasks.html
@@ -533,12 +533,12 @@
     .prj-sidebar-head { display:flex; align-items:center; justify-content:space-between; padding:13px 16px; border-bottom:1px solid var(--line); background:var(--surf-lo); }
     .prj-sidebar-title { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; }
     .prj-list-empty { padding:16px; font-size:11px; color:var(--muted2); }
-    .prj-list-item { display:flex; align-items:center; gap:9px; padding:10px 16px; cursor:pointer; border-bottom:1px solid var(--line); transition:background .1s; }
+    .prj-list-item { display:flex; align-items:flex-start; gap:9px; padding:10px 16px; cursor:pointer; border-bottom:1px solid var(--line); transition:background .1s; }
     .prj-list-item:hover { background:var(--surf-lo); }
     .prj-list-item.active { background:var(--blue-tint); }
     .prj-list-item.active .prj-list-title { color:var(--blue); }
     .prj-color-dot { width:9px; height:9px; border-radius:50%; flex-shrink:0; }
-    .prj-list-title { font-size:12px; font-weight:700; flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    .prj-list-title { font-size:12px; font-weight:700; flex:1; white-space:normal; overflow:visible; text-overflow:clip; line-height:1.35; min-height:calc(1.35em * 2); }
     .prj-list-count { font-size:10px; color:var(--muted2); background:var(--surf-lo); border:1px solid var(--line); padding:1px 6px; border-radius:999px; font-weight:700; }
     .prj-ph { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:10px; min-height:260px; color:var(--muted2); text-align:center; padding:24px; }
     .prj-board-head { display:flex; align-items:flex-start; justify-content:space-between; gap:16px; margin-bottom:18px; padding:18px 20px; background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); flex-wrap:wrap; }
@@ -883,9 +883,9 @@
               <span class="material-symbols-outlined" style="font-size:16px;color:var(--blue)">add_task</span>
               Nowe zadanie
             </strong>
-            <button class="btn sm ghost" id="qa-toggle">Zwiń</button>
+            <button class="btn sm ghost" id="qa-toggle">Rozwiń</button>
           </div>
-          <div class="qa-body open" id="qa-body">
+          <div class="qa-body" id="qa-body">
             <input type="hidden" id="f-edit-id">
             <div class="fgrid g3" style="margin-bottom:12px">
               <div class="fg"><label class="fl">Tytuł *</label><input type="text" id="f-title" placeholder="Np. Przygotuj prezentację"></div>

--- a/tasks.html
+++ b/tasks.html
@@ -79,7 +79,7 @@
 
     /* ── LAYOUT FIXES ── */
     .main { flex: 1; min-width: 0; width: 0; }
-    .content { width: 100%; max-width: 100%; }
+    .content { width: 100%; max-width: 100%; grid-template-columns: minmax(0,1fr); }
     .page-content { width: 100%; max-width: 100% !important; }
 
     /* ── ANIMATIONS ── */
@@ -172,38 +172,39 @@
     .seg-item:hover { color:var(--ink); }
     .seg-item.active { background:var(--card); color:var(--ink); box-shadow:var(--sh-xs); }
 
-    /* ── MODULE NAV — aligned with budget tabs ── */
+    /* ── MODULE NAV — 1:1 with trainings subnav ── */
     .module-nav {
       display:flex;
-      gap:6px;
-      flex-wrap:nowrap;
+      align-items:center;
+      gap:10px;
+      flex-wrap:wrap;
       position:sticky;
       top:0;
       background:var(--bg);
       z-index:8;
-      padding:8px 0;
+      padding:8px 0 12px;
       margin:12px 0 0;
+      border-bottom:1px solid var(--line);
       overflow-x:auto;
     }
     .mod-tab {
       display:inline-flex;
       align-items:center;
-      gap:4px;
-      padding:7px 10px;
-      border-radius:var(--r-xs);
-      border:1px solid var(--line);
-      background:var(--surface);
+      gap:6px;
+      padding:8px 14px;
+      border-radius:10px;
+      border:1px solid transparent;
+      background:transparent;
       color:var(--muted);
-      font-weight:700;
-      font-size:12px;
+      font-weight:600;
+      font-size:13px;
       cursor:pointer;
-      transition:all var(--transition);
+      transition:background var(--transition), color var(--transition), border-color var(--transition);
       white-space:nowrap;
-      flex-shrink:0;
     }
-    .mod-tab .material-symbols-outlined { font-size:14px; line-height:1; }
-    .mod-tab:hover { color:var(--ink); border-color:var(--blue-bg); }
-    .mod-tab.active { color:var(--ink); border-color:var(--blue-bg); background:var(--blue-tint); }
+    .mod-tab .material-symbols-outlined { font-size:16px; line-height:1; }
+    .mod-tab:hover { background:var(--surface); color:var(--ink); }
+    .mod-tab.active { background:var(--card); border-color:var(--line); color:var(--ink); box-shadow:var(--shadow-sm); }
     .module { display:none; margin-top:12px; }
     .module.active { display:block; animation:fadeUp .22s ease-out; }
 

--- a/tasks.html
+++ b/tasks.html
@@ -1142,7 +1142,7 @@ const STORE='lifeos_workhub_v1',OLD='lifeos_tasks_pro_v2',DAY=86400000;
 const DEF_MEMBERS=[{id:'m1',name:'Pracownik 1',role:'',color:'#6366f1',profileNote:'',specialties:[]},{id:'m2',name:'Pracownik 2',role:'',color:'#f59e0b',profileNote:'',specialties:[]},{id:'m3',name:'Pracownik 3',role:'',color:'#10b981',profileNote:'',specialties:[]},{id:'m4',name:'Pracownik 4',role:'',color:'#f43f5e',profileNote:'',specialties:[]}];
 let S={tasks:[],members:[...DEF_MEMBERS],teamTasks:[],notes:[],selfNotes:[],projects:[]};
 let charts={};
-let calDate=todayUTC(),calSel=null,calFilter=new Set(['me','m1','m2','m3','m4']);
+let calDate=todayUTC(),calSel=null,calFilter=new Set();
 let selMember=null,activePTab='tasks',collGroups=new Set(),expandedRows=new Set(),formSubs=[],modalSteps=[],goalExpandedIds=new Set();
 let selectedTaskIds=new Set(),currentVisibleTaskIds=[];
 let statsR=7,statsC='all';
@@ -1184,17 +1184,18 @@ const uniqIds=arr=>[...new Set((Array.isArray(arr)?arr:[]).map(x=>(x||'').toStri
 function buildCalFilter(){
   const el=document.getElementById('cal-filter');if(!el)return;
   const chips=[{id:'me',label:'Ja',color:'var(--blue)',init:'M'},...S.members.map(m=>({id:m.id,label:m.name.split(' ')[0],color:m.color,init:m.name.charAt(0).toUpperCase()}))];
-  el.innerHTML='<span class="small muted" style="font-weight:800;font-size:10px;text-transform:uppercase;letter-spacing:.6px;margin-right:4px">Pokaż:</span>'+chips.map(c=>`<div class="pf-chip ${calFilter.has(c.id)?'active':''}" data-cid="${c.id}" style="color:${c.color}"><div class="pf-av" style="background:${c.color}">${c.init}</div>${c.label}</div>`).join('');
+  el.innerHTML='<span class="small muted" style="font-weight:800;font-size:10px;text-transform:uppercase;letter-spacing:.6px;margin-right:4px">Pokaż:</span><span class="small muted" style="font-size:10px">Brak zaznaczeń = cały zespół</span>'+chips.map(c=>`<div class="pf-chip ${calFilter.has(c.id)?'active':''}" data-cid="${c.id}" style="color:${c.color}"><div class="pf-av" style="background:${c.color}">${c.init}</div>${c.label}</div>`).join('');
   el.querySelectorAll('.pf-chip').forEach(chip=>chip.addEventListener('click',()=>{const id=chip.dataset.cid;calFilter.has(id)?calFilter.delete(id):calFilter.add(id);buildCalFilter();renderCalendar();if(calSel)updateDayPanel(calSel);}));
 }
 function getCalTasks(){
   const tasks=[];
-  if(calFilter.has('me'))S.tasks.forEach(t=>tasks.push({...t,_owner:'me',_color:'var(--blue)'}));
-  S.members.forEach(m=>{if(!calFilter.has(m.id))return;S.teamTasks.filter(t=>t.assigneeId===m.id).forEach(t=>tasks.push({...t,_owner:m.id,_ownerName:m.name,_color:m.color,category:'work'}));});
+  const showAll=calFilter.size===0;
+  if(showAll||calFilter.has('me'))S.tasks.forEach(t=>tasks.push({...t,_owner:'me',_color:'var(--blue)'}));
+  S.members.forEach(m=>{if(!showAll&&!calFilter.has(m.id))return;S.teamTasks.filter(t=>t.assigneeId===m.id).forEach(t=>tasks.push({...t,_owner:m.id,_ownerName:m.name,_color:m.color,category:'work'}));});
   // Project cards — one entry per matching assignee (so card shows in each person's row)
   S.projects.filter(p=>p.status==='active').forEach(proj=>{
     proj.cards.filter(c=>c.dueDate&&c.stage!=='done').forEach(card=>{
-      uniqIds(card.assignees).filter(a=>calFilter.has(a)).forEach(owner=>{
+      uniqIds(card.assignees).filter(a=>showAll||calFilter.has(a)).forEach(owner=>{
         const m=owner==='me'?null:S.members.find(x=>x.id===owner);
         tasks.push({id:card.id,title:`◈ ${card.title}`,dueDate:card.dueDate,priority:card.priority,status:'todo',_owner:owner,_ownerName:m?.name,_color:proj.color,_isProject:true,_projectId:proj.id,category:'work'});
       });

--- a/tasks.html
+++ b/tasks.html
@@ -1217,6 +1217,13 @@ function renderCalendar(){
     const dt=(byDate[ds]||[]).sort((a,b)=>priW(a.priority)-priW(b.priority));
     const owners={};
     dt.forEach(task=>{const key=task._owner||'me';if(!owners[key])owners[key]={name:key==='me'?'Ja':(task._ownerName||S.members.find(m=>m.id===key)?.name||'Członek'),color:task._color||'#64748b',tasks:[]};owners[key].tasks.push(task);});
+    Object.values(owners).forEach(ownerGroup=>{
+      ownerGroup.tasks.sort((a,b)=>{
+        const doneDelta=(a.status==='done')-(b.status==='done');
+        if(doneDelta!==0) return doneDelta;
+        return priW(a.priority)-priW(b.priority);
+      });
+    });
     const ownerBlocks=Object.entries(owners).map(([ownerKey,o])=>`<div class="cal-own"><div class="cal-own-h"><span class="dot" style="background:${o.color}"></span>${escH(o.name)} <span style="font-size:8px;opacity:.6">(${o.tasks.length})</span></div>${o.tasks.map(t=>`<div class="cal-pill prio-${t.priority} ${t.status==='done'?'is-done':''}" style="border-left-color:${o.color}" draggable="true" data-move-id="${t.id}" data-move-own="${ownerKey}"><span>${escH(t.title)}</span></div>`).join('')}</div>`).join('');
     html+=`<div class="cal-day ${cls}" data-ds="${ds}"><span class="cal-dn">${d.getUTCDate()}</span><div class="cal-pills">${ownerBlocks||''}</div></div>`;
   }
@@ -1236,7 +1243,16 @@ function updateDayPanel(ds){
   dpDow.textContent=d.toLocaleDateString('pl-PL',{weekday:'long'});
   const _raw=getCalTasks().filter(t=>t.dueDate===ds);
   const _seen=new Set();
-  const tasks=_raw.filter(t=>{if(!t._isProject)return true;if(_seen.has(t.id))return false;_seen.add(t.id);return true;});
+  const tasks=_raw
+    .filter(t=>{if(!t._isProject)return true;if(_seen.has(t.id))return false;_seen.add(t.id);return true;})
+    .sort((a,b)=>{
+      const doneDelta=(a.status==='done')-(b.status==='done');
+      if(doneDelta!==0) return doneDelta;
+      const ownerA=(a._owner==='me'?'Ja':(a._ownerName||S.members.find(m=>m.id===a._owner)?.name||'Członek')).toLowerCase();
+      const ownerB=(b._owner==='me'?'Ja':(b._ownerName||S.members.find(m=>m.id===b._owner)?.name||'Członek')).toLowerCase();
+      if(ownerA!==ownerB) return ownerA.localeCompare(ownerB,'pl');
+      return priW(a.priority)-priW(b.priority);
+    });
   if(!tasks.length){dpBody.innerHTML=`<div class="dp-empty">📭<br>Brak zadań — dodaj poniżej.</div>`;}
   else{
     dpBody.innerHTML=tasks.map(t=>{const m=t._owner!=='me'?S.members.find(x=>x.id===t._owner):null;const bdrColor=t.priority==='high'?'var(--red)':t.priority==='medium'?'var(--amber)':'var(--green)';return `<div class="dp-task" style="border-left-color:${bdrColor}"><input type="checkbox" data-dpid="${t.id}" data-dpown="${t._owner}" ${t.status==='done'?'checked':''}><div class="dp-task-body"><div class="dp-task-title ${t.status==='done'?'done':''}">${escH(t.title)}</div><div class="dp-task-who">${m?`<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${m.color}"></span> ${escH(m.name)}`:'<span style="color:var(--blue);font-weight:800">Ja</span>'} <span class="pill prio-${t.priority}" style="font-size:9px;padding:1px 5px">${priShort(t.priority)}</span></div></div><button class="btn ghost sm" data-dpedit="${t.id}" data-dpown="${t._owner}" style="padding:3px 5px"><span class="material-symbols-outlined" style="font-size:13px">edit</span></button></div>`;}).join('');

--- a/tasks.html
+++ b/tasks.html
@@ -71,11 +71,17 @@
     body {
       background: var(--bg);
       color: var(--ink);
-      font-family: 'Inter', system-ui, sans-serif;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       font-size: 14px;
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
     }
+
+    /* ── TYPOGRAPHY HARMONIZATION (match Budget module) ── */
+    h1, h2, h3, h4, h5, h6 { font-weight: 700; letter-spacing: -0.02em; }
+    .label-xs, .fl { font-weight: 700; letter-spacing: .06em; }
+    .pill, .tag-chip, .seg-item { font-weight: 600; }
+    .modal-title, .bento-lbl { font-weight: 700; }
 
     /* ── LAYOUT FIXES ── */
     .main { flex: 1; min-width: 0; width: 0; }

--- a/tasks.html
+++ b/tasks.html
@@ -71,25 +71,15 @@
     body {
       background: var(--bg);
       color: var(--ink);
-      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      font-size: 14px;
-      line-height: 1.6;
+      font-family: 'Inter', system-ui, sans-serif;
+      font-size: 13px;
+      line-height: 1.5;
       -webkit-font-smoothing: antialiased;
     }
 
-    /* ── TYPOGRAPHY HARMONIZATION (match Budget module) ── */
-    h1, h2, h3, h4, h5, h6 { font-weight: 700; letter-spacing: -0.02em; }
-    .label-xs, .fl { font-weight: 700; letter-spacing: .06em; }
-    .pill, .tag-chip, .seg-item { font-weight: 600; }
-    .modal-title, .bento-lbl { font-weight: 700; }
-
     /* ── LAYOUT FIXES ── */
     .main { flex: 1; min-width: 0; width: 0; }
-    .content {
-      display: block;
-      width: 100%;
-      max-width: 100%;
-    }
+    .content { width: 100%; max-width: 100%; }
     .page-content { width: 100%; max-width: 100% !important; }
 
     /* ── ANIMATIONS ── */
@@ -117,7 +107,7 @@
       border-radius: var(--r-sm); padding: 8px 16px;
       border: 1.5px solid var(--line2);
       background: var(--card); color: var(--ink);
-      cursor: pointer; font-weight: 600; font-size: 13px; letter-spacing: 0;
+      cursor: pointer; font-weight: 700; font-size: 11px; letter-spacing: .3px;
       font-family: inherit; white-space: nowrap; user-select: none;
       transition: background .15s, transform .12s, box-shadow .15s, border-color .15s;
     }
@@ -182,7 +172,7 @@
     .seg-item:hover { color:var(--ink); }
     .seg-item.active { background:var(--card); color:var(--ink); box-shadow:var(--sh-xs); }
 
-    /* ── MODULE NAV — pill style ── */
+    /* ── MODULE NAV — underline tabs style ── */
     .module-nav {
       display:flex;
       gap:10px;
@@ -191,7 +181,7 @@
       top:0;
       background:var(--bg);
       z-index:8;
-      padding:8px 0;
+      padding:8px 0 0;
       margin:12px 0 0;
       border-bottom:1px solid var(--line);
       overflow-x:auto;
@@ -200,21 +190,22 @@
       display:flex;
       align-items:center;
       gap:6px;
-      padding:8px 14px;
-      border-radius:10px;
-      border:1px solid transparent;
+      padding:8px 4px 10px;
+      border-radius:0;
+      border:none;
+      border-bottom:2px solid transparent;
       background:transparent;
       color:var(--muted);
       font-weight:600;
       font-size:13px;
       cursor:pointer;
-      transition:background var(--transition), color var(--transition), border-color var(--transition);
+      transition:color var(--transition), border-color var(--transition);
       white-space:nowrap;
       flex-shrink:0;
     }
     .mod-tab .material-symbols-outlined { font-size:16px; line-height:1; }
-    .mod-tab:hover { background:var(--surface); color:var(--ink); }
-    .mod-tab.active { background:var(--card); border-color:var(--line); color:var(--ink); box-shadow:var(--shadow-sm); }
+    .mod-tab:hover { color:var(--ink); }
+    .mod-tab.active { color:var(--ink); border-bottom-color:var(--blue); }
     .module { display:none; margin-top:12px; }
     .module.active { display:block; animation:fadeUp .22s ease-out; }
 

--- a/tasks.html
+++ b/tasks.html
@@ -209,7 +209,7 @@
     .overlay { position:fixed; inset:0; background:rgb(26 29 31/.6); display:flex; align-items:center; justify-content:center; z-index:1000; backdrop-filter:blur(5px); animation:fadeIn .15s; }
     .modal { background:var(--card); border-radius:var(--r-xl); padding:28px; box-shadow:var(--sh-md); width:90%; max-width:500px; max-height:92vh; overflow-y:auto; animation:scaleIn .18s ease-out; border:1px solid var(--line); }
     .modal.wide { max-width:860px; }
-    .modal-title { font-size:16px; font-weight:900; margin-bottom:20px; letter-spacing:-.3px; }
+    .modal-title { font-size:16px; font-weight:700; margin-bottom:20px; letter-spacing:.2px; }
     .modal-footer { display:flex; justify-content:flex-end; gap:8px; margin-top:22px; padding-top:18px; border-top:1px solid var(--line); }
 
     /* ═══════════ OVERVIEW ═══════════ */
@@ -226,7 +226,7 @@
     }
     .bento:hover { transform:translateY(-3px); box-shadow:var(--sh); }
     .bento-top { display:flex; align-items:flex-start; justify-content:space-between; margin-bottom:18px; }
-    .bento-val { font-size:34px; font-weight:900; line-height:1; letter-spacing:-2px; font-variant-numeric:tabular-nums; }
+    .bento-val { font-size:34px; font-weight:700; line-height:1; letter-spacing:-.6px; font-variant-numeric:tabular-nums; }
     .bento-lbl { font-size:10px; font-weight:800; text-transform:uppercase; letter-spacing:.8px; color:var(--muted2); margin-top:7px; }
     .bento-sub { font-size:11px; font-weight:700; display:flex; align-items:center; gap:4px; margin-top:10px; color:var(--muted2); }
     .bento.compact { padding:12px 14px; border-radius:18px; }
@@ -234,7 +234,7 @@
     .bento.compact .ib { width:28px; height:28px; border-radius:8px; }
     .bento.compact .ib .material-symbols-outlined { font-size:15px; }
     .bento.compact .pill { font-size:8px!important; padding:1px 6px!important; }
-    .bento.compact .bento-val { font-size:22px; letter-spacing:-1px; }
+    .bento.compact .bento-val { font-size:22px; letter-spacing:-.3px; }
     .bento.compact .bento-lbl { margin-top:3px; font-size:9px; letter-spacing:.6px; }
     .bento.compact .bento-sub { margin-top:4px; font-size:10px; }
 
@@ -257,7 +257,7 @@
     .task-card-left { display:flex; align-items:flex-start; gap:14px; flex:1; min-width:0; }
     .task-card-accent { width:4px; border-radius:999px; flex-shrink:0; align-self:stretch; min-height:44px; }
     .task-card-body { flex:1; min-width:0; }
-    .task-card-title { font-weight:800; font-size:13px; letter-spacing:-.1px; line-height:1.3; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; }
+    .task-card-title { font-weight:700; font-size:13px; letter-spacing:.1px; line-height:1.3; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; }
     .task-card-meta { display:flex; align-items:center; flex-wrap:wrap; gap:8px; margin-top:6px; }
 
     /* Ov list items */
@@ -299,7 +299,7 @@
     .pf-chip[data-cid="me"].active { border-color:var(--blue); color:var(--blue); background:var(--blue-tint); }
     .pf-av { width:22px; height:22px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:800; color:#fff; flex-shrink:0; }
     .cal-nav { display:flex; align-items:center; justify-content:space-between; margin-bottom:14px; gap:10px; }
-    .cal-nav-title { font-size:13px; font-weight:800; letter-spacing:-.2px; }
+    .cal-nav-title { font-size:13px; font-weight:700; letter-spacing:.1px; }
     .cal-grid-wrap { background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); overflow:hidden; box-shadow:var(--sh-sm); }
     .cal-grid { display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); }
     .cal-hdr { text-align:center; padding:10px 4px; background:var(--surf-lo); font-weight:800; font-size:10px; text-transform:uppercase; letter-spacing:.8px; color:var(--muted2); border-bottom:1px solid var(--line); }
@@ -326,7 +326,7 @@
     .cal-own-h .dot { width:6px; height:6px; border-radius:50%; flex-shrink:0; }
     .day-panel { background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); position:sticky; top:64px; overflow:hidden; box-shadow:var(--sh-sm); }
     .dp-head { padding:18px 20px 14px; border-bottom:1px solid var(--line); background:var(--surf-lo); }
-    .dp-date { font-size:17px; font-weight:900; line-height:1.1; letter-spacing:-.4px; }
+    .dp-date { font-size:17px; font-weight:700; line-height:1.1; letter-spacing:.2px; }
     .dp-dow  { font-size:10px; color:var(--muted2); margin-top:4px; font-weight:800; text-transform:uppercase; letter-spacing:.6px; }
     .dp-body { padding:12px; display:flex; flex-direction:column; gap:8px; min-height:180px; max-height:min(570px, calc(100vh - 260px)); overflow-y:auto; }
     .dp-task { display:flex; align-items:flex-start; gap:8px; padding:10px 12px; border-radius:var(--r-lg); background:var(--surf-lo); border:1px solid var(--line); border-left:3px solid var(--blue); transition:box-shadow .12s, transform .12s; }
@@ -345,7 +345,7 @@
     .team-layout { display:grid; grid-template-columns:256px 1fr; gap:16px; align-items:start; min-height:600px; }
     @media(max-width:860px){.team-layout{grid-template-columns:1fr}}
     .ml-card { background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); overflow:hidden; position:sticky; top:64px; box-shadow:var(--sh-sm); }
-    .ml-head { padding:14px 18px; border-bottom:1px solid var(--line); font-weight:900; font-size:11px; letter-spacing:.5px; text-transform:uppercase; display:flex; align-items:center; justify-content:space-between; background:var(--surf-lo); }
+    .ml-head { padding:14px 18px; border-bottom:1px solid var(--line); font-weight:700; font-size:11px; letter-spacing:.5px; text-transform:uppercase; display:flex; align-items:center; justify-content:space-between; background:var(--surf-lo); }
     .spec-card { margin-top:12px; background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); padding:14px; box-shadow:var(--sh-sm); max-height:540px; overflow-y:auto; }
     .spec-head { font-size:10px; font-weight:800; margin-bottom:10px; text-transform:uppercase; letter-spacing:.7px; color:var(--muted2); }
     .spec-search { display:flex; align-items:center; gap:6px; padding:7px 10px; border:1.5px solid var(--line); border-radius:var(--r-xs); background:var(--surf-lo); margin-bottom:8px; }
@@ -365,7 +365,7 @@
     .member-row.active { background:var(--blue-tint); }
     .member-row.active::before { content:''; position:absolute; left:0; top:0; bottom:0; width:3px; background:var(--blue); border-radius:0 3px 3px 0; }
     /* Square avatar like Editorial CRM */
-    .m-av { width:38px; height:38px; border-radius:10px; display:flex; align-items:center; justify-content:center; font-size:16px; font-weight:900; color:#fff; flex-shrink:0; }
+    .m-av { width:38px; height:38px; border-radius:10px; display:flex; align-items:center; justify-content:center; font-size:16px; font-weight:700; color:#fff; flex-shrink:0; }
     .m-name { font-weight:800; font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
     .m-role { font-size:10px; color:var(--muted2); letter-spacing:.2px; font-weight:600; }
     .m-badge { margin-left:auto; background:var(--surf); border:1px solid var(--line); color:var(--ink); font-size:10px; font-weight:800; padding:2px 8px; border-radius:999px; flex-shrink:0; }
@@ -373,13 +373,13 @@
     /* Person detail */
     .pd-card { background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); overflow:hidden; animation:slideIn .2s ease-out; box-shadow:var(--sh-sm); }
     .ph { padding:22px 24px 16px; border-bottom:1px solid var(--line); display:flex; align-items:center; gap:18px; background:var(--surf-lo); }
-    .ph-av { width:62px; height:62px; border-radius:var(--r); display:flex; align-items:center; justify-content:center; font-size:28px; font-weight:900; color:#fff; flex-shrink:0; box-shadow:var(--sh); }
-    .ph-name { font-size:20px; font-weight:900; line-height:1.1; letter-spacing:-.4px; }
+    .ph-av { width:62px; height:62px; border-radius:var(--r); display:flex; align-items:center; justify-content:center; font-size:28px; font-weight:700; color:#fff; flex-shrink:0; box-shadow:var(--sh); }
+    .ph-name { font-size:20px; font-weight:700; line-height:1.1; letter-spacing:.2px; }
     .ph-role { font-size:10px; color:var(--muted2); margin-top:4px; font-weight:800; text-transform:uppercase; letter-spacing:.5px; }
     .ph-stats { display:flex; border-bottom:1px solid var(--line); background:var(--surf-lo); flex-wrap:wrap; }
     .phs { display:flex; flex-direction:column; align-items:center; padding:14px 22px; border-right:1px solid var(--line); }
     .phs:last-child { border-right:none; }
-    .phs-val { font-size:22px; font-weight:900; line-height:1; letter-spacing:-.5px; font-variant-numeric:tabular-nums; }
+    .phs-val { font-size:22px; font-weight:700; line-height:1; letter-spacing:-.1px; font-variant-numeric:tabular-nums; }
     .phs-lbl { font-size:9px; color:var(--muted2); text-transform:uppercase; letter-spacing:.7px; margin-top:3px; font-weight:800; }
     .ptabs { display:flex; border-bottom:1px solid var(--line); overflow-x:auto; background:var(--surf-lo); }
     .ptab { padding:13px 20px; font-weight:800; font-size:10px; letter-spacing:.5px; text-transform:uppercase; cursor:pointer; color:var(--muted2); border-bottom:2.5px solid transparent; transition:all .15s; white-space:nowrap; flex-shrink:0; }
@@ -453,7 +453,7 @@
     /* Quick add panel */
     .quick-add { background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); overflow:hidden; margin-bottom:18px; box-shadow:var(--sh-sm); }
     .qa-head { display:flex; align-items:center; justify-content:space-between; gap:10px; padding:14px 20px; background:var(--surf-lo); border-bottom:1px solid var(--line); }
-    .qa-head strong { font-size:11px; font-weight:900; letter-spacing:.4px; text-transform:uppercase; display:flex; align-items:center; gap:8px; }
+    .qa-head strong { font-size:11px; font-weight:700; letter-spacing:.4px; text-transform:uppercase; display:flex; align-items:center; gap:8px; }
     .qa-body { padding:20px; display:none; }
     .qa-body.open { display:block; animation:fadeUp .15s ease-out; }
     /* Bulk row */
@@ -462,7 +462,7 @@
     /* Table */
     .t-table { width:100%; border-collapse:collapse; }
     .t-table th, .t-table td { padding:11px 10px; text-align:left; border-bottom:1px solid var(--line); vertical-align:middle; }
-    .t-table th { font-size:9px; color:var(--muted2); text-transform:uppercase; font-weight:900; letter-spacing:.7px; background:var(--surf-lo); }
+    .t-table th { font-size:9px; color:var(--muted2); text-transform:uppercase; font-weight:700; letter-spacing:.7px; background:var(--surf-lo); }
     .t-table tr:last-child td { border-bottom:none; }
     .t-table tbody tr:hover td { background:var(--blue-tint); }
     .t-table input[type=checkbox] { width:14px; height:14px; accent-color:var(--blue); }
@@ -470,7 +470,7 @@
     .t-ttl:hover { color:var(--blue); }
     .t-ttl.done { text-decoration:line-through; color:var(--muted2); font-weight:400; }
     /* Group headers */
-    .grp-hdr td { background:var(--surf); font-size:9px; font-weight:900; text-transform:uppercase; letter-spacing:.7px; color:var(--muted2); padding:8px 10px; border-top:2px solid var(--line); border-bottom:1px solid var(--line); cursor:pointer; }
+    .grp-hdr td { background:var(--surf); font-size:9px; font-weight:700; text-transform:uppercase; letter-spacing:.7px; color:var(--muted2); padding:8px 10px; border-top:2px solid var(--line); border-bottom:1px solid var(--line); cursor:pointer; }
     .grp-hdr:hover td { background:var(--surf-hi); }
     .grp-hdr.over-g td { background:var(--red-tint); color:var(--red); }
     .grp-hdr.done-g td { background:var(--green-tint); color:var(--green); }
@@ -487,7 +487,7 @@
     .kpi-sidebar { display:flex; flex-direction:column; gap:10px; }
     .kpi-c { background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); padding:16px 18px; display:flex; align-items:flex-start; gap:12px; box-shadow:var(--sh-xs); transition:transform .15s, box-shadow .15s; }
     .kpi-c:hover { transform:translateY(-1px); box-shadow:var(--sh-sm); }
-    .kpi-v { font-size:22px; font-weight:900; line-height:1.1; letter-spacing:-.5px; }
+    .kpi-v { font-size:22px; font-weight:700; line-height:1.1; letter-spacing:-.1px; }
     .kpi-lbl { font-size:9px; font-weight:800; text-transform:uppercase; letter-spacing:.6px; color:var(--muted2); }
     .kpi-note { font-size:10px; color:var(--muted2); margin-top:2px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width:100%; }
     .i-bub { background:var(--surf-lo); border:1px solid var(--line); border-radius:var(--r-lg); padding:11px 14px; font-size:11px; color:var(--muted2); line-height:1.6; }
@@ -502,7 +502,7 @@
     .ins[data-tone=alert]   { border-color:var(--red-bg); }
     .ins[data-tone=success] { border-color:var(--green-bg); }
     .ins[data-tone=focus]   { border-color:var(--blue-bg); }
-    .ins-title { font-weight:900; font-size:12px; margin-bottom:2px; letter-spacing:-.1px; }
+    .ins-title { font-weight:700; font-size:12px; margin-bottom:2px; letter-spacing:.1px; }
     .ins-body  { font-size:11px; color:var(--muted2); line-height:1.5; }
     /* Filters */
     .filters-row { display:flex; flex-wrap:wrap; gap:7px; padding:11px 16px; border-bottom:1px solid var(--line); align-items:center; background:var(--surf-lo); }
@@ -513,17 +513,17 @@
     .stats-kpis { display:grid; grid-template-columns:repeat(auto-fit,minmax(130px,1fr)); gap:12px; margin-bottom:24px; }
     .sk { background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); padding:18px 20px; box-shadow:var(--sh-xs); transition:transform .15s, box-shadow .15s; }
     .sk:hover { transform:translateY(-2px); box-shadow:var(--sh-sm); }
-    .sk-val { font-size:30px; font-weight:900; line-height:1; letter-spacing:-1.5px; font-variant-numeric:tabular-nums; }
+    .sk-val { font-size:30px; font-weight:700; line-height:1; letter-spacing:-.5px; font-variant-numeric:tabular-nums; }
     .sk-lbl { font-size:10px; color:var(--muted2); margin-top:6px; text-transform:uppercase; letter-spacing:.7px; font-weight:800; }
     .charts-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:16px; }
     .ch-card { background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); padding:22px; box-shadow:var(--sh-xs); }
-    .ch-card h4 { font-size:13px; font-weight:900; margin-bottom:3px; letter-spacing:-.2px; }
+    .ch-card h4 { font-size:13px; font-weight:700; margin-bottom:3px; letter-spacing:.1px; }
     .ch-card p { font-size:11px; color:var(--muted2); margin-bottom:14px; }
     .ch-wrap { position:relative; min-height:200px; }
 
     /* ═══════════ SECTION HEADERS ═══════════ */
     .sec-header { display:flex; align-items:flex-start; justify-content:space-between; gap:16px; margin-bottom:20px; flex-wrap:wrap; }
-    .sec-title-lg { font-size:18px; font-weight:900; line-height:1.2; letter-spacing:-.4px; display:flex; align-items:center; gap:10px; }
+    .sec-title-lg { font-size:18px; font-weight:700; line-height:1.2; letter-spacing:.2px; display:flex; align-items:center; gap:10px; }
     .sec-sub-sm { font-size:11px; color:var(--muted2); margin-top:3px; }
     .page-acts { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
 
@@ -531,7 +531,7 @@
     .prj-layout { display:grid; grid-template-columns:220px 1fr; gap:20px; align-items:start; }
     .prj-sidebar { background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); overflow:hidden; }
     .prj-sidebar-head { display:flex; align-items:center; justify-content:space-between; padding:13px 16px; border-bottom:1px solid var(--line); background:var(--surf-lo); }
-    .prj-sidebar-title { font-size:11px; font-weight:900; text-transform:uppercase; letter-spacing:.06em; }
+    .prj-sidebar-title { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; }
     .prj-list-empty { padding:16px; font-size:11px; color:var(--muted2); }
     .prj-list-item { display:flex; align-items:center; gap:9px; padding:10px 16px; cursor:pointer; border-bottom:1px solid var(--line); transition:background .1s; }
     .prj-list-item:hover { background:var(--surf-lo); }
@@ -542,7 +542,7 @@
     .prj-list-count { font-size:10px; color:var(--muted2); background:var(--surf-lo); border:1px solid var(--line); padding:1px 6px; border-radius:999px; font-weight:700; }
     .prj-ph { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:10px; min-height:260px; color:var(--muted2); text-align:center; padding:24px; }
     .prj-board-head { display:flex; align-items:flex-start; justify-content:space-between; gap:16px; margin-bottom:18px; padding:18px 20px; background:var(--card); border:1px solid var(--line); border-radius:var(--r-xl); flex-wrap:wrap; }
-    .prj-board-title { font-size:17px; font-weight:900; letter-spacing:-.4px; display:flex; align-items:center; gap:10px; margin-bottom:4px; }
+    .prj-board-title { font-size:17px; font-weight:700; letter-spacing:.2px; display:flex; align-items:center; gap:10px; margin-bottom:4px; }
     .prj-board-desc { font-size:12px; color:var(--muted2); margin-bottom:8px; }
     .prj-board-assignees { display:flex; align-items:center; gap:4px; flex-wrap:wrap; }
     .prj-av { width:26px; height:26px; border-radius:50%; color:#fff; font-size:10px; font-weight:800; display:flex; align-items:center; justify-content:center; flex-shrink:0; }
@@ -551,7 +551,7 @@
     .kanban-col { background:var(--surf-lo); border-radius:14px; padding:12px; min-height:200px; }
     .kanban-col-head { display:flex; align-items:center; gap:7px; padding-bottom:10px; border-bottom:1px solid var(--line); margin-bottom:10px; }
     .kanban-col-icon { font-size:14px; }
-    .kanban-col-title { font-size:10px; font-weight:900; text-transform:uppercase; letter-spacing:.07em; flex:1; }
+    .kanban-col-title { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.07em; flex:1; }
     .kanban-col-count { font-size:10px; color:var(--muted2); background:var(--card); border:1px solid var(--line); padding:1px 6px; border-radius:999px; font-weight:700; }
     .kanban-col-body { display:flex; flex-direction:column; gap:8px; min-height:40px; }
     .kanban-card { background:var(--card); border:1px solid var(--line); border-radius:10px; padding:11px 12px; cursor:pointer; transition:box-shadow .15s,transform .15s; border-left:3px solid transparent; }
@@ -583,7 +583,7 @@
     .card-modal.open { display:flex; }
     .card-modal-box { background:var(--card); border-radius:18px; width:100%; max-width:620px; max-height:88vh; overflow-y:auto; box-shadow:0 20px 60px rgba(0,0,0,.2); display:flex; flex-direction:column; }
     .card-modal-head { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; padding:18px 22px 14px; border-bottom:1px solid var(--line); position:sticky; top:0; background:var(--card); z-index:1; }
-    .card-modal-title-inp { flex:1; font-size:15px; font-weight:900; letter-spacing:-.3px; border:none; outline:none; background:transparent; font-family:inherit; color:var(--ink); resize:none; width:100%; }
+    .card-modal-title-inp { flex:1; font-size:15px; font-weight:700; letter-spacing:.2px; border:none; outline:none; background:transparent; font-family:inherit; color:var(--ink); resize:none; width:100%; }
     .card-modal-body { padding:16px 22px; display:flex; flex-direction:column; gap:13px; flex:1; }
     .card-modal-footer { padding:13px 22px; border-top:1px solid var(--line); display:flex; justify-content:space-between; align-items:center; gap:10px; }
     .cfl { font-size:10px; font-weight:800; text-transform:uppercase; letter-spacing:.06em; color:var(--muted2); margin-bottom:4px; }
@@ -864,7 +864,7 @@
           <div id="person-area">
             <div class="team-ph" id="team-ph">
               <span style="font-size:56px;opacity:.18">👥</span>
-              <span style="font-weight:900;font-size:14px;letter-spacing:-.3px">Wybierz osobę z listy</span>
+              <span style="font-weight:700;font-size:14px;letter-spacing:.2px">Wybierz osobę z listy</span>
               <span class="small muted" style="text-align:center;max-width:240px;line-height:1.7">Zarządzaj zadaniami, notatkami i celami każdego z Twojego zespołu.</span>
             </div>
             <div id="person-detail" style="display:none"></div>
@@ -1045,7 +1045,7 @@
           <div>
             <div class="prj-ph" id="prj-ph">
               <span style="font-size:52px;opacity:.13">🗂️</span>
-              <span style="font-weight:900;font-size:13px;letter-spacing:-.3px;color:var(--ink)">Wybierz projekt</span>
+              <span style="font-weight:700;font-size:13px;letter-spacing:.2px;color:var(--ink)">Wybierz projekt</span>
               <span style="font-size:11px;color:var(--muted2);text-align:center;max-width:220px;line-height:1.7">Śledź etapy projektu w widoku Kanban, przypisuj osoby i daty — wszystko trafi do kalendarza.</span>
             </div>
             <div id="prj-board" style="display:none">
@@ -1439,7 +1439,7 @@ function renderOverview(){
   if(loadEl){
     const per=S.members.map(m=>{const open=S.teamTasks.filter(tt=>tt.assigneeId===m.id&&tt.status!=='done');const over=open.filter(tt=>{const d=parseDate(tt.dueDate);return d&&d<t;}).length;return{m,open:open.length,over};});
     const max=Math.max(1,...per.map(x=>x.open));
-    loadEl.innerHTML=per.length?per.sort((a,b)=>b.open-a.open).map(({m,open,over})=>`<button type="button" class="ov-item ov-note-jump" data-ov-member-id="${m.id}"><div class="m-av" style="background:${m.color};width:34px;height:34px;border-radius:9px;flex-shrink:0">${m.name.charAt(0).toUpperCase()}</div><div class="ov-item-body"><div class="ov-item-title" style="display:flex;align-items:center;justify-content:space-between"><span>${escH(m.name)}</span><span style="font-size:11px;font-weight:900;margin-left:8px">${Math.round(open/max*100)}%</span></div><div class="ov-item-meta">${open} aktywnych${over?` · <span style="color:var(--red);font-weight:800">⚠️ ${over} po terminie</span>`:'&nbsp;&nbsp;<span style="color:var(--green);font-weight:700">✓ brak zaległości</span>'}</div><div class="wl-wrap"><div class="wl-track"><div class="wl-fill" style="width:${Math.round(open/max*100)}%;background:${m.color}"></div></div></div></div></button>`).join(''):'<div class="ov-empty">Dodaj członków i zadania aby zobaczyć workload.</div>';
+    loadEl.innerHTML=per.length?per.sort((a,b)=>b.open-a.open).map(({m,open,over})=>`<button type="button" class="ov-item ov-note-jump" data-ov-member-id="${m.id}"><div class="m-av" style="background:${m.color};width:34px;height:34px;border-radius:9px;flex-shrink:0">${m.name.charAt(0).toUpperCase()}</div><div class="ov-item-body"><div class="ov-item-title" style="display:flex;align-items:center;justify-content:space-between"><span>${escH(m.name)}</span><span style="font-size:11px;font-weight:700;margin-left:8px">${Math.round(open/max*100)}%</span></div><div class="ov-item-meta">${open} aktywnych${over?` · <span style="color:var(--red);font-weight:800">⚠️ ${over} po terminie</span>`:'&nbsp;&nbsp;<span style="color:var(--green);font-weight:700">✓ brak zaległości</span>'}</div><div class="wl-wrap"><div class="wl-track"><div class="wl-fill" style="width:${Math.round(open/max*100)}%;background:${m.color}"></div></div></div></div></button>`).join(''):'<div class="ov-empty">Dodaj członków i zadania aby zobaczyć workload.</div>';
     loadEl.querySelectorAll('[data-ov-member-id]').forEach(btn=>btn.addEventListener('click',()=>{
       selMember=btn.dataset.ovMemberId;
       activePTab='tasks';

--- a/trainings.html
+++ b/trainings.html
@@ -37,33 +37,10 @@
   --vacation-color: #64748b;
 }
 
-body {
-  background: var(--bg);
-  color: var(--ink);
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 14px;
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-}
-
-/* Typography harmonization (match Budget/Tasks) */
-h1, h2, h3, h4, h5, h6 { font-weight: 700; letter-spacing: -0.02em; }
-.label-xs, .fl { font-weight: 700; letter-spacing: .06em; }
-.pill, .chip, .seg-item { font-weight: 600; }
-
-/* Layout fixes (match Tasks) */
-.main { flex: 1; min-width: 0; width: 0; }
-.content {
-  display: block;
-  width: 100%;
-  max-width: 100%;
-}
 .page-content {
   display: flex;
   flex-direction: column;
   gap: 24px;
-  width: 100%;
-  max-width: 100% !important;
 }
 
 .month-switcher {
@@ -1333,7 +1310,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; letter-spacing: -0.02em; }
   top: 0;
   background: var(--bg);
   z-index: 8;
-  padding: 8px 0;
+  padding: 8px 0 0;
   margin: 12px 0 0;
   border-bottom: 1px solid var(--line);
   overflow-x: auto;
@@ -1343,9 +1320,10 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; letter-spacing: -0.02em; }
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 14px;
-  border-radius: 10px;
-  border: 1px solid transparent;
+  padding: 8px 4px 10px;
+  border-radius: 0;
+  border: none;
+  border-bottom: 2px solid transparent;
   background: transparent;
   font-size: 13px;
   font-weight: 600;
@@ -1353,19 +1331,16 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; letter-spacing: -0.02em; }
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
-  transition: background var(--transition), color var(--transition), border-color var(--transition);
+  transition: color var(--transition), border-color var(--transition);
 }
 
 .subnav button:hover {
-  background: var(--surface);
   color: var(--ink);
 }
 
 .subnav button.is-active {
-  background: var(--card);
-  border-color: var(--line);
   color: var(--ink);
-  box-shadow: var(--shadow-sm);
+  border-bottom-color: var(--accent);
 }
 
 .section-panel {

--- a/trainings.html
+++ b/trainings.html
@@ -1356,6 +1356,7 @@
     display: flex;
     flex-direction: column;
     gap: 20px;
+    padding: 20px;
 }
 
 .analytics-top-row {
@@ -1831,7 +1832,7 @@
           </section>
 
           <!-- MODERN ANALYTICS DASHBOARD -->
-          <section class="section-panel" id="analytics">
+          <section class="card section-panel" id="analytics">
             <div class="analytics-dashboard">
                 <div class="card-header">
                     <div>

--- a/trainings.html
+++ b/trainings.html
@@ -134,7 +134,14 @@
   padding-bottom: 4px;
 }
 
-.calendar-header h3 { font-size: 16px; font-weight: 700; }
+.calendar-header h3,
+.card-header > div > h3,
+.bm-dashboard-header h3 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
 .calendar-legend { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; font-size: 11px; color: var(--muted); }
 .calendar-legend span { display: inline-flex; align-items: center; gap: 6px; font-weight: 500;}
 
@@ -539,12 +546,6 @@
   gap: 16px;
   flex-wrap: wrap;
   padding: 24px 24px 0;
-}
-
-.bm-dashboard-header h3 {
-  font-size: 20px;
-  font-weight: 800;
-  letter-spacing: -0.02em;
 }
 
 .bm-header-controls {
@@ -1693,7 +1694,6 @@
             <div class="card-header">
               <div>
                 <h3>Historia aktywności</h3>
-                <p class="muted tiny">Podsumowanie ukończonych zadań w ciągu roku</p>
               </div>
               <span class="month-chip" id="heatmap-year-label">--</span>
             </div>
@@ -1712,11 +1712,10 @@
           </section>
 
           <section class="card body-metrics-card section-panel" id="body-metrics">
-            <!-- Dashboard Header -->
+              <!-- Dashboard Header -->
             <div class="bm-dashboard-header">
               <div>
                 <h3>Body Composition Dashboard</h3>
-                <p class="muted tiny">Codzienne ważenie · średnie tygodniowe · analityka progresu</p>
               </div>
               <div class="bm-header-controls">
                 <div class="metrics-filter">
@@ -1837,7 +1836,6 @@
                 <div class="card-header">
                     <div>
                       <h3>Dashboard Analityczny</h3>
-                      <p class="muted tiny">Twoje centrum dowodzenia nawykami.</p>
                     </div>
                     <span class="month-chip">Live</span>
                 </div>

--- a/trainings.html
+++ b/trainings.html
@@ -1357,7 +1357,17 @@
     display: flex;
     flex-direction: column;
     gap: 20px;
-    padding: 24px;
+    padding: 0 0 24px;
+}
+
+#analytics .card-header {
+    padding: 24px 24px 0;
+    margin-bottom: 0;
+}
+
+#analytics .analytics-top-row,
+#analytics .analytics-grid {
+    padding: 0 24px;
 }
 
 .analytics-top-row {

--- a/trainings.html
+++ b/trainings.html
@@ -37,10 +37,33 @@
   --vacation-color: #64748b;
 }
 
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Typography harmonization (match Budget/Tasks) */
+h1, h2, h3, h4, h5, h6 { font-weight: 700; letter-spacing: -0.02em; }
+.label-xs, .fl { font-weight: 700; letter-spacing: .06em; }
+.pill, .chip, .seg-item { font-weight: 600; }
+
+/* Layout fixes (match Tasks) */
+.main { flex: 1; min-width: 0; width: 0; }
+.content {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+}
 .page-content {
   display: flex;
   flex-direction: column;
   gap: 24px;
+  width: 100%;
+  max-width: 100% !important;
 }
 
 .month-switcher {
@@ -1306,39 +1329,48 @@
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
-  margin: 8px 0 20px;
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 8;
+  padding: 8px 0;
+  margin: 12px 0 0;
+  border-bottom: 1px solid var(--line);
+  overflow-x: auto;
 }
 
 .subnav button {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  font-size: 12px;
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  font-size: 13px;
   font-weight: 600;
   color: var(--muted);
   cursor: pointer;
-  transition: var(--transition);
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
 }
 
 .subnav button:hover {
-  color: var(--accent);
-  border-color: var(--primary-border);
-  box-shadow: var(--shadow-sm);
+  background: var(--surface);
+  color: var(--ink);
 }
 
 .subnav button.is-active {
-  color: var(--accent);
-  background: var(--primary-soft);
-  border-color: var(--primary-border);
+  background: var(--card);
+  border-color: var(--line);
+  color: var(--ink);
   box-shadow: var(--shadow-sm);
 }
 
 .section-panel {
   display: none;
+  margin-top: 12px;
 }
 
 .section-panel.is-active {

--- a/trainings.html
+++ b/trainings.html
@@ -1357,7 +1357,7 @@
     display: flex;
     flex-direction: column;
     gap: 20px;
-    padding: 20px;
+    padding: 24px;
 }
 
 .analytics-top-row {

--- a/trainings.html
+++ b/trainings.html
@@ -1306,41 +1306,36 @@
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
-  position: sticky;
-  top: 0;
-  background: var(--bg);
-  z-index: 8;
-  padding: 8px 0 0;
+  padding: 8px 0 12px;
   margin: 12px 0 0;
   border-bottom: 1px solid var(--line);
-  overflow-x: auto;
 }
 
 .subnav button {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 4px 10px;
-  border-radius: 0;
-  border: none;
-  border-bottom: 2px solid transparent;
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1px solid transparent;
   background: transparent;
   font-size: 13px;
   font-weight: 600;
   color: var(--muted);
   cursor: pointer;
-  white-space: nowrap;
-  flex-shrink: 0;
-  transition: color var(--transition), border-color var(--transition);
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
 }
 
 .subnav button:hover {
+  background: var(--surface);
   color: var(--ink);
 }
 
 .subnav button.is-active {
+  background: var(--card);
+  border-color: var(--line);
   color: var(--ink);
-  border-bottom-color: var(--accent);
+  box-shadow: var(--shadow-sm);
 }
 
 .section-panel {
@@ -1649,15 +1644,15 @@
         </div>
       </header>
 
-      <nav class="subnav" aria-label="Podmenu sekcji">
-        <button type="button" class="is-active" data-section-target="activity-hub"><i data-lucide="calendar-days" class="icon"></i>Dziennik</button>
-        <button type="button" data-section-target="activity-heatmap"><i data-lucide="flame" class="icon"></i>Historia</button>
-        <button type="button" data-section-target="body-metrics"><i data-lucide="activity" class="icon"></i>Log wagi</button>
-        <button type="button" data-section-target="analytics"><i data-lucide="pie-chart" class="icon"></i>Analityka</button>
-      </nav>
-
       <div class="content">
         <main class="page-content content-main stack">
+          <nav class="subnav" aria-label="Podmenu sekcji">
+            <button type="button" class="is-active" data-section-target="activity-hub"><i data-lucide="calendar-days" class="icon"></i>Dziennik</button>
+            <button type="button" data-section-target="activity-heatmap"><i data-lucide="flame" class="icon"></i>Historia</button>
+            <button type="button" data-section-target="body-metrics"><i data-lucide="activity" class="icon"></i>Log wagi</button>
+            <button type="button" data-section-target="analytics"><i data-lucide="pie-chart" class="icon"></i>Analityka</button>
+          </nav>
+
           <!-- New Activity Hub Layout -->
           <div class="card activity-hub section-panel is-active" id="activity-hub">
             <div class="calendar-wrapper">

--- a/trainings.html
+++ b/trainings.html
@@ -4616,8 +4616,6 @@ function setupEventListeners() {
       const target = button.dataset.sectionTarget;
       sectionButtons.forEach(btn => btn.classList.toggle('is-active', btn === button));
       sectionPanels.forEach(panel => panel.classList.toggle('is-active', panel.id === target));
-      const main = document.querySelector('.page-content');
-      if (main) main.scrollIntoView({ behavior: 'smooth', block: 'start' });
       if (target === 'analytics') {
         // Wait for display:block to apply then render
         requestAnimationFrame(() => renderNewAnalytics());


### PR DESCRIPTION
### Motivation
- The Tasks page displayed an unwanted empty whitespace column on the right because the `.content` element was behaving like a multi-column/grid container instead of occupying the full available width.

### Description
- Modified the inline CSS in `tasks.html` to set `.content` to `display: block; width: 100%; max-width: 100%;` so the Tasks page content renders as a single full-width block.
- Ensured the file ends with a newline to avoid trailing-file warnings.

### Testing
- Ran a whitespace/error check with `git diff --check` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabcd798a08331bf51ff8cac304fdf)