### PR TITLE
Add day-trading panel & mode toggle to Investments tab

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -11059,6 +11059,16 @@
     dt.limits.maxWeeklyLossPct=Math.abs(num(dt.limits.maxWeeklyLossPct)||0);
     dt.limits.targetDailyProfitPct=Math.abs(num(dt.limits.targetDailyProfitPct)||0);
     dt.limits.targetWeeklyProfitPct=Math.abs(num(dt.limits.targetWeeklyProfitPct)||0);
+    for(const p of dt.positions){
+      if(!Array.isArray(p.tags)) p.tags=[];
+      if(!Number.isFinite(Number(p.executionRating))) p.executionRating=null;
+      if(!Number.isFinite(Number(p.fees))) p.fees=0;
+    }
+    for(const c of dt.closes){
+      if(!Array.isArray(c.tags)) c.tags=[];
+      if(!Number.isFinite(Number(c.executionRating))) c.executionRating=null;
+      if(!Number.isFinite(Number(c.fees))) c.fees=Math.abs(num(c.fee)||0);
+    }
     return dt;
   };
 
@@ -11092,6 +11102,7 @@
     const weekStart=dtWeekStart(today);
     let activeNotional=0, lockedMargin=0, unrealized=0, realized=0, todayPnl=0, weeklyPnl=0;
     let win=0,loss=0;
+    let grossProfit=0,grossLossAbs=0,netProfit=0,netLossAbs=0,totalFees=0;
     const deposits=(dt.capitalFlows||[]).reduce((sum,f)=>sum+(f.type==='deposit'?Math.abs(num(f.amountUsd)):0),0);
     const withdrawals=(dt.capitalFlows||[]).reduce((sum,f)=>sum+(f.type==='withdrawal'?Math.abs(num(f.amountUsd)):0),0);
     const netFlows=deposits-withdrawals;
@@ -11112,9 +11123,14 @@
     }
     for(const c of dt.closes){
       const net=num(c.netPnl);
+      const gross=num(c.grossPnl);
+      const fees=Math.abs(num(c.fees ?? c.fee));
       const cDate=String(c.date||'');
       realized+=net;
+      totalFees+=fees;
       if(net>=0) win++; else loss++;
+      if(gross>=0) grossProfit+=gross; else grossLossAbs+=Math.abs(gross);
+      if(net>=0) netProfit+=net; else netLossAbs+=Math.abs(net);
       if(cDate===today) todayPnl+=net;
       if(cDate>=weekStart && cDate<=today) weeklyPnl+=net;
     }
@@ -11126,7 +11142,19 @@
     const roi=((equity-netFlows)/baseForRoi)*100;
     const todayPct=netFlows!==0?(todayPnl/Math.abs(netFlows))*100:0;
     const weeklyPct=netFlows!==0?(weeklyPnl/Math.abs(netFlows))*100:0;
-    return {activeNotional,lockedMargin,unrealized,realized,todayPnl,weeklyPnl,todayPct,weeklyPct,roi,win,loss,winRate:total?((win/total)*100):0,openPositions,deposits,withdrawals,netFlows,freeCash,walletBalance,equity,canTrade:deposits>0&&freeCash>0};
+    const winRate=total?((win/total)*100):0;
+    const avgWin=win>0?netProfit/win:0;
+    const avgLoss=loss>0?netLossAbs/loss:0;
+    const expectancy=(winRate/100)*avgWin-((100-winRate)/100)*avgLoss;
+    const profitFactor=grossLossAbs>0?(grossProfit/grossLossAbs):(grossProfit>0?Infinity:0);
+    let running=netFlows;
+    let peak=running;
+    for(const c of [...dt.closes].sort((a,b)=>String(a.date||'').localeCompare(String(b.date||'')))){
+      running+=num(c.netPnl);
+      if(running>peak) peak=running;
+    }
+    const currentDrawdown=Math.max(0,peak-equity);
+    return {activeNotional,lockedMargin,unrealized,realized,todayPnl,weeklyPnl,todayPct,weeklyPct,roi,win,loss,winRate,openPositions,deposits,withdrawals,netFlows,freeCash,walletBalance,equity,canTrade:deposits>0&&freeCash>0,profitFactor,expectancy,currentDrawdown,totalFees};
   }
 
   function renderDayTradingDashboard(){
@@ -11171,15 +11199,18 @@
     const gross=(closePrice-num(position.entry))*qty*dir;
     const riskPerUnit=(num(position.entry)-num(position.sl))*dir;
     const riskAbs=Math.max(0,riskPerUnit*qty);
-    const net=gross-fee;
+    const fees=Math.abs(num(fee));
+    const net=gross-fees;
     const rr=riskAbs>0?net/riskAbs:null;
     dayTrading().closes.unshift({
       id:'dt_close_'+Math.random().toString(36).slice(2),
       positionId:position.id,ticker:position.ticker,side:position.side,date:closeDate,
-      qty,closePrice,fee,grossPnl:gross,netPnl:net,rr,releasedMargin:(num(position.entry)*qty)/lev,partial:(qty<(num(position.initialQty)-num(position.closedQty||0)-0.0000001))
+      qty,closePrice,fees,fee:fees,grossPnl:gross,netPnl:net,rr,releasedMargin:(num(position.entry)*qty)/lev,partial:(qty<(num(position.initialQty)-num(position.closedQty||0)-0.0000001)),
+      tags:Array.isArray(position.tags)?[...position.tags]:[],executionRating:Number.isFinite(Number(position.executionRating))?Number(position.executionRating):null
     });
     position.closedQty=(num(position.closedQty)||0)+qty;
     position.realizedPnl=(num(position.realizedPnl)||0)+net;
+    position.fees=(num(position.fees)||0)+fees;
     if(position.closedQty>=num(position.initialQty)-0.0000001){
       position.status='closed';
       position.closedDate=closeDate;
@@ -11456,7 +11487,8 @@
         dt.positions.unshift({
           id:'dt_pos_'+Math.random().toString(36).slice(2),ticker:payload.ticker,side:payload.side,openDate:payload.date,sizeQty:payload.sizeQty,
           entry:payload.entry,sl:payload.sl,tp:payload.tp,note:payload.note,status:'open',leverage:payload.leverage,
-          initialQty:m.qty,closedQty:0,realizedPnl:0,markPrice:payload.entry,plannedRisk:m.riskUsd,plannedReward:m.rewardUsd,plannedRr:m.rr,notionalUsd:m.notionalUsd,marginRequired:m.marginRequired
+          initialQty:m.qty,closedQty:0,realizedPnl:0,markPrice:payload.entry,plannedRisk:m.riskUsd,plannedReward:m.rewardUsd,plannedRr:m.rr,notionalUsd:m.notionalUsd,marginRequired:m.marginRequired,
+          tags:[],executionRating:null,fees:0
         });
         save(state);form.reset();
         if(dateInput) dateInput.value=new Date().toISOString().slice(0,10);

--- a/budget.html
+++ b/budget.html
@@ -118,6 +118,40 @@
     .inv-kpi-card.accent .inv-kpi-value { color:#fff; }
     .inv-kpi-card.accent .inv-kpi-sub { color:rgba(255,255,255,.65); }
 
+    .inv-mode-switch { display:inline-flex; gap:4px; padding:4px; border-radius:12px; background:rgba(148,163,184,.14); }
+    .inv-mode-btn { border:none; background:transparent; color:var(--muted); padding:8px 14px; border-radius:9px; font-size:12px; font-weight:700; cursor:pointer; transition:all .18s; }
+    .inv-mode-btn.is-active { background:#fff; color:var(--ink); box-shadow:0 8px 20px rgba(15,23,42,.12); }
+
+    .dt-grid { display:grid; gap:14px; }
+    .dt-dashboard { display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:10px; }
+    .dt-kpi { background:var(--surface); border:1px solid rgba(148,163,184,.2); border-radius:14px; padding:14px 15px; display:flex; flex-direction:column; gap:3px; }
+    .dt-kpi .label { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.04em; color:var(--muted); }
+    .dt-kpi .value { font-size:21px; font-weight:800; color:var(--ink); line-height:1.2; }
+    .dt-kpi .sub { font-size:11px; color:var(--muted); }
+    .dt-kpi.positive .value { color:#16a34a; }
+    .dt-kpi.negative .value { color:#dc2626; }
+    .dt-kpi.alert { border-color:rgba(220,38,38,.35); background:rgba(220,38,38,.05); }
+    .dt-kpi.accent { background:linear-gradient(135deg,#0f172a,#1e293b); border-color:transparent; }
+    .dt-kpi.accent .label,.dt-kpi.accent .sub { color:rgba(255,255,255,.72); }
+    .dt-kpi.accent .value { color:#fff; }
+    .dt-form-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(140px,1fr)); gap:10px; align-items:end; }
+    .dt-form-grid label { display:flex; flex-direction:column; gap:4px; font-size:12px; font-weight:600; }
+    .dt-form-grid input,.dt-form-grid select { height:38px; }
+    .dt-preview { border-radius:12px; border:1px solid rgba(37,99,235,.2); background:rgba(37,99,235,.06); padding:11px 13px; font-size:12px; line-height:1.55; }
+    .dt-preview .neg { color:#dc2626; font-weight:700; }
+    .dt-preview .pos { color:#16a34a; font-weight:700; }
+    .dt-table { width:100%; border-collapse:collapse; font-size:12px; }
+    .dt-table th { text-align:left; font-size:10px; color:var(--muted); text-transform:uppercase; letter-spacing:.03em; padding:8px; border-bottom:1px solid rgba(148,163,184,.2); }
+    .dt-table td { padding:8px; border-bottom:1px solid rgba(148,163,184,.1); vertical-align:middle; }
+    .dt-table tr:last-child td { border-bottom:none; }
+    .dt-chip { display:inline-flex; align-items:center; gap:4px; padding:3px 8px; border-radius:999px; font-size:10px; font-weight:700; }
+    .dt-chip.long { background:rgba(22,163,74,.12); color:#15803d; }
+    .dt-chip.short { background:rgba(239,68,68,.12); color:#dc2626; }
+    .dt-inline-input { width:84px; height:30px; font-size:11px; text-align:right; border:1px solid rgba(148,163,184,.28); border-radius:7px; padding:0 6px; }
+    .dt-inline-input.qty { width:75px; }
+    .dt-chart-box { height:260px; position:relative; }
+    .dt-muted-empty { text-align:center; color:var(--muted); font-size:12px; padding:18px 0; }
+
     .inv-trade-tabs { display:inline-flex; gap:0; border-radius:10px; overflow:hidden; border:1px solid rgba(148,163,184,.3); }
     .inv-trade-tab { border:none; background:transparent; padding:8px 20px; font-weight:600; font-size:13px; cursor:pointer; color:var(--muted); transition:all .2s; }
     .inv-trade-tab.is-active { background:#2563eb; color:#fff; }
@@ -5017,6 +5051,70 @@
             </div>
           </div>
 
+          <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
+            <div class="inv-mode-switch" role="tablist" aria-label="Tryb inwestycji">
+              <button type="button" class="inv-mode-btn is-active" data-inv-mode="longterm">Inwestycje long-term</button>
+              <button type="button" class="inv-mode-btn" data-inv-mode="daytrade">Day trading (krypto)</button>
+            </div>
+            <span class="tiny muted" id="inv-mode-subtitle">Panel planowania i kontroli ryzyka day tradera.</span>
+          </div>
+
+          <div id="inv-daytrade-panel" class="dt-grid" style="display:none">
+            <div class="dt-dashboard" id="dt-dashboard"></div>
+
+            <div class="card stack">
+              <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
+                <strong>Plan pozycji i zarządzanie ryzykiem</strong>
+                <span class="tiny muted">SL/TP, RR i kontrola pozycji w czasie rzeczywistym</span>
+              </div>
+              <form id="dt-plan-form" class="dt-form-grid">
+                <label>Ticker<input name="ticker" placeholder="np. BTC, ETH, SOL" required /></label>
+                <label>Strona<select name="side"><option value="long">Long</option><option value="short">Short</option></select></label>
+                <label>Data<input name="date" type="date" required /></label>
+                <label>Kapitał pozycji (USD)<input name="sizeUsd" inputmode="decimal" placeholder="0.00" required /></label>
+                <label>Entry<input name="entry" inputmode="decimal" placeholder="0.00" required /></label>
+                <label>SL<input name="sl" inputmode="decimal" placeholder="0.00" required /></label>
+                <label>TP planowany<input name="tp" inputmode="decimal" placeholder="0.00" required /></label>
+                <label>Notatka<input name="note" placeholder="setup, bias, konfluencje..." /></label>
+                <button class="btn" type="submit">Dodaj pozycję</button>
+              </form>
+              <div class="dt-preview" id="dt-plan-preview">Wypełnij formularz, aby zobaczyć planowaną stratę, zysk i RR.</div>
+            </div>
+
+            <div class="card stack">
+              <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
+                <strong>Otwarte pozycje</strong>
+                <span class="tiny muted">Partial TP / zamykanie pozycji / prowizje</span>
+              </div>
+              <div class="table-wrapper">
+                <table class="dt-table">
+                  <thead><tr><th>Ticker</th><th>Strona</th><th>Entry</th><th>Akt. cena</th><th>Pozostało</th><th>Niezreal. PnL</th><th>Plan RR</th><th>Partial close qty</th><th>Cena close</th><th>Fee (USD)</th><th></th></tr></thead>
+                  <tbody id="dt-open-rows"></tbody>
+                </table>
+              </div>
+              <div class="dt-muted-empty" id="dt-open-empty" style="display:none">Brak otwartych pozycji.</div>
+            </div>
+
+            <div class="card stack">
+              <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
+                <strong>Statystyki i dyscyplina</strong>
+                <div class="row" style="gap:10px;align-items:end;flex-wrap:wrap">
+                  <label class="tiny muted" style="display:flex;flex-direction:column;gap:4px">Max strata dzienna (USD)<input id="dt-max-daily-loss" inputmode="decimal" class="dt-inline-input" /></label>
+                  <label class="tiny muted" style="display:flex;flex-direction:column;gap:4px">Max strata tygodniowa (USD)<input id="dt-max-weekly-loss" inputmode="decimal" class="dt-inline-input" /></label>
+                </div>
+              </div>
+              <div class="dt-chart-box"><canvas id="dt-equity-chart"></canvas></div>
+              <div class="table-wrapper">
+                <table class="dt-table">
+                  <thead><tr><th>Data</th><th>Ticker</th><th>Strona</th><th>Zamknięta ilość</th><th>PnL brutto</th><th>Prowizje</th><th>PnL netto</th><th>RR (real)</th><th>Typ</th></tr></thead>
+                  <tbody id="dt-close-log"></tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          <div id="inv-longterm-panel">
+
           <!-- Dashboard KPIs -->
           <div class="inv-dashboard" id="inv-dashboard">
             <div class="inv-kpi-card accent">
@@ -5366,6 +5464,7 @@
               <!-- =============== /HUB ANALITYCZNY =============== -->
 
             </div>
+          </div>
           </div>
 
         </div>
@@ -6136,9 +6235,15 @@
     // NEW: fixed expense templates
     if(!Array.isArray(bud.fixedTemplates)) bud.fixedTemplates=[];
     if(!bud.investments) bud.investments={assets:[], trades:[], groups:[]};
+    if(!bud.dayTrading) bud.dayTrading={positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}};
     if(!Array.isArray(bud.investments.assets)) bud.investments.assets=[];
     if(!Array.isArray(bud.investments.trades)) bud.investments.trades=[];
     if(!Array.isArray(bud.investments.groups)) bud.investments.groups=[];
+    if(!Array.isArray(bud.dayTrading.positions)) bud.dayTrading.positions=[];
+    if(!Array.isArray(bud.dayTrading.closes)) bud.dayTrading.closes=[];
+    if(!bud.dayTrading.limits || typeof bud.dayTrading.limits!=='object') bud.dayTrading.limits={dailyLoss:0,weeklyLoss:0};
+    if(!Number.isFinite(Number(bud.dayTrading.limits.dailyLoss))) bud.dayTrading.limits.dailyLoss=0;
+    if(!Number.isFinite(Number(bud.dayTrading.limits.weeklyLoss))) bud.dayTrading.limits.weeklyLoss=0;
     if(!Array.isArray(bud.eomInvestmentBridge)) bud.eomInvestmentBridge=[];
     for(const t of bud.investments.trades){
       if(!t.side) t.side='buy';
@@ -6175,6 +6280,7 @@
         recurringTemplates:[],recurringLog:[],
         fixedTemplates:[],
         investments:{assets:[], trades:[], groups:[]},
+        dayTrading:{positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}},
         eomInvestmentBridge:[]
       }}
     });
@@ -7438,10 +7544,12 @@
   let invSelectedAllocationGroup=null;
   let invModalBound=false;
   let invActivePanel='hub';
+  let invInvestMode='longterm';
   let invTradeMode='buy';
   let invTradeFilter='all';
   let invHoldingsSort={key:'value',dir:'desc'};
   const invCollapsedGroups=new Set();
+  let dtEquityChart=null;
 
   const investments=()=>{
     if(!b().investments) b().investments={assets:[],trades:[],groups:[]};
@@ -10823,11 +10931,277 @@
     });
   }
 
+  // --- Day Trading (crypto) -------------------------------------------------
+  const dayTrading=()=>{
+    if(!b().dayTrading) b().dayTrading={positions:[],closes:[],limits:{dailyLoss:0,weeklyLoss:0}};
+    const dt=b().dayTrading;
+    if(!Array.isArray(dt.positions)) dt.positions=[];
+    if(!Array.isArray(dt.closes)) dt.closes=[];
+    if(!dt.limits) dt.limits={dailyLoss:0,weeklyLoss:0};
+    dt.limits.dailyLoss=num(dt.limits.dailyLoss)||0;
+    dt.limits.weeklyLoss=num(dt.limits.weeklyLoss)||0;
+    return dt;
+  };
+
+  function dtComputePlanMetrics(payload){
+    const entry=num(payload.entry), sl=num(payload.sl), tp=num(payload.tp), sizeUsd=Math.abs(num(payload.sizeUsd));
+    const side=(payload.side||'long')==='short'?'short':'long';
+    if(entry<=0||sizeUsd<=0) return {isValid:false};
+    const qty=sizeUsd/entry;
+    const dir=side==='short'?-1:1;
+    const riskPerUnit=(entry-sl)*dir;
+    const rewardPerUnit=(tp-entry)*dir;
+    const riskUsd=Math.max(0,riskPerUnit*qty);
+    const rewardUsd=Math.max(0,rewardPerUnit*qty);
+    const rr=riskUsd>0?rewardUsd/riskUsd:null;
+    return {isValid:true,qty,dir,riskUsd,rewardUsd,rr};
+  }
+
+  function dtWeekStart(dateStr){
+    const d=new Date(`${dateStr}T00:00:00`);
+    const day=(d.getDay()+6)%7;
+    d.setDate(d.getDate()-day);
+    return d.toISOString().slice(0,10);
+  }
+
+  function dtComputeStats(){
+    const dt=dayTrading();
+    const today=new Date().toISOString().slice(0,10);
+    const weekStart=dtWeekStart(today);
+    let capital=0, realized=0, todayPnl=0, weeklyPnl=0;
+    let win=0,loss=0;
+    const openPositions=[];
+    for(const p of dt.positions){
+      const initQty=num(p.initialQty)||0;
+      const closedQty=num(p.closedQty)||0;
+      const remainingQty=Math.max(0,initQty-closedQty);
+      if((p.status||'open')==='open' && remainingQty>0.0000001){
+        openPositions.push({...p,remainingQty});
+        capital+=num(p.sizeUsd)||0;
+      }
+    }
+    for(const c of dt.closes){
+      const net=num(c.netPnl);
+      const cDate=String(c.date||'');
+      realized+=net;
+      if(net>=0) win++; else loss++;
+      if(cDate===today) todayPnl+=net;
+      if(cDate>=weekStart && cDate<=today) weeklyPnl+=net;
+    }
+    const total=win+loss;
+    const roi=capital>0?(realized/capital)*100:0;
+    const todayPct=capital>0?(todayPnl/capital)*100:0;
+    return {capital,realized,todayPnl,weeklyPnl,todayPct,roi,win,loss,winRate:total?((win/total)*100):0,openPositions};
+  }
+
+  function renderDayTradingDashboard(){
+    const dt=dayTrading();
+    const stats=dtComputeStats();
+    const dash=document.getElementById('dt-dashboard');
+    if(!dash) return;
+    const dailyLimit=Math.abs(num(dt.limits.dailyLoss)||0);
+    const weeklyLimit=Math.abs(num(dt.limits.weeklyLoss)||0);
+    const dailyHit=dailyLimit>0 && stats.todayPnl<=-dailyLimit;
+    const weeklyHit=weeklyLimit>0 && stats.weeklyPnl<=-weeklyLimit;
+    dash.innerHTML=`
+      <div class="dt-kpi accent"><span class="label">Kapitał aktywny USD</span><span class="value">${fmt(stats.capital,'USD')}</span><span class="sub">${stats.openPositions.length} otwartych pozycji</span></div>
+      <div class="dt-kpi ${stats.roi>=0?'positive':'negative'}"><span class="label">ROI łącznie</span><span class="value">${stats.capital>0?stats.roi.toFixed(2)+'%':'—'}</span><span class="sub">Netto z zamkniętych pozycji</span></div>
+      <div class="dt-kpi ${stats.realized>=0?'positive':'negative'}"><span class="label">PnL zrealizowany</span><span class="value">${fmt(stats.realized,'USD')}</span><span class="sub">Po uwzględnieniu prowizji</span></div>
+      <div class="dt-kpi ${stats.todayPnl>=0?'positive':'negative'} ${dailyHit?'alert':''}"><span class="label">Dzisiaj PnL</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">${stats.todayPct.toFixed(2)}% kapitału aktywnego</span></div>
+      <div class="dt-kpi ${stats.weeklyPnl>=0?'positive':'negative'} ${weeklyHit?'alert':''}"><span class="label">Tydzień PnL</span><span class="value">${fmt(stats.weeklyPnl,'USD')}</span><span class="sub">Limit: ${weeklyLimit>0?fmt(-weeklyLimit,'USD'):'nie ustawiono'}</span></div>
+      <div class="dt-kpi"><span class="label">Win rate</span><span class="value">${stats.winRate.toFixed(1)}%</span><span class="sub">W: ${stats.win} | L: ${stats.loss}</span></div>
+    `;
+  }
+
+  function renderDtPlanPreview(){
+    const form=document.getElementById('dt-plan-form');
+    const preview=document.getElementById('dt-plan-preview');
+    if(!form||!preview) return;
+    const f=new FormData(form);
+    const m=dtComputePlanMetrics({
+      side:f.get('side'), entry:f.get('entry'), sl:f.get('sl'), tp:f.get('tp'), sizeUsd:f.get('sizeUsd')
+    });
+    if(!m.isValid){preview.textContent='Wypełnij formularz, aby zobaczyć planowaną stratę, zysk i RR.';return;}
+    preview.innerHTML=`Plan: ilość <b>${m.qty.toFixed(6)}</b> | Ryzyko SL: <span class="neg">${fmt(-m.riskUsd,'USD')}</span> | Potencjał TP: <span class="pos">${fmt(m.rewardUsd,'USD')}</span> | RR: <b>${m.rr?m.rr.toFixed(2):'—'}</b>`;
+  }
+
+  function dtRecordClose(position, qty, closePrice, fee, closeDate){
+    const dir=position.side==='short'?-1:1;
+    const gross=(closePrice-num(position.entry))*qty*dir;
+    const riskPerUnit=(num(position.entry)-num(position.sl))*dir;
+    const riskAbs=Math.max(0,riskPerUnit*qty);
+    const net=gross-fee;
+    const rr=riskAbs>0?net/riskAbs:null;
+    dayTrading().closes.unshift({
+      id:'dt_close_'+Math.random().toString(36).slice(2),
+      positionId:position.id,ticker:position.ticker,side:position.side,date:closeDate,
+      qty,closePrice,fee,grossPnl:gross,netPnl:net,rr,partial:(qty<(num(position.initialQty)-num(position.closedQty||0)-0.0000001))
+    });
+    position.closedQty=(num(position.closedQty)||0)+qty;
+    position.realizedPnl=(num(position.realizedPnl)||0)+net;
+    if(position.closedQty>=num(position.initialQty)-0.0000001){
+      position.status='closed';
+      position.closedDate=closeDate;
+    }
+  }
+
+  function renderDayTradingOpenPositions(){
+    const dt=dayTrading();
+    const tbody=document.getElementById('dt-open-rows');
+    const empty=document.getElementById('dt-open-empty');
+    if(!tbody||!empty) return;
+    tbody.innerHTML='';
+    const opens=(dt.positions||[]).filter(p=>(p.status||'open')==='open' && (num(p.initialQty)-num(p.closedQty||0))>0.0000001);
+    empty.style.display=opens.length?'none':'block';
+    for(const p of opens){
+      const remainingQty=num(p.initialQty)-num(p.closedQty||0);
+      const mark=num(p.markPrice)||num(p.entry);
+      const dir=p.side==='short'?-1:1;
+      const unrl=(mark-num(p.entry))*remainingQty*dir;
+      const risk=Math.max(0,(num(p.entry)-num(p.sl))*dir*remainingQty);
+      const reward=Math.max(0,(num(p.tp)-num(p.entry))*dir*remainingQty);
+      const rr=risk>0?reward/risk:null;
+      const tr=document.createElement('tr');
+      tr.innerHTML=`
+        <td><strong>${escapeHtml(p.ticker)}</strong><div class="tiny muted">${p.openDate||''}</div></td>
+        <td><span class="dt-chip ${p.side==='short'?'short':'long'}">${p.side==='short'?'SHORT':'LONG'}</span></td>
+        <td>${num(p.entry).toFixed(4)}</td>
+        <td><input class="dt-inline-input" data-k="mark" value="${mark}" /></td>
+        <td>${remainingQty.toFixed(6)}</td>
+        <td class="${unrl>=0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(unrl,'USD')}</td>
+        <td>${rr?rr.toFixed(2):'—'}</td>
+        <td><input class="dt-inline-input qty" data-k="closeQty" value="${remainingQty.toFixed(6)}" /></td>
+        <td><input class="dt-inline-input" data-k="closePrice" value="${mark}" /></td>
+        <td><input class="dt-inline-input" data-k="fee" value="0" /></td>
+        <td class="row" style="gap:6px"><button class="btn soft" data-act="partial">Zamknij</button></td>
+      `;
+      tr.querySelector('[data-k="mark"]').onchange=e=>{p.markPrice=num(e.target.value)||num(p.entry);save(state);renderInvestments();};
+      tr.querySelector('[data-act="partial"]').onclick=()=>{
+        const qty=Math.abs(num(tr.querySelector('[data-k="closeQty"]').value));
+        const closePrice=Math.abs(num(tr.querySelector('[data-k="closePrice"]').value));
+        const fee=Math.abs(num(tr.querySelector('[data-k="fee"]').value));
+        if(qty<=0||closePrice<=0){alert('Podaj poprawną ilość i cenę zamknięcia.');return;}
+        if(qty>remainingQty+0.0000001){alert(`Maksymalna ilość do zamknięcia: ${remainingQty.toFixed(6)}`);return;}
+        dtRecordClose(p,qty,closePrice,fee,new Date().toISOString().slice(0,10));
+        save(state); renderInvestments();
+      };
+      tbody.appendChild(tr);
+    }
+  }
+
+  function renderDayTradingCloseLog(){
+    const closes=dayTrading().closes||[];
+    const tbody=document.getElementById('dt-close-log');
+    if(!tbody) return;
+    tbody.innerHTML='';
+    for(const c of closes.slice(0,120)){
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${c.date||''}</td><td>${escapeHtml(c.ticker||'')}</td><td>${(c.side||'').toUpperCase()}</td><td>${num(c.qty).toFixed(6)}</td><td class="${num(c.grossPnl)>=0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(num(c.grossPnl),'USD')}</td><td>${fmt(num(c.fee),'USD')}</td><td class="${num(c.netPnl)>=0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(num(c.netPnl),'USD')}</td><td>${c.rr!=null?Number(c.rr).toFixed(2):'—'}</td><td>${c.partial?'Partial':'Full'}</td>`;
+      tbody.appendChild(tr);
+    }
+  }
+
+  function renderDayTradingChart(){
+    if(dtEquityChart){dtEquityChart.destroy();dtEquityChart=null;}
+    const canvas=document.getElementById('dt-equity-chart');
+    if(!canvas) return;
+    const closes=(dayTrading().closes||[]).slice().sort((a,bb)=>String(a.date).localeCompare(String(bb.date)));
+    if(!closes.length) return;
+    const byDay={};
+    for(const c of closes) byDay[c.date]=(byDay[c.date]||0)+num(c.netPnl);
+    const labels=Object.keys(byDay).sort();
+    let cumul=0;
+    const series=labels.map(d=>{cumul+=byDay[d];return +cumul.toFixed(2);});
+    dtEquityChart=new Chart(canvas.getContext('2d'),{
+      type:'line',
+      data:{labels,datasets:[{label:'Equity curve (PnL netto)',data:series,borderColor:'#2563eb',backgroundColor:'rgba(37,99,235,.12)',fill:true,tension:.28,pointRadius:2}]},
+      options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{grid:{display:false}},y:{ticks:{callback:v=>currencyTicks(v)}}}}
+    });
+  }
+
+  function bindDayTrading(){
+    const dt=dayTrading();
+    const form=document.getElementById('dt-plan-form');
+    if(form&&!form._bound){
+      form._bound=true;
+      const dateInput=form.querySelector('input[name="date"]');
+      if(dateInput&&!dateInput.value) dateInput.value=new Date().toISOString().slice(0,10);
+      form.addEventListener('input',renderDtPlanPreview);
+      form.onsubmit=e=>{
+        e.preventDefault();
+        const f=new FormData(form);
+        const payload={
+          ticker:String(f.get('ticker')||'').trim().toUpperCase(),
+          side:String(f.get('side')||'long'),
+          date:String(f.get('date')||new Date().toISOString().slice(0,10)),
+          sizeUsd:Math.abs(num(f.get('sizeUsd'))),
+          entry:Math.abs(num(f.get('entry'))),
+          sl:Math.abs(num(f.get('sl'))),
+          tp:Math.abs(num(f.get('tp'))),
+          note:String(f.get('note')||'').trim()
+        };
+        if(!payload.ticker||payload.sizeUsd<=0||payload.entry<=0||payload.sl<=0||payload.tp<=0){alert('Uzupełnij poprawnie ticker, kapitał, entry, SL i TP.');return;}
+        const m=dtComputePlanMetrics(payload);
+        dt.positions.unshift({
+          id:'dt_pos_'+Math.random().toString(36).slice(2),ticker:payload.ticker,side:payload.side,openDate:payload.date,sizeUsd:payload.sizeUsd,
+          entry:payload.entry,sl:payload.sl,tp:payload.tp,note:payload.note,status:'open',
+          initialQty:m.qty,closedQty:0,realizedPnl:0,markPrice:payload.entry,plannedRisk:m.riskUsd,plannedReward:m.rewardUsd,plannedRr:m.rr
+        });
+        save(state);form.reset();
+        if(dateInput) dateInput.value=new Date().toISOString().slice(0,10);
+        renderInvestments();
+      };
+    }
+    const dailyInput=document.getElementById('dt-max-daily-loss');
+    const weeklyInput=document.getElementById('dt-max-weekly-loss');
+    if(dailyInput && !dailyInput._bound){
+      dailyInput._bound=true;
+      dailyInput.onchange=()=>{dt.limits.dailyLoss=Math.abs(num(dailyInput.value)||0);save(state);renderInvestments();};
+    }
+    if(weeklyInput && !weeklyInput._bound){
+      weeklyInput._bound=true;
+      weeklyInput.onchange=()=>{dt.limits.weeklyLoss=Math.abs(num(weeklyInput.value)||0);save(state);renderInvestments();};
+    }
+    if(dailyInput) dailyInput.value=dt.limits.dailyLoss?String(dt.limits.dailyLoss).replace('.',','):'';
+    if(weeklyInput) weeklyInput.value=dt.limits.weeklyLoss?String(dt.limits.weeklyLoss).replace('.',','):'';
+    renderDtPlanPreview();
+  }
+
+  function setInvestmentMode(mode){
+    invInvestMode=(mode==='daytrade')?'daytrade':'longterm';
+    const longPanel=document.getElementById('inv-longterm-panel');
+    const dayPanel=document.getElementById('inv-daytrade-panel');
+    const subtitle=document.getElementById('inv-mode-subtitle');
+    document.querySelectorAll('.inv-mode-btn').forEach(btn=>btn.classList.toggle('is-active',btn.dataset.invMode===invInvestMode));
+    if(longPanel) longPanel.style.display=invInvestMode==='longterm'?'block':'none';
+    if(dayPanel) dayPanel.style.display=invInvestMode==='daytrade'?'grid':'none';
+    if(subtitle) subtitle.textContent=invInvestMode==='daytrade'
+      ?'Skupienie na kapitale, ROI, PnL, RR i limitach dyscypliny.'
+      :'Moduł long-term: portfel, analityka, snapshoty i alokacja.';
+  }
+
   // --- Main Render -----------------------------------------------------------
   function renderInvestments(){
     ensureInvestmentCategory();
     const data=investments();
     bindInvestmentModal();
+    bindDayTrading();
+
+    document.querySelectorAll('.inv-mode-btn').forEach(btn=>{
+      if(btn._bound) return; btn._bound=true;
+      btn.onclick=()=>{ setInvestmentMode(btn.dataset.invMode||'longterm'); renderInvestments(); };
+    });
+    setInvestmentMode(invInvestMode);
+    if(invInvestMode==='daytrade'){
+      renderDayTradingDashboard();
+      renderDayTradingOpenPositions();
+      renderDayTradingCloseLog();
+      renderDayTradingChart();
+    }
+    if(invInvestMode!=='longterm'){
+      bindMoneyInputs(document.getElementById('tab-investments'));
+      return;
+    }
     bindInvestmentAnalyticsNav();
 
     // Trade mode tabs

--- a/budget.html
+++ b/budget.html
@@ -5147,14 +5147,15 @@
 
             <div class="card stack dt-span-2">
               <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
-                <strong>Statystyki i dyscyplina</strong>
+                <strong>Panel sterowania (% kapitału)</strong>
                 <div class="row" style="gap:10px;align-items:end;flex-wrap:wrap">
-                  <label class="tiny muted" style="display:flex;flex-direction:column;gap:4px">Max strata dzienna (USD)<input id="dt-max-daily-loss" inputmode="decimal" class="dt-inline-input" /></label>
-                  <label class="tiny muted" style="display:flex;flex-direction:column;gap:4px">Max strata tygodniowa (USD)<input id="dt-max-weekly-loss" inputmode="decimal" class="dt-inline-input" /></label>
+                  <label class="tiny muted" style="display:flex;flex-direction:column;gap:4px">Max strata dzienna (%)<input id="dt-max-daily-loss-pct" inputmode="decimal" class="dt-inline-input" /></label>
+                  <label class="tiny muted" style="display:flex;flex-direction:column;gap:4px">Max strata tygodniowa (%)<input id="dt-max-weekly-loss-pct" inputmode="decimal" class="dt-inline-input" /></label>
+                  <label class="tiny muted" style="display:flex;flex-direction:column;gap:4px">Cel zysku dziennego (%)<input id="dt-target-daily-profit-pct" inputmode="decimal" class="dt-inline-input" /></label>
+                  <label class="tiny muted" style="display:flex;flex-direction:column;gap:4px">Cel zysku tygodniowego (%)<input id="dt-target-weekly-profit-pct" inputmode="decimal" class="dt-inline-input" /></label>
                   <button type="button" class="btn ghost" id="dt-clear-closed" style="font-size:11px">Usuń historię zamkniętych</button>
                 </div>
               </div>
-              <div class="dt-chart-box"><canvas id="dt-equity-chart"></canvas></div>
               <div class="table-wrapper">
                 <table class="dt-table">
                   <thead><tr><th>Data</th><th>Ticker</th><th>Strona</th><th>Zamknięta ilość</th><th>PnL brutto</th><th>Prowizje</th><th>PnL netto</th><th>RR (real)</th><th>Typ</th><th></th></tr></thead>
@@ -6343,16 +6344,18 @@
     // NEW: fixed expense templates
     if(!Array.isArray(bud.fixedTemplates)) bud.fixedTemplates=[];
     if(!bud.investments) bud.investments={assets:[], trades:[], groups:[]};
-    if(!bud.dayTrading) bud.dayTrading={positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}, capitalFlows:[]};
+    if(!bud.dayTrading) bud.dayTrading={positions:[], closes:[], limits:{maxDailyLossPct:0,maxWeeklyLossPct:0,targetDailyProfitPct:0,targetWeeklyProfitPct:0}, capitalFlows:[]};
     if(!Array.isArray(bud.investments.assets)) bud.investments.assets=[];
     if(!Array.isArray(bud.investments.trades)) bud.investments.trades=[];
     if(!Array.isArray(bud.investments.groups)) bud.investments.groups=[];
     if(!Array.isArray(bud.dayTrading.positions)) bud.dayTrading.positions=[];
     if(!Array.isArray(bud.dayTrading.closes)) bud.dayTrading.closes=[];
     if(!Array.isArray(bud.dayTrading.capitalFlows)) bud.dayTrading.capitalFlows=[];
-    if(!bud.dayTrading.limits || typeof bud.dayTrading.limits!=='object') bud.dayTrading.limits={dailyLoss:0,weeklyLoss:0};
-    if(!Number.isFinite(Number(bud.dayTrading.limits.dailyLoss))) bud.dayTrading.limits.dailyLoss=0;
-    if(!Number.isFinite(Number(bud.dayTrading.limits.weeklyLoss))) bud.dayTrading.limits.weeklyLoss=0;
+    if(!bud.dayTrading.limits || typeof bud.dayTrading.limits!=='object') bud.dayTrading.limits={maxDailyLossPct:0,maxWeeklyLossPct:0,targetDailyProfitPct:0,targetWeeklyProfitPct:0};
+    if(!Number.isFinite(Number(bud.dayTrading.limits.maxDailyLossPct))) bud.dayTrading.limits.maxDailyLossPct=Math.abs(num(bud.dayTrading.limits.dailyLoss)||0);
+    if(!Number.isFinite(Number(bud.dayTrading.limits.maxWeeklyLossPct))) bud.dayTrading.limits.maxWeeklyLossPct=Math.abs(num(bud.dayTrading.limits.weeklyLoss)||0);
+    if(!Number.isFinite(Number(bud.dayTrading.limits.targetDailyProfitPct))) bud.dayTrading.limits.targetDailyProfitPct=0;
+    if(!Number.isFinite(Number(bud.dayTrading.limits.targetWeeklyProfitPct))) bud.dayTrading.limits.targetWeeklyProfitPct=0;
     if(!Array.isArray(bud.eomInvestmentBridge)) bud.eomInvestmentBridge=[];
     for(const t of bud.investments.trades){
       if(!t.side) t.side='buy';
@@ -6389,7 +6392,7 @@
         recurringTemplates:[],recurringLog:[],
         fixedTemplates:[],
         investments:{assets:[], trades:[], groups:[]},
-        dayTrading:{positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}, capitalFlows:[]},
+        dayTrading:{positions:[], closes:[], limits:{maxDailyLossPct:0,maxWeeklyLossPct:0,targetDailyProfitPct:0,targetWeeklyProfitPct:0}, capitalFlows:[]},
         eomInvestmentBridge:[]
       }}
     });
@@ -7658,7 +7661,6 @@
   let invTradeFilter='all';
   let invHoldingsSort={key:'value',dir:'desc'};
   const invCollapsedGroups=new Set();
-  let dtEquityChart=null;
   let dtHubRoiChart=null;
   let dtHubPnlChart=null;
   let dtHubMode='daily';
@@ -11047,14 +11049,16 @@
 
   // --- Day Trading (crypto) -------------------------------------------------
   const dayTrading=()=>{
-    if(!b().dayTrading) b().dayTrading={positions:[],closes:[],limits:{dailyLoss:0,weeklyLoss:0},capitalFlows:[]};
+    if(!b().dayTrading) b().dayTrading={positions:[],closes:[],limits:{maxDailyLossPct:0,maxWeeklyLossPct:0,targetDailyProfitPct:0,targetWeeklyProfitPct:0},capitalFlows:[]};
     const dt=b().dayTrading;
     if(!Array.isArray(dt.positions)) dt.positions=[];
     if(!Array.isArray(dt.closes)) dt.closes=[];
     if(!Array.isArray(dt.capitalFlows)) dt.capitalFlows=[];
-    if(!dt.limits) dt.limits={dailyLoss:0,weeklyLoss:0};
-    dt.limits.dailyLoss=num(dt.limits.dailyLoss)||0;
-    dt.limits.weeklyLoss=num(dt.limits.weeklyLoss)||0;
+    if(!dt.limits) dt.limits={maxDailyLossPct:0,maxWeeklyLossPct:0,targetDailyProfitPct:0,targetWeeklyProfitPct:0};
+    dt.limits.maxDailyLossPct=Math.abs(num(dt.limits.maxDailyLossPct)||0);
+    dt.limits.maxWeeklyLossPct=Math.abs(num(dt.limits.maxWeeklyLossPct)||0);
+    dt.limits.targetDailyProfitPct=Math.abs(num(dt.limits.targetDailyProfitPct)||0);
+    dt.limits.targetWeeklyProfitPct=Math.abs(num(dt.limits.targetWeeklyProfitPct)||0);
     return dt;
   };
 
@@ -11121,7 +11125,8 @@
     const baseForRoi=Math.max(1,Math.abs(netFlows));
     const roi=((equity-netFlows)/baseForRoi)*100;
     const todayPct=netFlows!==0?(todayPnl/Math.abs(netFlows))*100:0;
-    return {activeNotional,lockedMargin,unrealized,realized,todayPnl,weeklyPnl,todayPct,roi,win,loss,winRate:total?((win/total)*100):0,openPositions,deposits,withdrawals,netFlows,freeCash,walletBalance,equity,canTrade:deposits>0&&freeCash>0};
+    const weeklyPct=netFlows!==0?(weeklyPnl/Math.abs(netFlows))*100:0;
+    return {activeNotional,lockedMargin,unrealized,realized,todayPnl,weeklyPnl,todayPct,weeklyPct,roi,win,loss,winRate:total?((win/total)*100):0,openPositions,deposits,withdrawals,netFlows,freeCash,walletBalance,equity,canTrade:deposits>0&&freeCash>0};
   }
 
   function renderDayTradingDashboard(){
@@ -11129,16 +11134,22 @@
     const stats=dtComputeStats();
     const dash=document.getElementById('dt-dashboard');
     if(!dash) return;
-    const dailyLimit=Math.abs(num(dt.limits.dailyLoss)||0);
-    const dailyHit=dailyLimit>0 && stats.todayPnl<=-dailyLimit;
+    const dailyLossPct=Math.abs(num(dt.limits.maxDailyLossPct)||0);
+    const weeklyLossPct=Math.abs(num(dt.limits.maxWeeklyLossPct)||0);
+    const dailyTargetPct=Math.abs(num(dt.limits.targetDailyProfitPct)||0);
+    const weeklyTargetPct=Math.abs(num(dt.limits.targetWeeklyProfitPct)||0);
+    const dailyHit=dailyLossPct>0 && stats.todayPct<=-dailyLossPct;
+    const weeklyHit=weeklyLossPct>0 && stats.weeklyPct<=-weeklyLossPct;
+    const dailyTargetHit=dailyTargetPct>0 && stats.todayPct>=dailyTargetPct;
+    const weeklyTargetHit=weeklyTargetPct>0 && stats.weeklyPct>=weeklyTargetPct;
     const todayCloses=(dt.closes||[]).filter(c=>String(c.date||'')===new Date().toISOString().slice(0,10));
     const todayFees=todayCloses.reduce((s,c)=>s+Math.abs(num(c.fee)),0);
     const avgTodayRr=todayCloses.length?todayCloses.reduce((s,c)=>s+(num(c.rr)||0),0)/todayCloses.length:0;
     dash.innerHTML=`
-      <div class="dt-kpi accent"><span class="label">Dzisiaj: PnL netto</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">Limit dzienny: ${dailyLimit?fmt(-dailyLimit,'USD'):'—'}</span></div>
+      <div class="dt-kpi accent"><span class="label">Dzisiaj: PnL netto</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">${stats.todayPct.toFixed(2)}% kapitału</span></div>
       <div class="dt-kpi ${stats.todayPnl>=0?'positive':'negative'} ${dailyHit?'alert':''}"><span class="label">Dzisiejsze zamknięcia</span><span class="value">${todayCloses.length}</span><span class="sub">Śr. RR: ${todayCloses.length?avgTodayRr.toFixed(2):'—'}</span></div>
-      <div class="dt-kpi"><span class="label">Dzisiaj: prowizje</span><span class="value">${fmt(-todayFees,'USD')}</span><span class="sub">Tydzień PnL: ${fmt(stats.weeklyPnl,'USD')}</span></div>
-      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Dostępny margin</span><span class="value">${fmt(stats.freeCash,'USD')}</span><span class="sub">Locked: ${fmt(stats.lockedMargin,'USD')} | Equity: ${fmt(stats.equity,'USD')}</span></div>
+      <div class="dt-kpi ${(dailyTargetHit||weeklyTargetHit)?'positive':(dailyHit||weeklyHit)?'negative':''} ${dailyHit||weeklyHit?'alert':''}"><span class="label">Rekomendacje % (D/T)</span><span class="value">${stats.todayPct.toFixed(2)}% / ${stats.weeklyPct.toFixed(2)}%</span><span class="sub">Max loss: ${dailyLossPct||0}% / ${weeklyLossPct||0}% • Cel: ${dailyTargetPct||0}% / ${weeklyTargetPct||0}%</span></div>
+      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Dostępny margin</span><span class="value">${fmt(stats.freeCash,'USD')}</span><span class="sub">Prowizje dziś: ${fmt(-todayFees,'USD')} | Equity: ${fmt(stats.equity,'USD')}</span></div>
     `;
   }
 
@@ -11292,24 +11303,6 @@
       tr.querySelector('[data-del]').onclick=()=>{dayTrading().closes=dayTrading().closes.filter(x=>x.id!==c.id);save(state);renderInvestments();};
       tbody.appendChild(tr);
     }
-  }
-
-  function renderDayTradingChart(){
-    if(dtEquityChart){dtEquityChart.destroy();dtEquityChart=null;}
-    const canvas=document.getElementById('dt-equity-chart');
-    if(!canvas) return;
-    const closes=(dayTrading().closes||[]).slice().sort((a,bb)=>String(a.date).localeCompare(String(bb.date)));
-    if(!closes.length) return;
-    const byDay={};
-    for(const c of closes) byDay[c.date]=(byDay[c.date]||0)+num(c.netPnl);
-    const labels=Object.keys(byDay).sort();
-    let cumul=0;
-    const series=labels.map(d=>{cumul+=byDay[d];return +cumul.toFixed(2);});
-    dtEquityChart=new Chart(canvas.getContext('2d'),{
-      type:'line',
-      data:{labels,datasets:[{label:'Equity curve (PnL netto)',data:series,borderColor:'#2563eb',backgroundColor:'rgba(37,99,235,.12)',fill:true,tension:.28,pointRadius:2}]},
-      options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{grid:{display:false}},y:{ticks:{callback:v=>currencyTicks(v)}}}}
-    });
   }
 
   function dtPeriodKey(dateStr,mode){
@@ -11470,18 +11463,23 @@
         renderInvestments();
       };
     }
-    const dailyInput=document.getElementById('dt-max-daily-loss');
-    const weeklyInput=document.getElementById('dt-max-weekly-loss');
-    if(dailyInput && !dailyInput._bound){
-      dailyInput._bound=true;
-      dailyInput.onchange=()=>{dt.limits.dailyLoss=Math.abs(num(dailyInput.value)||0);save(state);renderInvestments();};
-    }
-    if(weeklyInput && !weeklyInput._bound){
-      weeklyInput._bound=true;
-      weeklyInput.onchange=()=>{dt.limits.weeklyLoss=Math.abs(num(weeklyInput.value)||0);save(state);renderInvestments();};
-    }
-    if(dailyInput) dailyInput.value=dt.limits.dailyLoss?String(dt.limits.dailyLoss).replace('.',','):'';
-    if(weeklyInput) weeklyInput.value=dt.limits.weeklyLoss?String(dt.limits.weeklyLoss).replace('.',','):'';
+    const dailyLossInput=document.getElementById('dt-max-daily-loss-pct');
+    const weeklyLossInput=document.getElementById('dt-max-weekly-loss-pct');
+    const dailyTargetInput=document.getElementById('dt-target-daily-profit-pct');
+    const weeklyTargetInput=document.getElementById('dt-target-weekly-profit-pct');
+    const bindPct=(el,key)=>{
+      if(!el || el._bound) return;
+      el._bound=true;
+      el.onchange=()=>{dt.limits[key]=Math.abs(num(el.value)||0);save(state);renderInvestments();};
+    };
+    bindPct(dailyLossInput,'maxDailyLossPct');
+    bindPct(weeklyLossInput,'maxWeeklyLossPct');
+    bindPct(dailyTargetInput,'targetDailyProfitPct');
+    bindPct(weeklyTargetInput,'targetWeeklyProfitPct');
+    if(dailyLossInput) dailyLossInput.value=dt.limits.maxDailyLossPct?String(dt.limits.maxDailyLossPct).replace('.',','):'';
+    if(weeklyLossInput) weeklyLossInput.value=dt.limits.maxWeeklyLossPct?String(dt.limits.maxWeeklyLossPct).replace('.',','):'';
+    if(dailyTargetInput) dailyTargetInput.value=dt.limits.targetDailyProfitPct?String(dt.limits.targetDailyProfitPct).replace('.',','):'';
+    if(weeklyTargetInput) weeklyTargetInput.value=dt.limits.targetWeeklyProfitPct?String(dt.limits.targetWeeklyProfitPct).replace('.',','):'';
 
     const clearOpenBtn=document.getElementById('dt-clear-open');
     if(clearOpenBtn && !clearOpenBtn._bound){
@@ -11568,7 +11566,6 @@
       renderDayTradingDashboard();
       renderDayTradingOpenPositions();
       renderDayTradingCloseLog();
-      renderDayTradingChart();
       bindDtHub();
       renderDtHubCharts();
       renderDtHubCalendar();

--- a/budget.html
+++ b/budget.html
@@ -123,6 +123,9 @@
     .inv-mode-btn.is-active { background:#fff; color:var(--ink); box-shadow:0 8px 20px rgba(15,23,42,.12); }
 
     .dt-grid { display:grid; gap:14px; }
+    .dt-layout { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; }
+    .dt-span-2 { grid-column:1 / -1; }
+    @media(max-width:980px){ .dt-layout{grid-template-columns:1fr;} .dt-span-2{grid-column:auto;} }
     .dt-dashboard { display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:10px; }
     .dt-kpi { background:var(--surface); border:1px solid rgba(148,163,184,.2); border-radius:14px; padding:14px 15px; display:flex; flex-direction:column; gap:3px; }
     .dt-kpi .label { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.04em; color:var(--muted); }
@@ -5067,6 +5070,7 @@
 
           <div id="inv-daytrade-panel" class="dt-grid" style="display:none">
             <div class="dt-dashboard" id="dt-dashboard"></div>
+            <div class="dt-layout">
 
             <div class="card stack">
               <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
@@ -5099,6 +5103,7 @@
                 <label>Strona<select name="side"><option value="long">Long</option><option value="short">Short</option></select></label>
                 <label>Data<input name="date" type="date" required /></label>
                 <label>Position size (krypto)<input name="sizeQty" inputmode="decimal" placeholder="np. 0.02" required /></label>
+                <label>Dźwignia<input name="leverage" type="number" min="1" max="125" step="1" value="1" required /></label>
                 <label>Entry<input name="entry" inputmode="decimal" placeholder="0.00" required /></label>
                 <label>SL<input name="sl" inputmode="decimal" placeholder="0.00" required /></label>
                 <label>TP planowany<input name="tp" inputmode="decimal" placeholder="0.00" required /></label>
@@ -5108,21 +5113,21 @@
               <div class="dt-preview" id="dt-plan-preview">Wypełnij formularz, aby zobaczyć planowaną stratę, zysk i RR.</div>
             </div>
 
-            <div class="card stack">
+            <div class="card stack dt-span-2">
               <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
                 <strong>Otwarte pozycje</strong>
                 <span class="tiny muted">Partial TP / zamykanie pozycji / prowizje</span>
               </div>
               <div class="table-wrapper">
                 <table class="dt-table">
-                  <thead><tr><th>Ticker</th><th>Strona</th><th>Entry</th><th>Akt. cena</th><th>Pozostało</th><th>Nominał (USD)</th><th>Niezreal. PnL</th><th>Plan RR</th><th></th></tr></thead>
+                  <thead><tr><th>Ticker</th><th>Strona</th><th>Entry</th><th>Akt. cena</th><th>Pozostało</th><th>Lev</th><th>Margin</th><th>Niezreal. PnL</th><th>Plan RR</th><th></th></tr></thead>
                   <tbody id="dt-open-rows"></tbody>
                 </table>
               </div>
               <div class="dt-muted-empty" id="dt-open-empty" style="display:none">Brak otwartych pozycji.</div>
             </div>
 
-            <div class="card stack">
+            <div class="card stack dt-span-2">
               <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
                 <strong>Statystyki i dyscyplina</strong>
                 <div class="row" style="gap:10px;align-items:end;flex-wrap:wrap">
@@ -5137,6 +5142,7 @@
                   <tbody id="dt-close-log"></tbody>
                 </table>
               </div>
+            </div>
             </div>
           </div>
           <div id="dt-close-modal-backdrop" class="dt-close-modal-backdrop"></div>
@@ -11001,6 +11007,7 @@
 
   function dtComputePlanMetrics(payload){
     const entry=num(payload.entry), sl=num(payload.sl), tp=num(payload.tp), sizeQty=Math.abs(num(payload.sizeQty));
+    const leverage=Math.max(1,num(payload.leverage)||1);
     const side=(payload.side||'long')==='short'?'short':'long';
     if(entry<=0||sizeQty<=0) return {isValid:false};
     const qty=sizeQty;
@@ -11010,7 +11017,9 @@
     const riskUsd=Math.max(0,riskPerUnit*qty);
     const rewardUsd=Math.max(0,rewardPerUnit*qty);
     const rr=riskUsd>0?rewardUsd/riskUsd:null;
-    return {isValid:true,qty,dir,riskUsd,rewardUsd,rr,notionalUsd:qty*entry};
+    const notionalUsd=qty*entry;
+    const marginRequired=notionalUsd/leverage;
+    return {isValid:true,qty,dir,riskUsd,rewardUsd,rr,notionalUsd,marginRequired,leverage};
   }
 
   function dtWeekStart(dateStr){
@@ -11024,7 +11033,7 @@
     const dt=dayTrading();
     const today=new Date().toISOString().slice(0,10);
     const weekStart=dtWeekStart(today);
-    let activeNotional=0, openedCostTotal=0, unrealized=0, realized=0, todayPnl=0, weeklyPnl=0;
+    let activeNotional=0, lockedMargin=0, unrealized=0, realized=0, todayPnl=0, weeklyPnl=0;
     let win=0,loss=0;
     const deposits=(dt.capitalFlows||[]).reduce((sum,f)=>sum+(f.type==='deposit'?Math.abs(num(f.amountUsd)):0),0);
     const withdrawals=(dt.capitalFlows||[]).reduce((sum,f)=>sum+(f.type==='withdrawal'?Math.abs(num(f.amountUsd)):0),0);
@@ -11034,12 +11043,13 @@
       const initQty=num(p.initialQty)||0;
       const closedQty=num(p.closedQty)||0;
       const remainingQty=Math.max(0,initQty-closedQty);
-      openedCostTotal+=initQty*num(p.entry);
+      const lev=Math.max(1,num(p.leverage)||1);
       if((p.status||'open')==='open' && remainingQty>0.0000001){
         openPositions.push({...p,remainingQty});
         const mark=num(p.markPrice)||num(p.entry);
         const dir=p.side==='short'?-1:1;
         activeNotional+=remainingQty*num(p.entry);
+        lockedMargin+=(remainingQty*num(p.entry))/lev;
         unrealized+=(mark-num(p.entry))*remainingQty*dir;
       }
     }
@@ -11052,14 +11062,13 @@
       if(cDate>=weekStart && cDate<=today) weeklyPnl+=net;
     }
     const total=win+loss;
-    const cashFromClosed=(dt.closes||[]).reduce((sum,c)=>sum+((num(c.closePrice)*num(c.qty))-Math.abs(num(c.fee))),0);
-    const freeCash=netFlows-openedCostTotal+cashFromClosed;
-    const marketValueOpen=openPositions.reduce((sum,p)=>sum+((num(p.markPrice)||num(p.entry))*num(p.remainingQty)),0);
-    const equity=freeCash+marketValueOpen;
+    const walletBalance=netFlows+realized;
+    const freeCash=walletBalance-lockedMargin;
+    const equity=walletBalance+unrealized;
     const baseForRoi=Math.max(1,Math.abs(netFlows));
     const roi=((equity-netFlows)/baseForRoi)*100;
     const todayPct=netFlows!==0?(todayPnl/Math.abs(netFlows))*100:0;
-    return {activeNotional,unrealized,realized,todayPnl,weeklyPnl,todayPct,roi,win,loss,winRate:total?((win/total)*100):0,openPositions,deposits,withdrawals,netFlows,freeCash,marketValueOpen,equity,canTrade:deposits>0&&freeCash>0};
+    return {activeNotional,lockedMargin,unrealized,realized,todayPnl,weeklyPnl,todayPct,roi,win,loss,winRate:total?((win/total)*100):0,openPositions,deposits,withdrawals,netFlows,freeCash,walletBalance,equity,canTrade:deposits>0&&freeCash>0};
   }
 
   function renderDayTradingDashboard(){
@@ -11072,7 +11081,7 @@
     const dailyHit=dailyLimit>0 && stats.todayPnl<=-dailyLimit;
     const weeklyHit=weeklyLimit>0 && stats.weeklyPnl<=-weeklyLimit;
     dash.innerHTML=`
-      <div class="dt-kpi accent"><span class="label">Equity rachunku</span><span class="value">${fmt(stats.equity,'USD')}</span><span class="sub">Cash ${fmt(stats.freeCash,'USD')} + Open MV ${fmt(stats.marketValueOpen,'USD')}</span></div>
+      <div class="dt-kpi accent"><span class="label">Equity rachunku</span><span class="value">${fmt(stats.equity,'USD')}</span><span class="sub">Wallet ${fmt(stats.walletBalance,'USD')} | Unrealized ${fmt(stats.unrealized,'USD')}</span></div>
       <div class="dt-kpi"><span class="label">Wpłaty / wypłaty</span><span class="value">${fmt(stats.deposits,'USD')}</span><span class="sub">Wypłaty: ${fmt(-stats.withdrawals,'USD')} | Net: ${fmt(stats.netFlows,'USD')}</span></div>
       <div class="dt-kpi ${stats.roi>=0?'positive':'negative'}"><span class="label">ROI łącznie</span><span class="value">${stats.roi.toFixed(2)}%</span><span class="sub">Liczone od net flow rachunku</span></div>
       <div class="dt-kpi ${stats.realized>=0?'positive':'negative'}"><span class="label">PnL zrealizowany</span><span class="value">${fmt(stats.realized,'USD')}</span><span class="sub">Po uwzględnieniu prowizji</span></div>
@@ -11080,7 +11089,7 @@
       <div class="dt-kpi ${stats.todayPnl>=0?'positive':'negative'} ${dailyHit?'alert':''}"><span class="label">Dzisiaj PnL</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">${stats.todayPct.toFixed(2)}% względem net flow</span></div>
       <div class="dt-kpi ${stats.weeklyPnl>=0?'positive':'negative'} ${weeklyHit?'alert':''}"><span class="label">Tydzień PnL</span><span class="value">${fmt(stats.weeklyPnl,'USD')}</span><span class="sub">Limit: ${weeklyLimit>0?fmt(-weeklyLimit,'USD'):'nie ustawiono'}</span></div>
       <div class="dt-kpi"><span class="label">Win rate</span><span class="value">${stats.winRate.toFixed(1)}%</span><span class="sub">W: ${stats.win} | L: ${stats.loss} | Open: ${stats.openPositions.length}</span></div>
-      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Dostępne do handlu</span><span class="value">${fmt(stats.freeCash,'USD')}</span><span class="sub">${stats.canTrade?'Gotowe do wejścia':'Najpierw zasil konto'}</span></div>
+      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Dostępne do handlu</span><span class="value">${fmt(stats.freeCash,'USD')}</span><span class="sub">Zablokowany margin: ${fmt(stats.lockedMargin,'USD')}</span></div>
     `;
   }
 
@@ -11090,14 +11099,15 @@
     if(!form||!preview) return;
     const f=new FormData(form);
     const m=dtComputePlanMetrics({
-      side:f.get('side'), entry:f.get('entry'), sl:f.get('sl'), tp:f.get('tp'), sizeQty:f.get('sizeQty')
+      side:f.get('side'), entry:f.get('entry'), sl:f.get('sl'), tp:f.get('tp'), sizeQty:f.get('sizeQty'), leverage:f.get('leverage')
     });
     if(!m.isValid){preview.textContent='Wypełnij formularz, aby zobaczyć planowaną stratę, zysk i RR.';return;}
-    preview.innerHTML=`Plan: ilość <b>${m.qty.toFixed(6)}</b> | Nominał: <b>${fmt(m.notionalUsd,'USD')}</b> | Ryzyko SL: <span class="neg">${fmt(-m.riskUsd,'USD')}</span> | Potencjał TP: <span class="pos">${fmt(m.rewardUsd,'USD')}</span> | RR: <b>${m.rr?m.rr.toFixed(2):'—'}</b>`;
+    preview.innerHTML=`Plan: ilość <b>${m.qty.toFixed(6)}</b> | Nominał: <b>${fmt(m.notionalUsd,'USD')}</b> | Leverage: <b>x${m.leverage.toFixed(0)}</b> | Margin: <b>${fmt(m.marginRequired,'USD')}</b> | Ryzyko SL: <span class="neg">${fmt(-m.riskUsd,'USD')}</span> | Potencjał TP: <span class="pos">${fmt(m.rewardUsd,'USD')}</span> | RR: <b>${m.rr?m.rr.toFixed(2):'—'}</b>`;
   }
 
   function dtRecordClose(position, qty, closePrice, fee, closeDate){
     const dir=position.side==='short'?-1:1;
+    const lev=Math.max(1,num(position.leverage)||1);
     const gross=(closePrice-num(position.entry))*qty*dir;
     const riskPerUnit=(num(position.entry)-num(position.sl))*dir;
     const riskAbs=Math.max(0,riskPerUnit*qty);
@@ -11106,7 +11116,7 @@
     dayTrading().closes.unshift({
       id:'dt_close_'+Math.random().toString(36).slice(2),
       positionId:position.id,ticker:position.ticker,side:position.side,date:closeDate,
-      qty,closePrice,fee,grossPnl:gross,netPnl:net,rr,partial:(qty<(num(position.initialQty)-num(position.closedQty||0)-0.0000001))
+      qty,closePrice,fee,grossPnl:gross,netPnl:net,rr,releasedMargin:(num(position.entry)*qty)/lev,partial:(qty<(num(position.initialQty)-num(position.closedQty||0)-0.0000001))
     });
     position.closedQty=(num(position.closedQty)||0)+qty;
     position.realizedPnl=(num(position.realizedPnl)||0)+net;
@@ -11126,7 +11136,7 @@
     if(summary){
       summary.innerHTML=stats.deposits<=0
         ?'Brak zasileń rachunku — dodaj pierwszą wpłatę, aby otwierać pozycje.'
-        :`Net flow: <b>${fmt(stats.netFlows,'USD')}</b> | Dostępne cash: <b>${fmt(stats.freeCash,'USD')}</b> | Equity: <b>${fmt(stats.equity,'USD')}</b>`;
+        :`Net flow: <b>${fmt(stats.netFlows,'USD')}</b> | Dostępne cash: <b>${fmt(stats.freeCash,'USD')}</b> | Locked margin: <b>${fmt(stats.lockedMargin,'USD')}</b> | Equity: <b>${fmt(stats.equity,'USD')}</b>`;
     }
     for(const flow of (dt.capitalFlows||[])){
       const tr=document.createElement('tr');
@@ -11191,10 +11201,12 @@
       const remainingQty=num(p.initialQty)-num(p.closedQty||0);
       const mark=num(p.markPrice)||num(p.entry);
       const dir=p.side==='short'?-1:1;
+      const lev=Math.max(1,num(p.leverage)||1);
       const unrl=(mark-num(p.entry))*remainingQty*dir;
       const risk=Math.max(0,(num(p.entry)-num(p.sl))*dir*remainingQty);
       const reward=Math.max(0,(num(p.tp)-num(p.entry))*dir*remainingQty);
       const rr=risk>0?reward/risk:null;
+      const margin=(remainingQty*num(p.entry))/lev;
       const tr=document.createElement('tr');
       tr.innerHTML=`
         <td><strong>${escapeHtml(p.ticker)}</strong><div class="tiny muted">${p.openDate||''}</div></td>
@@ -11202,7 +11214,8 @@
         <td>${num(p.entry).toFixed(4)}</td>
         <td><input class="dt-inline-input" data-k="mark" value="${mark}" /></td>
         <td>${remainingQty.toFixed(6)}</td>
-        <td>${fmt(remainingQty*num(p.entry),'USD')}</td>
+        <td>x${lev.toFixed(0)}</td>
+        <td>${fmt(margin,'USD')}</td>
         <td class="${unrl>=0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(unrl,'USD')}</td>
         <td>${rr?rr.toFixed(2):'—'}</td>
         <td class="row" style="gap:6px"><button class="btn soft" data-act="partial">Zamknij / partial TP</button></td>
@@ -11291,6 +11304,7 @@
           side:String(f.get('side')||'long'),
           date:String(f.get('date')||new Date().toISOString().slice(0,10)),
           sizeQty:Math.abs(num(f.get('sizeQty'))),
+          leverage:Math.max(1,num(f.get('leverage'))||1),
           entry:Math.abs(num(f.get('entry'))),
           sl:Math.abs(num(f.get('sl'))),
           tp:Math.abs(num(f.get('tp'))),
@@ -11300,11 +11314,11 @@
         const m=dtComputePlanMetrics(payload);
         const wallet=dtComputeStats();
         if(wallet.deposits<=0){alert('Najpierw dodaj pierwszą wpłatę w sekcji „Rachunek tradingowy”.');return;}
-        if(m.notionalUsd>wallet.freeCash+0.0001){alert(`Za mało dostępnego cash. Potrzebujesz ${fmt(m.notionalUsd,'USD')}, masz ${fmt(wallet.freeCash,'USD')}.`);return;}
+        if(m.marginRequired>wallet.freeCash+0.0001){alert(`Za mało dostępnego marginu. Potrzebujesz ${fmt(m.marginRequired,'USD')} (x${m.leverage.toFixed(0)}), masz ${fmt(wallet.freeCash,'USD')}.`);return;}
         dt.positions.unshift({
           id:'dt_pos_'+Math.random().toString(36).slice(2),ticker:payload.ticker,side:payload.side,openDate:payload.date,sizeQty:payload.sizeQty,
-          entry:payload.entry,sl:payload.sl,tp:payload.tp,note:payload.note,status:'open',
-          initialQty:m.qty,closedQty:0,realizedPnl:0,markPrice:payload.entry,plannedRisk:m.riskUsd,plannedReward:m.rewardUsd,plannedRr:m.rr,notionalUsd:m.notionalUsd
+          entry:payload.entry,sl:payload.sl,tp:payload.tp,note:payload.note,status:'open',leverage:payload.leverage,
+          initialQty:m.qty,closedQty:0,realizedPnl:0,markPrice:payload.entry,plannedRisk:m.riskUsd,plannedReward:m.rewardUsd,plannedRr:m.rr,notionalUsd:m.notionalUsd,marginRequired:m.marginRequired
         });
         save(state);form.reset();
         if(dateInput) dateInput.value=new Date().toISOString().slice(0,10);

--- a/budget.html
+++ b/budget.html
@@ -5070,17 +5070,17 @@
 
             <div class="card stack">
               <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
-                <strong>Zarządzanie kapitałem konta</strong>
-                <span class="tiny muted">Saldo startowe + wpłaty/wypłaty</span>
+                <strong>Rachunek tradingowy</strong>
+                <span class="tiny muted">Najpierw zasil konto, potem otwieraj pozycje</span>
               </div>
               <form id="dt-capital-form" class="dt-form-grid">
-                <label>Saldo początkowe (USD)<input name="startingBalance" inputmode="decimal" placeholder="0.00" /></label>
                 <label>Data<input name="date" type="date" required /></label>
                 <label>Typ przepływu<select name="flowType"><option value="deposit">Wpłata</option><option value="withdrawal">Wypłata</option></select></label>
                 <label>Kwota (USD)<input name="amountUsd" inputmode="decimal" placeholder="0.00" required /></label>
                 <label>Notatka<input name="note" placeholder="np. dopłata kapitału / wypłata zysku" /></label>
                 <button class="btn soft" type="submit">Dodaj przepływ</button>
               </form>
+              <div class="dt-preview" id="dt-capital-summary">Brak zasileń rachunku — dodaj pierwszą wpłatę, aby otwierać pozycje.</div>
               <div class="table-wrapper">
                 <table class="dt-table">
                   <thead><tr><th>Data</th><th>Typ</th><th>Kwota</th><th>Notatka</th><th></th></tr></thead>
@@ -6288,7 +6288,7 @@
     // NEW: fixed expense templates
     if(!Array.isArray(bud.fixedTemplates)) bud.fixedTemplates=[];
     if(!bud.investments) bud.investments={assets:[], trades:[], groups:[]};
-    if(!bud.dayTrading) bud.dayTrading={positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}, startingBalance:0, capitalFlows:[]};
+    if(!bud.dayTrading) bud.dayTrading={positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}, capitalFlows:[]};
     if(!Array.isArray(bud.investments.assets)) bud.investments.assets=[];
     if(!Array.isArray(bud.investments.trades)) bud.investments.trades=[];
     if(!Array.isArray(bud.investments.groups)) bud.investments.groups=[];
@@ -6298,7 +6298,6 @@
     if(!bud.dayTrading.limits || typeof bud.dayTrading.limits!=='object') bud.dayTrading.limits={dailyLoss:0,weeklyLoss:0};
     if(!Number.isFinite(Number(bud.dayTrading.limits.dailyLoss))) bud.dayTrading.limits.dailyLoss=0;
     if(!Number.isFinite(Number(bud.dayTrading.limits.weeklyLoss))) bud.dayTrading.limits.weeklyLoss=0;
-    if(!Number.isFinite(Number(bud.dayTrading.startingBalance))) bud.dayTrading.startingBalance=0;
     if(!Array.isArray(bud.eomInvestmentBridge)) bud.eomInvestmentBridge=[];
     for(const t of bud.investments.trades){
       if(!t.side) t.side='buy';
@@ -6335,7 +6334,7 @@
         recurringTemplates:[],recurringLog:[],
         fixedTemplates:[],
         investments:{assets:[], trades:[], groups:[]},
-        dayTrading:{positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}, startingBalance:0, capitalFlows:[]},
+        dayTrading:{positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}, capitalFlows:[]},
         eomInvestmentBridge:[]
       }}
     });
@@ -10989,7 +10988,7 @@
 
   // --- Day Trading (crypto) -------------------------------------------------
   const dayTrading=()=>{
-    if(!b().dayTrading) b().dayTrading={positions:[],closes:[],limits:{dailyLoss:0,weeklyLoss:0},startingBalance:0,capitalFlows:[]};
+    if(!b().dayTrading) b().dayTrading={positions:[],closes:[],limits:{dailyLoss:0,weeklyLoss:0},capitalFlows:[]};
     const dt=b().dayTrading;
     if(!Array.isArray(dt.positions)) dt.positions=[];
     if(!Array.isArray(dt.closes)) dt.closes=[];
@@ -10997,7 +10996,6 @@
     if(!dt.limits) dt.limits={dailyLoss:0,weeklyLoss:0};
     dt.limits.dailyLoss=num(dt.limits.dailyLoss)||0;
     dt.limits.weeklyLoss=num(dt.limits.weeklyLoss)||0;
-    dt.startingBalance=num(dt.startingBalance)||0;
     return dt;
   };
 
@@ -11026,14 +11024,17 @@
     const dt=dayTrading();
     const today=new Date().toISOString().slice(0,10);
     const weekStart=dtWeekStart(today);
-    let activeNotional=0, unrealized=0, realized=0, todayPnl=0, weeklyPnl=0;
+    let activeNotional=0, openedCostTotal=0, unrealized=0, realized=0, todayPnl=0, weeklyPnl=0;
     let win=0,loss=0;
-    const flows=(dt.capitalFlows||[]).reduce((sum,f)=>sum+(f.type==='withdrawal'?-Math.abs(num(f.amountUsd)):Math.abs(num(f.amountUsd))),0);
+    const deposits=(dt.capitalFlows||[]).reduce((sum,f)=>sum+(f.type==='deposit'?Math.abs(num(f.amountUsd)):0),0);
+    const withdrawals=(dt.capitalFlows||[]).reduce((sum,f)=>sum+(f.type==='withdrawal'?Math.abs(num(f.amountUsd)):0),0);
+    const netFlows=deposits-withdrawals;
     const openPositions=[];
     for(const p of dt.positions){
       const initQty=num(p.initialQty)||0;
       const closedQty=num(p.closedQty)||0;
       const remainingQty=Math.max(0,initQty-closedQty);
+      openedCostTotal+=initQty*num(p.entry);
       if((p.status||'open')==='open' && remainingQty>0.0000001){
         openPositions.push({...p,remainingQty});
         const mark=num(p.markPrice)||num(p.entry);
@@ -11051,11 +11052,14 @@
       if(cDate>=weekStart && cDate<=today) weeklyPnl+=net;
     }
     const total=win+loss;
-    const equity=dt.startingBalance+flows+realized+unrealized;
-    const baseForRoi=Math.max(1,dt.startingBalance+flows);
-    const roi=((equity-baseForRoi)/baseForRoi)*100;
-    const todayPct=baseForRoi>0?(todayPnl/baseForRoi)*100:0;
-    return {activeNotional,unrealized,realized,todayPnl,weeklyPnl,todayPct,roi,win,loss,winRate:total?((win/total)*100):0,openPositions,startingBalance:dt.startingBalance,flows,equity};
+    const cashFromClosed=(dt.closes||[]).reduce((sum,c)=>sum+((num(c.closePrice)*num(c.qty))-Math.abs(num(c.fee))),0);
+    const freeCash=netFlows-openedCostTotal+cashFromClosed;
+    const marketValueOpen=openPositions.reduce((sum,p)=>sum+((num(p.markPrice)||num(p.entry))*num(p.remainingQty)),0);
+    const equity=freeCash+marketValueOpen;
+    const baseForRoi=Math.max(1,Math.abs(netFlows));
+    const roi=((equity-netFlows)/baseForRoi)*100;
+    const todayPct=netFlows!==0?(todayPnl/Math.abs(netFlows))*100:0;
+    return {activeNotional,unrealized,realized,todayPnl,weeklyPnl,todayPct,roi,win,loss,winRate:total?((win/total)*100):0,openPositions,deposits,withdrawals,netFlows,freeCash,marketValueOpen,equity,canTrade:deposits>0&&freeCash>0};
   }
 
   function renderDayTradingDashboard(){
@@ -11068,14 +11072,15 @@
     const dailyHit=dailyLimit>0 && stats.todayPnl<=-dailyLimit;
     const weeklyHit=weeklyLimit>0 && stats.weeklyPnl<=-weeklyLimit;
     dash.innerHTML=`
-      <div class="dt-kpi accent"><span class="label">Saldo konta (equity)</span><span class="value">${fmt(stats.equity,'USD')}</span><span class="sub">Start ${fmt(stats.startingBalance,'USD')} | przepływy ${fmt(stats.flows,'USD')}</span></div>
-      <div class="dt-kpi ${stats.roi>=0?'positive':'negative'}"><span class="label">ROI łącznie</span><span class="value">${stats.roi.toFixed(2)}%</span><span class="sub">Na bazie salda + wpłat/wypłat</span></div>
+      <div class="dt-kpi accent"><span class="label">Equity rachunku</span><span class="value">${fmt(stats.equity,'USD')}</span><span class="sub">Cash ${fmt(stats.freeCash,'USD')} + Open MV ${fmt(stats.marketValueOpen,'USD')}</span></div>
+      <div class="dt-kpi"><span class="label">Wpłaty / wypłaty</span><span class="value">${fmt(stats.deposits,'USD')}</span><span class="sub">Wypłaty: ${fmt(-stats.withdrawals,'USD')} | Net: ${fmt(stats.netFlows,'USD')}</span></div>
+      <div class="dt-kpi ${stats.roi>=0?'positive':'negative'}"><span class="label">ROI łącznie</span><span class="value">${stats.roi.toFixed(2)}%</span><span class="sub">Liczone od net flow rachunku</span></div>
       <div class="dt-kpi ${stats.realized>=0?'positive':'negative'}"><span class="label">PnL zrealizowany</span><span class="value">${fmt(stats.realized,'USD')}</span><span class="sub">Po uwzględnieniu prowizji</span></div>
       <div class="dt-kpi ${stats.unrealized>=0?'positive':'negative'}"><span class="label">PnL niezrealizowany</span><span class="value">${fmt(stats.unrealized,'USD')}</span><span class="sub">Na otwartych pozycjach</span></div>
-      <div class="dt-kpi ${stats.todayPnl>=0?'positive':'negative'} ${dailyHit?'alert':''}"><span class="label">Dzisiaj PnL</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">${stats.todayPct.toFixed(2)}% kapitału aktywnego</span></div>
+      <div class="dt-kpi ${stats.todayPnl>=0?'positive':'negative'} ${dailyHit?'alert':''}"><span class="label">Dzisiaj PnL</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">${stats.todayPct.toFixed(2)}% względem net flow</span></div>
       <div class="dt-kpi ${stats.weeklyPnl>=0?'positive':'negative'} ${weeklyHit?'alert':''}"><span class="label">Tydzień PnL</span><span class="value">${fmt(stats.weeklyPnl,'USD')}</span><span class="sub">Limit: ${weeklyLimit>0?fmt(-weeklyLimit,'USD'):'nie ustawiono'}</span></div>
       <div class="dt-kpi"><span class="label">Win rate</span><span class="value">${stats.winRate.toFixed(1)}%</span><span class="sub">W: ${stats.win} | L: ${stats.loss} | Open: ${stats.openPositions.length}</span></div>
-      <div class="dt-kpi"><span class="label">Ekspozycja aktywna</span><span class="value">${fmt(stats.activeNotional,'USD')}</span><span class="sub">Nominał otwartych pozycji</span></div>
+      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Dostępne do handlu</span><span class="value">${fmt(stats.freeCash,'USD')}</span><span class="sub">${stats.canTrade?'Gotowe do wejścia':'Najpierw zasil konto'}</span></div>
     `;
   }
 
@@ -11114,8 +11119,15 @@
   function renderDayTradingCapitalFlows(){
     const dt=dayTrading();
     const tbody=document.getElementById('dt-capital-rows');
+    const summary=document.getElementById('dt-capital-summary');
     if(!tbody) return;
     tbody.innerHTML='';
+    const stats=dtComputeStats();
+    if(summary){
+      summary.innerHTML=stats.deposits<=0
+        ?'Brak zasileń rachunku — dodaj pierwszą wpłatę, aby otwierać pozycje.'
+        :`Net flow: <b>${fmt(stats.netFlows,'USD')}</b> | Dostępne cash: <b>${fmt(stats.freeCash,'USD')}</b> | Equity: <b>${fmt(stats.equity,'USD')}</b>`;
+    }
     for(const flow of (dt.capitalFlows||[])){
       const tr=document.createElement('tr');
       const sign=flow.type==='withdrawal'?-1:1;
@@ -11238,19 +11250,23 @@
     const capitalForm=document.getElementById('dt-capital-form');
     if(capitalForm&&!capitalForm._bound){
       capitalForm._bound=true;
-      const startInput=capitalForm.querySelector('input[name="startingBalance"]');
       const flowDate=capitalForm.querySelector('input[name="date"]');
       if(flowDate&&!flowDate.value) flowDate.value=new Date().toISOString().slice(0,10);
-      if(startInput) startInput.addEventListener('change',()=>{dt.startingBalance=Math.abs(num(startInput.value));save(state);renderInvestments();});
       capitalForm.onsubmit=e=>{
         e.preventDefault();
         const f=new FormData(capitalForm);
         const amount=Math.abs(num(f.get('amountUsd')));
         if(amount<=0){alert('Kwota przepływu musi być > 0.');return;}
+        const flowType=String(f.get('flowType')||'deposit');
+        const wallet=dtComputeStats();
+        if(flowType==='withdrawal' && amount>wallet.freeCash+0.0001){
+          alert(`Nie możesz wypłacić więcej niż wolny cash (${fmt(wallet.freeCash,'USD')}).`);
+          return;
+        }
         dt.capitalFlows.unshift({
           id:'dt_flow_'+Math.random().toString(36).slice(2),
           date:String(f.get('date')||new Date().toISOString().slice(0,10)),
-          type:String(f.get('flowType')||'deposit'),
+          type:flowType,
           amountUsd:amount,
           note:String(f.get('note')||'').trim()
         });
@@ -11260,8 +11276,6 @@
         renderInvestments();
       };
     }
-    const startInput=capitalForm?.querySelector('input[name="startingBalance"]');
-    if(startInput) startInput.value=dt.startingBalance?String(dt.startingBalance).replace('.',','):'';
 
     const form=document.getElementById('dt-plan-form');
     if(form&&!form._bound){
@@ -11284,6 +11298,9 @@
         };
         if(!payload.ticker||payload.sizeQty<=0||payload.entry<=0||payload.sl<=0||payload.tp<=0){alert('Uzupełnij poprawnie ticker, position size, entry, SL i TP.');return;}
         const m=dtComputePlanMetrics(payload);
+        const wallet=dtComputeStats();
+        if(wallet.deposits<=0){alert('Najpierw dodaj pierwszą wpłatę w sekcji „Rachunek tradingowy”.');return;}
+        if(m.notionalUsd>wallet.freeCash+0.0001){alert(`Za mało dostępnego cash. Potrzebujesz ${fmt(m.notionalUsd,'USD')}, masz ${fmt(wallet.freeCash,'USD')}.`);return;}
         dt.positions.unshift({
           id:'dt_pos_'+Math.random().toString(36).slice(2),ticker:payload.ticker,side:payload.side,openDate:payload.date,sizeQty:payload.sizeQty,
           entry:payload.entry,sl:payload.sl,tp:payload.tp,note:payload.note,status:'open',

--- a/budget.html
+++ b/budget.html
@@ -123,6 +123,17 @@
     .inv-mode-btn.is-active { background:#fff; color:var(--ink); box-shadow:0 8px 20px rgba(15,23,42,.12); }
 
     .dt-grid { display:grid; gap:14px; }
+    .dt-hero { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:10px; }
+    .dt-hero .dt-kpi { min-height:96px; }
+    .dt-limit-wrap { background:var(--surface); border:1px solid rgba(148,163,184,.2); border-radius:12px; padding:10px 12px; }
+    .dt-limit-head { display:flex; justify-content:space-between; align-items:center; font-size:11px; color:var(--muted); margin-bottom:6px; }
+    .dt-limit-track { height:10px; border-radius:999px; background:rgba(148,163,184,.2); overflow:hidden; }
+    .dt-limit-fill { height:100%; width:0%; background:#2563eb; transition:width .25s ease, background-color .25s ease; }
+    .dt-limit-meta { margin-top:6px; font-size:11px; color:var(--muted); }
+    .dt-active-cockpit { display:grid; grid-template-columns:2fr 1fr; gap:20px; align-items:start; }
+    .dt-cockpit-open { order:1; }
+    .dt-cockpit-plan { order:2; }
+    @media(max-width:1120px){ .dt-hero{grid-template-columns:repeat(2,minmax(0,1fr));} .dt-active-cockpit{grid-template-columns:1fr;} }
     .dt-layout { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; }
     .dt-span-2 { grid-column:1 / -1; }
     @media(max-width:980px){ .dt-layout{grid-template-columns:1fr;} .dt-span-2{grid-column:auto;} }
@@ -5084,10 +5095,18 @@
           </div>
 
           <div id="inv-daytrade-panel" class="dt-grid" style="display:none">
-            <div class="dt-dashboard" id="dt-dashboard"></div>
+            <div class="dt-dashboard dt-hero" id="dt-dashboard"></div>
+            <div class="dt-limit-wrap">
+              <div class="dt-limit-head">
+                <strong>Daily Limit Monitor</strong>
+                <span id="dt-limit-label">—</span>
+              </div>
+              <div class="dt-limit-track"><div class="dt-limit-fill" id="dt-limit-fill"></div></div>
+              <div class="dt-limit-meta" id="dt-limit-meta">Skonfiguruj limity dzienne w panelu sterowania.</div>
+            </div>
             <div class="dt-layout">
 
-            <div class="card stack">
+            <div class="card stack dt-cockpit-plan">
               <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
                 <strong>Rachunek tradingowy</strong>
                 <span class="tiny muted">Najpierw zasil konto, potem otwieraj pozycje</span>
@@ -5108,7 +5127,8 @@
               </div>
             </div>
 
-            <div class="card stack">
+            <div class="dt-active-cockpit dt-span-2">
+            <div class="card stack dt-cockpit-open">
               <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
                 <strong>Plan pozycji i zarządzanie ryzykiem</strong>
                 <span class="tiny muted">SL/TP, RR i kontrola pozycji w czasie rzeczywistym</span>
@@ -5128,7 +5148,7 @@
               <div class="dt-preview" id="dt-plan-preview">Wypełnij formularz, aby zobaczyć planowaną stratę, zysk i RR.</div>
             </div>
 
-            <div class="card stack dt-span-2">
+            <div class="card stack">
               <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
                 <strong>Otwarte pozycje</strong>
                 <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
@@ -5143,6 +5163,7 @@
                 </table>
               </div>
               <div class="dt-muted-empty" id="dt-open-empty" style="display:none">Brak otwartych pozycji.</div>
+            </div>
             </div>
 
             <div class="card stack dt-span-2">
@@ -11162,22 +11183,28 @@
     const stats=dtComputeStats();
     const dash=document.getElementById('dt-dashboard');
     if(!dash) return;
-    const dailyLossPct=Math.abs(num(dt.limits.maxDailyLossPct)||0);
-    const weeklyLossPct=Math.abs(num(dt.limits.maxWeeklyLossPct)||0);
     const dailyTargetPct=Math.abs(num(dt.limits.targetDailyProfitPct)||0);
-    const weeklyTargetPct=Math.abs(num(dt.limits.targetWeeklyProfitPct)||0);
+    const dailyLossPct=Math.abs(num(dt.limits.maxDailyLossPct)||0);
     const dailyHit=dailyLossPct>0 && stats.todayPct<=-dailyLossPct;
-    const weeklyHit=weeklyLossPct>0 && stats.weeklyPct<=-weeklyLossPct;
-    const dailyTargetHit=dailyTargetPct>0 && stats.todayPct>=dailyTargetPct;
-    const weeklyTargetHit=weeklyTargetPct>0 && stats.weeklyPct>=weeklyTargetPct;
-    const todayCloses=(dt.closes||[]).filter(c=>String(c.date||'')===new Date().toISOString().slice(0,10));
-    const todayFees=todayCloses.reduce((s,c)=>s+Math.abs(num(c.fee)),0);
-    const avgTodayRr=todayCloses.length?todayCloses.reduce((s,c)=>s+(num(c.rr)||0),0)/todayCloses.length:0;
+    const nearLoss=dailyLossPct>0 && stats.todayPct<=-(dailyLossPct*0.8);
+    const limitFill=document.getElementById('dt-limit-fill');
+    const limitLabel=document.getElementById('dt-limit-label');
+    const limitMeta=document.getElementById('dt-limit-meta');
+    const minPct=dailyLossPct>0?-dailyLossPct:Math.min(-5,stats.todayPct,0);
+    const maxPct=dailyTargetPct>0?dailyTargetPct:Math.max(5,stats.todayPct,0);
+    const ratio=maxPct===minPct?50:((stats.todayPct-minPct)/(maxPct-minPct))*100;
+    const clamped=Math.max(0,Math.min(100,ratio));
+    if(limitFill){
+      limitFill.style.width=`${clamped}%`;
+      limitFill.style.background=(dailyHit||nearLoss)?'#dc2626':(stats.todayPct>=dailyTargetPct&&dailyTargetPct>0?'#16a34a':'#2563eb');
+    }
+    if(limitLabel) limitLabel.textContent=`Today ${stats.todayPct.toFixed(2)}%`;
+    if(limitMeta) limitMeta.textContent=`Zakres: ${minPct.toFixed(2)}% → ${maxPct.toFixed(2)}% | Max loss ${dailyLossPct||0}% | Target ${dailyTargetPct||0}%`;
     dash.innerHTML=`
-      <div class="dt-kpi accent"><span class="label">Dzisiaj: PnL netto</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">${stats.todayPct.toFixed(2)}% kapitału</span></div>
-      <div class="dt-kpi ${stats.todayPnl>=0?'positive':'negative'} ${dailyHit?'alert':''}"><span class="label">Dzisiejsze zamknięcia</span><span class="value">${todayCloses.length}</span><span class="sub">Śr. RR: ${todayCloses.length?avgTodayRr.toFixed(2):'—'}</span></div>
-      <div class="dt-kpi ${(dailyTargetHit||weeklyTargetHit)?'positive':(dailyHit||weeklyHit)?'negative':''} ${dailyHit||weeklyHit?'alert':''}"><span class="label">Rekomendacje % (D/T)</span><span class="value">${stats.todayPct.toFixed(2)}% / ${stats.weeklyPct.toFixed(2)}%</span><span class="sub">Max loss: ${dailyLossPct||0}% / ${weeklyLossPct||0}% • Cel: ${dailyTargetPct||0}% / ${weeklyTargetPct||0}%</span></div>
-      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Dostępny margin</span><span class="value">${fmt(stats.freeCash,'USD')}</span><span class="sub">Prowizje dziś: ${fmt(-todayFees,'USD')} | Equity: ${fmt(stats.equity,'USD')}</span></div>
+      <div class="dt-kpi accent ${stats.todayPnl>=0?'positive':'negative'}"><span class="label">PnL (Dziś)</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">${stats.todayPct.toFixed(2)}% kapitału</span></div>
+      <div class="dt-kpi"><span class="label">Win Rate</span><span class="value">${stats.winRate.toFixed(1)}%</span><span class="sub">W: ${stats.win} | L: ${stats.loss}</span></div>
+      <div class="dt-kpi ${Number.isFinite(stats.profitFactor)&&stats.profitFactor>=1?'positive':'negative'}"><span class="label">Profit Factor</span><span class="value">${Number.isFinite(stats.profitFactor)?(stats.profitFactor===Infinity?'∞':stats.profitFactor.toFixed(2)):'—'}</span><span class="sub">Expectancy: ${fmt(stats.expectancy,'USD')}</span></div>
+      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Dostępny Margin</span><span class="value">${fmt(stats.freeCash,'USD')}</span><span class="sub">DD: ${fmt(-stats.currentDrawdown,'USD')} | Fees: ${fmt(-stats.totalFees,'USD')}</span></div>
     `;
   }
 

--- a/budget.html
+++ b/budget.html
@@ -151,6 +151,12 @@
     .dt-inline-input.qty { width:75px; }
     .dt-chart-box { height:260px; position:relative; }
     .dt-muted-empty { text-align:center; color:var(--muted); font-size:12px; padding:18px 0; }
+    .dt-close-modal-backdrop { position:fixed; inset:0; background:rgba(15,23,42,.4); backdrop-filter:blur(2px); z-index:70; display:none; }
+    .dt-close-modal { position:fixed; inset:0; margin:auto; width:min(560px,94vw); height:max-content; background:var(--surface); border-radius:18px; border:1px solid rgba(148,163,184,.2); box-shadow:0 20px 55px rgba(15,23,42,.22); padding:16px; z-index:75; display:none; }
+    .dt-close-modal[open], .dt-close-modal-backdrop[open] { display:block; }
+    .dt-close-pcts { display:flex; gap:6px; flex-wrap:wrap; }
+    .dt-close-pct { border:none; border-radius:7px; padding:6px 10px; font-size:11px; font-weight:700; color:var(--muted); background:rgba(148,163,184,.12); cursor:pointer; }
+    .dt-close-pct:hover { background:rgba(37,99,235,.12); color:#1d4ed8; }
 
     .inv-trade-tabs { display:inline-flex; gap:0; border-radius:10px; overflow:hidden; border:1px solid rgba(148,163,184,.3); }
     .inv-trade-tab { border:none; background:transparent; padding:8px 20px; font-weight:600; font-size:13px; cursor:pointer; color:var(--muted); transition:all .2s; }
@@ -5064,6 +5070,27 @@
 
             <div class="card stack">
               <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
+                <strong>Zarządzanie kapitałem konta</strong>
+                <span class="tiny muted">Saldo startowe + wpłaty/wypłaty</span>
+              </div>
+              <form id="dt-capital-form" class="dt-form-grid">
+                <label>Saldo początkowe (USD)<input name="startingBalance" inputmode="decimal" placeholder="0.00" /></label>
+                <label>Data<input name="date" type="date" required /></label>
+                <label>Typ przepływu<select name="flowType"><option value="deposit">Wpłata</option><option value="withdrawal">Wypłata</option></select></label>
+                <label>Kwota (USD)<input name="amountUsd" inputmode="decimal" placeholder="0.00" required /></label>
+                <label>Notatka<input name="note" placeholder="np. dopłata kapitału / wypłata zysku" /></label>
+                <button class="btn soft" type="submit">Dodaj przepływ</button>
+              </form>
+              <div class="table-wrapper">
+                <table class="dt-table">
+                  <thead><tr><th>Data</th><th>Typ</th><th>Kwota</th><th>Notatka</th><th></th></tr></thead>
+                  <tbody id="dt-capital-rows"></tbody>
+                </table>
+              </div>
+            </div>
+
+            <div class="card stack">
+              <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
                 <strong>Plan pozycji i zarządzanie ryzykiem</strong>
                 <span class="tiny muted">SL/TP, RR i kontrola pozycji w czasie rzeczywistym</span>
               </div>
@@ -5071,7 +5098,7 @@
                 <label>Ticker<input name="ticker" placeholder="np. BTC, ETH, SOL" required /></label>
                 <label>Strona<select name="side"><option value="long">Long</option><option value="short">Short</option></select></label>
                 <label>Data<input name="date" type="date" required /></label>
-                <label>Kapitał pozycji (USD)<input name="sizeUsd" inputmode="decimal" placeholder="0.00" required /></label>
+                <label>Position size (krypto)<input name="sizeQty" inputmode="decimal" placeholder="np. 0.02" required /></label>
                 <label>Entry<input name="entry" inputmode="decimal" placeholder="0.00" required /></label>
                 <label>SL<input name="sl" inputmode="decimal" placeholder="0.00" required /></label>
                 <label>TP planowany<input name="tp" inputmode="decimal" placeholder="0.00" required /></label>
@@ -5088,7 +5115,7 @@
               </div>
               <div class="table-wrapper">
                 <table class="dt-table">
-                  <thead><tr><th>Ticker</th><th>Strona</th><th>Entry</th><th>Akt. cena</th><th>Pozostało</th><th>Niezreal. PnL</th><th>Plan RR</th><th>Partial close qty</th><th>Cena close</th><th>Fee (USD)</th><th></th></tr></thead>
+                  <thead><tr><th>Ticker</th><th>Strona</th><th>Entry</th><th>Akt. cena</th><th>Pozostało</th><th>Nominał (USD)</th><th>Niezreal. PnL</th><th>Plan RR</th><th></th></tr></thead>
                   <tbody id="dt-open-rows"></tbody>
                 </table>
               </div>
@@ -5111,6 +5138,32 @@
                 </table>
               </div>
             </div>
+          </div>
+          <div id="dt-close-modal-backdrop" class="dt-close-modal-backdrop"></div>
+          <div id="dt-close-modal" class="dt-close-modal">
+            <div class="row" style="justify-content:space-between;align-items:center;margin-bottom:10px">
+              <strong>Zamykanie pozycji</strong>
+              <button type="button" class="btn ghost" id="dt-close-cancel-top">✕</button>
+            </div>
+            <form id="dt-close-form" class="dt-form-grid">
+              <label>Pozycja<input name="ticker" readonly /></label>
+              <label>Dostępna ilość<input name="maxQty" readonly /></label>
+              <label>Ilość do zamknięcia<input name="closeQty" inputmode="decimal" required /></label>
+              <label>Cena zamknięcia<input name="closePrice" inputmode="decimal" required /></label>
+              <label>Prowizja (USD)<input name="fee" inputmode="decimal" value="0" /></label>
+              <label>Data<input name="date" type="date" required /></label>
+              <div class="dt-close-pcts" style="grid-column:1/-1">
+                <button class="dt-close-pct" type="button" data-pct="25">25%</button>
+                <button class="dt-close-pct" type="button" data-pct="50">50%</button>
+                <button class="dt-close-pct" type="button" data-pct="75">75%</button>
+                <button class="dt-close-pct" type="button" data-pct="100">100%</button>
+              </div>
+              <div class="dt-preview" id="dt-close-preview" style="grid-column:1/-1">Wybierz ilość i cenę zamknięcia.</div>
+              <div class="row" style="gap:8px;grid-column:1/-1;justify-content:flex-end">
+                <button type="button" class="btn ghost" id="dt-close-cancel">Anuluj</button>
+                <button type="submit" class="btn">Zamknij pozycję</button>
+              </div>
+            </form>
           </div>
 
           <div id="inv-longterm-panel">
@@ -6235,15 +6288,17 @@
     // NEW: fixed expense templates
     if(!Array.isArray(bud.fixedTemplates)) bud.fixedTemplates=[];
     if(!bud.investments) bud.investments={assets:[], trades:[], groups:[]};
-    if(!bud.dayTrading) bud.dayTrading={positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}};
+    if(!bud.dayTrading) bud.dayTrading={positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}, startingBalance:0, capitalFlows:[]};
     if(!Array.isArray(bud.investments.assets)) bud.investments.assets=[];
     if(!Array.isArray(bud.investments.trades)) bud.investments.trades=[];
     if(!Array.isArray(bud.investments.groups)) bud.investments.groups=[];
     if(!Array.isArray(bud.dayTrading.positions)) bud.dayTrading.positions=[];
     if(!Array.isArray(bud.dayTrading.closes)) bud.dayTrading.closes=[];
+    if(!Array.isArray(bud.dayTrading.capitalFlows)) bud.dayTrading.capitalFlows=[];
     if(!bud.dayTrading.limits || typeof bud.dayTrading.limits!=='object') bud.dayTrading.limits={dailyLoss:0,weeklyLoss:0};
     if(!Number.isFinite(Number(bud.dayTrading.limits.dailyLoss))) bud.dayTrading.limits.dailyLoss=0;
     if(!Number.isFinite(Number(bud.dayTrading.limits.weeklyLoss))) bud.dayTrading.limits.weeklyLoss=0;
+    if(!Number.isFinite(Number(bud.dayTrading.startingBalance))) bud.dayTrading.startingBalance=0;
     if(!Array.isArray(bud.eomInvestmentBridge)) bud.eomInvestmentBridge=[];
     for(const t of bud.investments.trades){
       if(!t.side) t.side='buy';
@@ -6280,7 +6335,7 @@
         recurringTemplates:[],recurringLog:[],
         fixedTemplates:[],
         investments:{assets:[], trades:[], groups:[]},
-        dayTrading:{positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}},
+        dayTrading:{positions:[], closes:[], limits:{dailyLoss:0,weeklyLoss:0}, startingBalance:0, capitalFlows:[]},
         eomInvestmentBridge:[]
       }}
     });
@@ -7550,6 +7605,7 @@
   let invHoldingsSort={key:'value',dir:'desc'};
   const invCollapsedGroups=new Set();
   let dtEquityChart=null;
+  let dtCloseTargetId=null;
 
   const investments=()=>{
     if(!b().investments) b().investments={assets:[],trades:[],groups:[]};
@@ -10933,28 +10989,30 @@
 
   // --- Day Trading (crypto) -------------------------------------------------
   const dayTrading=()=>{
-    if(!b().dayTrading) b().dayTrading={positions:[],closes:[],limits:{dailyLoss:0,weeklyLoss:0}};
+    if(!b().dayTrading) b().dayTrading={positions:[],closes:[],limits:{dailyLoss:0,weeklyLoss:0},startingBalance:0,capitalFlows:[]};
     const dt=b().dayTrading;
     if(!Array.isArray(dt.positions)) dt.positions=[];
     if(!Array.isArray(dt.closes)) dt.closes=[];
+    if(!Array.isArray(dt.capitalFlows)) dt.capitalFlows=[];
     if(!dt.limits) dt.limits={dailyLoss:0,weeklyLoss:0};
     dt.limits.dailyLoss=num(dt.limits.dailyLoss)||0;
     dt.limits.weeklyLoss=num(dt.limits.weeklyLoss)||0;
+    dt.startingBalance=num(dt.startingBalance)||0;
     return dt;
   };
 
   function dtComputePlanMetrics(payload){
-    const entry=num(payload.entry), sl=num(payload.sl), tp=num(payload.tp), sizeUsd=Math.abs(num(payload.sizeUsd));
+    const entry=num(payload.entry), sl=num(payload.sl), tp=num(payload.tp), sizeQty=Math.abs(num(payload.sizeQty));
     const side=(payload.side||'long')==='short'?'short':'long';
-    if(entry<=0||sizeUsd<=0) return {isValid:false};
-    const qty=sizeUsd/entry;
+    if(entry<=0||sizeQty<=0) return {isValid:false};
+    const qty=sizeQty;
     const dir=side==='short'?-1:1;
     const riskPerUnit=(entry-sl)*dir;
     const rewardPerUnit=(tp-entry)*dir;
     const riskUsd=Math.max(0,riskPerUnit*qty);
     const rewardUsd=Math.max(0,rewardPerUnit*qty);
     const rr=riskUsd>0?rewardUsd/riskUsd:null;
-    return {isValid:true,qty,dir,riskUsd,rewardUsd,rr};
+    return {isValid:true,qty,dir,riskUsd,rewardUsd,rr,notionalUsd:qty*entry};
   }
 
   function dtWeekStart(dateStr){
@@ -10968,8 +11026,9 @@
     const dt=dayTrading();
     const today=new Date().toISOString().slice(0,10);
     const weekStart=dtWeekStart(today);
-    let capital=0, realized=0, todayPnl=0, weeklyPnl=0;
+    let activeNotional=0, unrealized=0, realized=0, todayPnl=0, weeklyPnl=0;
     let win=0,loss=0;
+    const flows=(dt.capitalFlows||[]).reduce((sum,f)=>sum+(f.type==='withdrawal'?-Math.abs(num(f.amountUsd)):Math.abs(num(f.amountUsd))),0);
     const openPositions=[];
     for(const p of dt.positions){
       const initQty=num(p.initialQty)||0;
@@ -10977,7 +11036,10 @@
       const remainingQty=Math.max(0,initQty-closedQty);
       if((p.status||'open')==='open' && remainingQty>0.0000001){
         openPositions.push({...p,remainingQty});
-        capital+=num(p.sizeUsd)||0;
+        const mark=num(p.markPrice)||num(p.entry);
+        const dir=p.side==='short'?-1:1;
+        activeNotional+=remainingQty*num(p.entry);
+        unrealized+=(mark-num(p.entry))*remainingQty*dir;
       }
     }
     for(const c of dt.closes){
@@ -10989,9 +11051,11 @@
       if(cDate>=weekStart && cDate<=today) weeklyPnl+=net;
     }
     const total=win+loss;
-    const roi=capital>0?(realized/capital)*100:0;
-    const todayPct=capital>0?(todayPnl/capital)*100:0;
-    return {capital,realized,todayPnl,weeklyPnl,todayPct,roi,win,loss,winRate:total?((win/total)*100):0,openPositions};
+    const equity=dt.startingBalance+flows+realized+unrealized;
+    const baseForRoi=Math.max(1,dt.startingBalance+flows);
+    const roi=((equity-baseForRoi)/baseForRoi)*100;
+    const todayPct=baseForRoi>0?(todayPnl/baseForRoi)*100:0;
+    return {activeNotional,unrealized,realized,todayPnl,weeklyPnl,todayPct,roi,win,loss,winRate:total?((win/total)*100):0,openPositions,startingBalance:dt.startingBalance,flows,equity};
   }
 
   function renderDayTradingDashboard(){
@@ -11004,12 +11068,14 @@
     const dailyHit=dailyLimit>0 && stats.todayPnl<=-dailyLimit;
     const weeklyHit=weeklyLimit>0 && stats.weeklyPnl<=-weeklyLimit;
     dash.innerHTML=`
-      <div class="dt-kpi accent"><span class="label">Kapitał aktywny USD</span><span class="value">${fmt(stats.capital,'USD')}</span><span class="sub">${stats.openPositions.length} otwartych pozycji</span></div>
-      <div class="dt-kpi ${stats.roi>=0?'positive':'negative'}"><span class="label">ROI łącznie</span><span class="value">${stats.capital>0?stats.roi.toFixed(2)+'%':'—'}</span><span class="sub">Netto z zamkniętych pozycji</span></div>
+      <div class="dt-kpi accent"><span class="label">Saldo konta (equity)</span><span class="value">${fmt(stats.equity,'USD')}</span><span class="sub">Start ${fmt(stats.startingBalance,'USD')} | przepływy ${fmt(stats.flows,'USD')}</span></div>
+      <div class="dt-kpi ${stats.roi>=0?'positive':'negative'}"><span class="label">ROI łącznie</span><span class="value">${stats.roi.toFixed(2)}%</span><span class="sub">Na bazie salda + wpłat/wypłat</span></div>
       <div class="dt-kpi ${stats.realized>=0?'positive':'negative'}"><span class="label">PnL zrealizowany</span><span class="value">${fmt(stats.realized,'USD')}</span><span class="sub">Po uwzględnieniu prowizji</span></div>
+      <div class="dt-kpi ${stats.unrealized>=0?'positive':'negative'}"><span class="label">PnL niezrealizowany</span><span class="value">${fmt(stats.unrealized,'USD')}</span><span class="sub">Na otwartych pozycjach</span></div>
       <div class="dt-kpi ${stats.todayPnl>=0?'positive':'negative'} ${dailyHit?'alert':''}"><span class="label">Dzisiaj PnL</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">${stats.todayPct.toFixed(2)}% kapitału aktywnego</span></div>
       <div class="dt-kpi ${stats.weeklyPnl>=0?'positive':'negative'} ${weeklyHit?'alert':''}"><span class="label">Tydzień PnL</span><span class="value">${fmt(stats.weeklyPnl,'USD')}</span><span class="sub">Limit: ${weeklyLimit>0?fmt(-weeklyLimit,'USD'):'nie ustawiono'}</span></div>
-      <div class="dt-kpi"><span class="label">Win rate</span><span class="value">${stats.winRate.toFixed(1)}%</span><span class="sub">W: ${stats.win} | L: ${stats.loss}</span></div>
+      <div class="dt-kpi"><span class="label">Win rate</span><span class="value">${stats.winRate.toFixed(1)}%</span><span class="sub">W: ${stats.win} | L: ${stats.loss} | Open: ${stats.openPositions.length}</span></div>
+      <div class="dt-kpi"><span class="label">Ekspozycja aktywna</span><span class="value">${fmt(stats.activeNotional,'USD')}</span><span class="sub">Nominał otwartych pozycji</span></div>
     `;
   }
 
@@ -11019,10 +11085,10 @@
     if(!form||!preview) return;
     const f=new FormData(form);
     const m=dtComputePlanMetrics({
-      side:f.get('side'), entry:f.get('entry'), sl:f.get('sl'), tp:f.get('tp'), sizeUsd:f.get('sizeUsd')
+      side:f.get('side'), entry:f.get('entry'), sl:f.get('sl'), tp:f.get('tp'), sizeQty:f.get('sizeQty')
     });
     if(!m.isValid){preview.textContent='Wypełnij formularz, aby zobaczyć planowaną stratę, zysk i RR.';return;}
-    preview.innerHTML=`Plan: ilość <b>${m.qty.toFixed(6)}</b> | Ryzyko SL: <span class="neg">${fmt(-m.riskUsd,'USD')}</span> | Potencjał TP: <span class="pos">${fmt(m.rewardUsd,'USD')}</span> | RR: <b>${m.rr?m.rr.toFixed(2):'—'}</b>`;
+    preview.innerHTML=`Plan: ilość <b>${m.qty.toFixed(6)}</b> | Nominał: <b>${fmt(m.notionalUsd,'USD')}</b> | Ryzyko SL: <span class="neg">${fmt(-m.riskUsd,'USD')}</span> | Potencjał TP: <span class="pos">${fmt(m.rewardUsd,'USD')}</span> | RR: <b>${m.rr?m.rr.toFixed(2):'—'}</b>`;
   }
 
   function dtRecordClose(position, qty, closePrice, fee, closeDate){
@@ -11043,6 +11109,62 @@
       position.status='closed';
       position.closedDate=closeDate;
     }
+  }
+
+  function renderDayTradingCapitalFlows(){
+    const dt=dayTrading();
+    const tbody=document.getElementById('dt-capital-rows');
+    if(!tbody) return;
+    tbody.innerHTML='';
+    for(const flow of (dt.capitalFlows||[])){
+      const tr=document.createElement('tr');
+      const sign=flow.type==='withdrawal'?-1:1;
+      tr.innerHTML=`<td>${flow.date||''}</td><td>${flow.type==='withdrawal'?'Wypłata':'Wpłata'}</td><td class="${sign>0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(sign*Math.abs(num(flow.amountUsd)),'USD')}</td><td>${escapeHtml(flow.note||'')}</td><td><button class="btn ghost" style="font-size:10px;padding:2px 7px" data-del="${flow.id}">Usuń</button></td>`;
+      tr.querySelector('[data-del]').onclick=()=>{dt.capitalFlows=dt.capitalFlows.filter(f=>f.id!==flow.id);save(state);renderInvestments();};
+      tbody.appendChild(tr);
+    }
+  }
+
+  function openDtCloseModal(position, defaultPrice){
+    dtCloseTargetId=position.id;
+    const modal=document.getElementById('dt-close-modal');
+    const backdrop=document.getElementById('dt-close-modal-backdrop');
+    const form=document.getElementById('dt-close-form');
+    if(!modal||!backdrop||!form) return;
+    const remain=Math.max(0,num(position.initialQty)-num(position.closedQty||0));
+    form.ticker.value=`${position.ticker} (${String(position.side||'long').toUpperCase()})`;
+    form.maxQty.value=remain.toFixed(6);
+    form.closeQty.value=remain.toFixed(6);
+    form.closePrice.value=(num(defaultPrice)||num(position.entry)||0).toString();
+    form.fee.value='0';
+    form.date.value=new Date().toISOString().slice(0,10);
+    backdrop.setAttribute('open','');
+    modal.setAttribute('open','');
+    renderDtClosePreview();
+  }
+
+  function closeDtCloseModal(){
+    dtCloseTargetId=null;
+    document.getElementById('dt-close-modal')?.removeAttribute('open');
+    document.getElementById('dt-close-modal-backdrop')?.removeAttribute('open');
+  }
+
+  function renderDtClosePreview(){
+    const form=document.getElementById('dt-close-form');
+    const out=document.getElementById('dt-close-preview');
+    if(!form||!out||!dtCloseTargetId) return;
+    const pos=dayTrading().positions.find(p=>p.id===dtCloseTargetId);
+    if(!pos){out.textContent='Pozycja nie istnieje.';return;}
+    const qty=Math.abs(num(form.closeQty.value));
+    const closePrice=Math.abs(num(form.closePrice.value));
+    const fee=Math.abs(num(form.fee.value));
+    if(qty<=0||closePrice<=0){out.textContent='Podaj ilość i cenę zamknięcia.';return;}
+    const dir=pos.side==='short'?-1:1;
+    const gross=(closePrice-num(pos.entry))*qty*dir;
+    const risk=Math.max(0,(num(pos.entry)-num(pos.sl))*dir*qty);
+    const net=gross-fee;
+    const rr=risk>0?net/risk:null;
+    out.innerHTML=`Podgląd: PnL brutto <span class="${gross>=0?'pos':'neg'}">${fmt(gross,'USD')}</span> | Fee ${fmt(-fee,'USD')} | PnL netto <span class="${net>=0?'pos':'neg'}">${fmt(net,'USD')}</span> | RR: <b>${rr!=null?rr.toFixed(2):'—'}</b>`;
   }
 
   function renderDayTradingOpenPositions(){
@@ -11068,22 +11190,14 @@
         <td>${num(p.entry).toFixed(4)}</td>
         <td><input class="dt-inline-input" data-k="mark" value="${mark}" /></td>
         <td>${remainingQty.toFixed(6)}</td>
+        <td>${fmt(remainingQty*num(p.entry),'USD')}</td>
         <td class="${unrl>=0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(unrl,'USD')}</td>
         <td>${rr?rr.toFixed(2):'—'}</td>
-        <td><input class="dt-inline-input qty" data-k="closeQty" value="${remainingQty.toFixed(6)}" /></td>
-        <td><input class="dt-inline-input" data-k="closePrice" value="${mark}" /></td>
-        <td><input class="dt-inline-input" data-k="fee" value="0" /></td>
-        <td class="row" style="gap:6px"><button class="btn soft" data-act="partial">Zamknij</button></td>
+        <td class="row" style="gap:6px"><button class="btn soft" data-act="partial">Zamknij / partial TP</button></td>
       `;
       tr.querySelector('[data-k="mark"]').onchange=e=>{p.markPrice=num(e.target.value)||num(p.entry);save(state);renderInvestments();};
       tr.querySelector('[data-act="partial"]').onclick=()=>{
-        const qty=Math.abs(num(tr.querySelector('[data-k="closeQty"]').value));
-        const closePrice=Math.abs(num(tr.querySelector('[data-k="closePrice"]').value));
-        const fee=Math.abs(num(tr.querySelector('[data-k="fee"]').value));
-        if(qty<=0||closePrice<=0){alert('Podaj poprawną ilość i cenę zamknięcia.');return;}
-        if(qty>remainingQty+0.0000001){alert(`Maksymalna ilość do zamknięcia: ${remainingQty.toFixed(6)}`);return;}
-        dtRecordClose(p,qty,closePrice,fee,new Date().toISOString().slice(0,10));
-        save(state); renderInvestments();
+        openDtCloseModal(p,mark);
       };
       tbody.appendChild(tr);
     }
@@ -11121,6 +11235,34 @@
 
   function bindDayTrading(){
     const dt=dayTrading();
+    const capitalForm=document.getElementById('dt-capital-form');
+    if(capitalForm&&!capitalForm._bound){
+      capitalForm._bound=true;
+      const startInput=capitalForm.querySelector('input[name="startingBalance"]');
+      const flowDate=capitalForm.querySelector('input[name="date"]');
+      if(flowDate&&!flowDate.value) flowDate.value=new Date().toISOString().slice(0,10);
+      if(startInput) startInput.addEventListener('change',()=>{dt.startingBalance=Math.abs(num(startInput.value));save(state);renderInvestments();});
+      capitalForm.onsubmit=e=>{
+        e.preventDefault();
+        const f=new FormData(capitalForm);
+        const amount=Math.abs(num(f.get('amountUsd')));
+        if(amount<=0){alert('Kwota przepływu musi być > 0.');return;}
+        dt.capitalFlows.unshift({
+          id:'dt_flow_'+Math.random().toString(36).slice(2),
+          date:String(f.get('date')||new Date().toISOString().slice(0,10)),
+          type:String(f.get('flowType')||'deposit'),
+          amountUsd:amount,
+          note:String(f.get('note')||'').trim()
+        });
+        save(state);
+        capitalForm.reset();
+        if(flowDate) flowDate.value=new Date().toISOString().slice(0,10);
+        renderInvestments();
+      };
+    }
+    const startInput=capitalForm?.querySelector('input[name="startingBalance"]');
+    if(startInput) startInput.value=dt.startingBalance?String(dt.startingBalance).replace('.',','):'';
+
     const form=document.getElementById('dt-plan-form');
     if(form&&!form._bound){
       form._bound=true;
@@ -11134,18 +11276,18 @@
           ticker:String(f.get('ticker')||'').trim().toUpperCase(),
           side:String(f.get('side')||'long'),
           date:String(f.get('date')||new Date().toISOString().slice(0,10)),
-          sizeUsd:Math.abs(num(f.get('sizeUsd'))),
+          sizeQty:Math.abs(num(f.get('sizeQty'))),
           entry:Math.abs(num(f.get('entry'))),
           sl:Math.abs(num(f.get('sl'))),
           tp:Math.abs(num(f.get('tp'))),
           note:String(f.get('note')||'').trim()
         };
-        if(!payload.ticker||payload.sizeUsd<=0||payload.entry<=0||payload.sl<=0||payload.tp<=0){alert('Uzupełnij poprawnie ticker, kapitał, entry, SL i TP.');return;}
+        if(!payload.ticker||payload.sizeQty<=0||payload.entry<=0||payload.sl<=0||payload.tp<=0){alert('Uzupełnij poprawnie ticker, position size, entry, SL i TP.');return;}
         const m=dtComputePlanMetrics(payload);
         dt.positions.unshift({
-          id:'dt_pos_'+Math.random().toString(36).slice(2),ticker:payload.ticker,side:payload.side,openDate:payload.date,sizeUsd:payload.sizeUsd,
+          id:'dt_pos_'+Math.random().toString(36).slice(2),ticker:payload.ticker,side:payload.side,openDate:payload.date,sizeQty:payload.sizeQty,
           entry:payload.entry,sl:payload.sl,tp:payload.tp,note:payload.note,status:'open',
-          initialQty:m.qty,closedQty:0,realizedPnl:0,markPrice:payload.entry,plannedRisk:m.riskUsd,plannedReward:m.rewardUsd,plannedRr:m.rr
+          initialQty:m.qty,closedQty:0,realizedPnl:0,markPrice:payload.entry,plannedRisk:m.riskUsd,plannedReward:m.rewardUsd,plannedRr:m.rr,notionalUsd:m.notionalUsd
         });
         save(state);form.reset();
         if(dateInput) dateInput.value=new Date().toISOString().slice(0,10);
@@ -11164,6 +11306,41 @@
     }
     if(dailyInput) dailyInput.value=dt.limits.dailyLoss?String(dt.limits.dailyLoss).replace('.',','):'';
     if(weeklyInput) weeklyInput.value=dt.limits.weeklyLoss?String(dt.limits.weeklyLoss).replace('.',','):'';
+
+    const closeForm=document.getElementById('dt-close-form');
+    if(closeForm && !closeForm._bound){
+      closeForm._bound=true;
+      closeForm.addEventListener('input',renderDtClosePreview);
+      closeForm.onsubmit=e=>{
+        e.preventDefault();
+        if(!dtCloseTargetId) return;
+        const pos=dt.positions.find(p=>p.id===dtCloseTargetId);
+        if(!pos) return;
+        const qty=Math.abs(num(closeForm.closeQty.value));
+        const closePrice=Math.abs(num(closeForm.closePrice.value));
+        const fee=Math.abs(num(closeForm.fee.value));
+        const maxQty=Math.max(0,num(pos.initialQty)-num(pos.closedQty||0));
+        if(qty<=0||closePrice<=0){alert('Podaj poprawną ilość i cenę zamknięcia.');return;}
+        if(qty>maxQty+0.0000001){alert(`Maksymalna ilość do zamknięcia: ${maxQty.toFixed(6)}`);return;}
+        dtRecordClose(pos,qty,closePrice,fee,closeForm.date.value||new Date().toISOString().slice(0,10));
+        save(state);
+        closeDtCloseModal();
+        renderInvestments();
+      };
+      closeForm.querySelectorAll('[data-pct]').forEach(btn=>{
+        btn.onclick=()=>{
+          const pct=num(btn.dataset.pct)/100;
+          const maxQty=num(closeForm.maxQty.value);
+          closeForm.closeQty.value=(maxQty*pct).toFixed(6);
+          renderDtClosePreview();
+        };
+      });
+      document.getElementById('dt-close-cancel')?.addEventListener('click',closeDtCloseModal);
+      document.getElementById('dt-close-cancel-top')?.addEventListener('click',closeDtCloseModal);
+      document.getElementById('dt-close-modal-backdrop')?.addEventListener('click',closeDtCloseModal);
+    }
+
+    renderDayTradingCapitalFlows();
     renderDtPlanPreview();
   }
 

--- a/budget.html
+++ b/budget.html
@@ -5116,7 +5116,10 @@
             <div class="card stack dt-span-2">
               <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
                 <strong>Otwarte pozycje</strong>
-                <span class="tiny muted">Partial TP / zamykanie pozycji / prowizje</span>
+                <div class="row" style="gap:8px;align-items:center;flex-wrap:wrap">
+                  <span class="tiny muted">Partial TP / zamykanie pozycji / prowizje</span>
+                  <button type="button" class="btn ghost" id="dt-clear-open" style="font-size:11px">Usuń wszystkie otwarte</button>
+                </div>
               </div>
               <div class="table-wrapper">
                 <table class="dt-table">
@@ -5133,12 +5136,13 @@
                 <div class="row" style="gap:10px;align-items:end;flex-wrap:wrap">
                   <label class="tiny muted" style="display:flex;flex-direction:column;gap:4px">Max strata dzienna (USD)<input id="dt-max-daily-loss" inputmode="decimal" class="dt-inline-input" /></label>
                   <label class="tiny muted" style="display:flex;flex-direction:column;gap:4px">Max strata tygodniowa (USD)<input id="dt-max-weekly-loss" inputmode="decimal" class="dt-inline-input" /></label>
+                  <button type="button" class="btn ghost" id="dt-clear-closed" style="font-size:11px">Usuń historię zamkniętych</button>
                 </div>
               </div>
               <div class="dt-chart-box"><canvas id="dt-equity-chart"></canvas></div>
               <div class="table-wrapper">
                 <table class="dt-table">
-                  <thead><tr><th>Data</th><th>Ticker</th><th>Strona</th><th>Zamknięta ilość</th><th>PnL brutto</th><th>Prowizje</th><th>PnL netto</th><th>RR (real)</th><th>Typ</th></tr></thead>
+                  <thead><tr><th>Data</th><th>Ticker</th><th>Strona</th><th>Zamknięta ilość</th><th>PnL brutto</th><th>Prowizje</th><th>PnL netto</th><th>RR (real)</th><th>Typ</th><th></th></tr></thead>
                   <tbody id="dt-close-log"></tbody>
                 </table>
               </div>
@@ -11080,16 +11084,13 @@
     const weeklyLimit=Math.abs(num(dt.limits.weeklyLoss)||0);
     const dailyHit=dailyLimit>0 && stats.todayPnl<=-dailyLimit;
     const weeklyHit=weeklyLimit>0 && stats.weeklyPnl<=-weeklyLimit;
+    const totalPnl=stats.equity-stats.netFlows;
     dash.innerHTML=`
-      <div class="dt-kpi accent"><span class="label">Equity rachunku</span><span class="value">${fmt(stats.equity,'USD')}</span><span class="sub">Wallet ${fmt(stats.walletBalance,'USD')} | Unrealized ${fmt(stats.unrealized,'USD')}</span></div>
-      <div class="dt-kpi"><span class="label">Wpłaty / wypłaty</span><span class="value">${fmt(stats.deposits,'USD')}</span><span class="sub">Wypłaty: ${fmt(-stats.withdrawals,'USD')} | Net: ${fmt(stats.netFlows,'USD')}</span></div>
-      <div class="dt-kpi ${stats.roi>=0?'positive':'negative'}"><span class="label">ROI łącznie</span><span class="value">${stats.roi.toFixed(2)}%</span><span class="sub">Liczone od net flow rachunku</span></div>
-      <div class="dt-kpi ${stats.realized>=0?'positive':'negative'}"><span class="label">PnL zrealizowany</span><span class="value">${fmt(stats.realized,'USD')}</span><span class="sub">Po uwzględnieniu prowizji</span></div>
-      <div class="dt-kpi ${stats.unrealized>=0?'positive':'negative'}"><span class="label">PnL niezrealizowany</span><span class="value">${fmt(stats.unrealized,'USD')}</span><span class="sub">Na otwartych pozycjach</span></div>
-      <div class="dt-kpi ${stats.todayPnl>=0?'positive':'negative'} ${dailyHit?'alert':''}"><span class="label">Dzisiaj PnL</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">${stats.todayPct.toFixed(2)}% względem net flow</span></div>
-      <div class="dt-kpi ${stats.weeklyPnl>=0?'positive':'negative'} ${weeklyHit?'alert':''}"><span class="label">Tydzień PnL</span><span class="value">${fmt(stats.weeklyPnl,'USD')}</span><span class="sub">Limit: ${weeklyLimit>0?fmt(-weeklyLimit,'USD'):'nie ustawiono'}</span></div>
-      <div class="dt-kpi"><span class="label">Win rate</span><span class="value">${stats.winRate.toFixed(1)}%</span><span class="sub">W: ${stats.win} | L: ${stats.loss} | Open: ${stats.openPositions.length}</span></div>
-      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Dostępne do handlu</span><span class="value">${fmt(stats.freeCash,'USD')}</span><span class="sub">Zablokowany margin: ${fmt(stats.lockedMargin,'USD')}</span></div>
+      <div class="dt-kpi accent"><span class="label">Equity rachunku</span><span class="value">${fmt(stats.equity,'USD')}</span><span class="sub">Baza: ${fmt(stats.netFlows,'USD')} | P/L: ${fmt(totalPnl,'USD')}</span></div>
+      <div class="dt-kpi ${stats.roi>=0?'positive':'negative'}"><span class="label">ROI całkowity</span><span class="value">${stats.roi.toFixed(2)}%</span><span class="sub">Realized: ${fmt(stats.realized,'USD')} | Unrealized: ${fmt(stats.unrealized,'USD')}</span></div>
+      <div class="dt-kpi ${(stats.todayPnl+stats.weeklyPnl)>=0?'positive':'negative'} ${(dailyHit||weeklyHit)?'alert':''}"><span class="label">PnL dzisiaj / tydzień</span><span class="value">${fmt(stats.todayPnl,'USD')} / ${fmt(stats.weeklyPnl,'USD')}</span><span class="sub">Limity: D ${dailyLimit?fmt(-dailyLimit,'USD'):'—'} | T ${weeklyLimit?fmt(-weeklyLimit,'USD'):'—'}</span></div>
+      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Wallet / Free cash</span><span class="value">${fmt(stats.walletBalance,'USD')} / ${fmt(stats.freeCash,'USD')}</span><span class="sub">Locked margin: ${fmt(stats.lockedMargin,'USD')} | Open: ${stats.openPositions.length}</span></div>
+      <div class="dt-kpi"><span class="label">Win rate</span><span class="value">${stats.winRate.toFixed(1)}%</span><span class="sub">W: ${stats.win} | L: ${stats.loss} | Wpłaty: ${fmt(stats.deposits,'USD')}</span></div>
     `;
   }
 
@@ -11218,11 +11219,15 @@
         <td>${fmt(margin,'USD')}</td>
         <td class="${unrl>=0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(unrl,'USD')}</td>
         <td>${rr?rr.toFixed(2):'—'}</td>
-        <td class="row" style="gap:6px"><button class="btn soft" data-act="partial">Zamknij / partial TP</button></td>
+        <td class="row" style="gap:6px"><button class="btn soft" data-act="partial">Zamknij / partial TP</button><button class="btn ghost" data-act="delete" style="font-size:10px;padding:2px 7px">Usuń</button></td>
       `;
       tr.querySelector('[data-k="mark"]').onchange=e=>{p.markPrice=num(e.target.value)||num(p.entry);save(state);renderInvestments();};
       tr.querySelector('[data-act="partial"]').onclick=()=>{
         openDtCloseModal(p,mark);
+      };
+      tr.querySelector('[data-act="delete"]').onclick=()=>{
+        dayTrading().positions=dayTrading().positions.filter(x=>x.id!==p.id);
+        save(state);renderInvestments();
       };
       tbody.appendChild(tr);
     }
@@ -11235,7 +11240,8 @@
     tbody.innerHTML='';
     for(const c of closes.slice(0,120)){
       const tr=document.createElement('tr');
-      tr.innerHTML=`<td>${c.date||''}</td><td>${escapeHtml(c.ticker||'')}</td><td>${(c.side||'').toUpperCase()}</td><td>${num(c.qty).toFixed(6)}</td><td class="${num(c.grossPnl)>=0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(num(c.grossPnl),'USD')}</td><td>${fmt(num(c.fee),'USD')}</td><td class="${num(c.netPnl)>=0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(num(c.netPnl),'USD')}</td><td>${c.rr!=null?Number(c.rr).toFixed(2):'—'}</td><td>${c.partial?'Partial':'Full'}</td>`;
+      tr.innerHTML=`<td>${c.date||''}</td><td>${escapeHtml(c.ticker||'')}</td><td>${(c.side||'').toUpperCase()}</td><td>${num(c.qty).toFixed(6)}</td><td class="${num(c.grossPnl)>=0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(num(c.grossPnl),'USD')}</td><td>${fmt(num(c.fee),'USD')}</td><td class="${num(c.netPnl)>=0?'inv-pnl-pos':'inv-pnl-neg'}">${fmt(num(c.netPnl),'USD')}</td><td>${c.rr!=null?Number(c.rr).toFixed(2):'—'}</td><td>${c.partial?'Partial':'Full'}</td><td><button class="btn ghost" style="font-size:10px;padding:2px 7px" data-del="${c.id}">Usuń</button></td>`;
+      tr.querySelector('[data-del]').onclick=()=>{dayTrading().closes=dayTrading().closes.filter(x=>x.id!==c.id);save(state);renderInvestments();};
       tbody.appendChild(tr);
     }
   }
@@ -11337,6 +11343,25 @@
     }
     if(dailyInput) dailyInput.value=dt.limits.dailyLoss?String(dt.limits.dailyLoss).replace('.',','):'';
     if(weeklyInput) weeklyInput.value=dt.limits.weeklyLoss?String(dt.limits.weeklyLoss).replace('.',','):'';
+
+    const clearOpenBtn=document.getElementById('dt-clear-open');
+    if(clearOpenBtn && !clearOpenBtn._bound){
+      clearOpenBtn._bound=true;
+      clearOpenBtn.onclick=()=>{
+        if(!confirm('Usunąć wszystkie otwarte pozycje?')) return;
+        dt.positions=(dt.positions||[]).filter(p=>(p.status||'open')!=='open');
+        save(state);renderInvestments();
+      };
+    }
+    const clearClosedBtn=document.getElementById('dt-clear-closed');
+    if(clearClosedBtn && !clearClosedBtn._bound){
+      clearClosedBtn._bound=true;
+      clearClosedBtn.onclick=()=>{
+        if(!confirm('Usunąć całą historię zamkniętych pozycji?')) return;
+        dt.closes=[];
+        save(state);renderInvestments();
+      };
+    }
 
     const closeForm=document.getElementById('dt-close-form');
     if(closeForm && !closeForm._bound){

--- a/budget.html
+++ b/budget.html
@@ -160,6 +160,21 @@
     .dt-close-pcts { display:flex; gap:6px; flex-wrap:wrap; }
     .dt-close-pct { border:none; border-radius:7px; padding:6px 10px; font-size:11px; font-weight:700; color:var(--muted); background:rgba(148,163,184,.12); cursor:pointer; }
     .dt-close-pct:hover { background:rgba(37,99,235,.12); color:#1d4ed8; }
+    .dt-hub-tabs { display:inline-flex; gap:4px; background:rgba(148,163,184,.12); border-radius:999px; padding:4px; }
+    .dt-hub-tab { border:none; background:transparent; color:var(--muted); font-size:11px; font-weight:700; padding:6px 10px; border-radius:999px; cursor:pointer; }
+    .dt-hub-tab.is-active { background:#fff; color:var(--ink); box-shadow:0 4px 14px rgba(15,23,42,.12); }
+    .dt-hub-grid { display:grid; grid-template-columns:1fr 1fr; gap:14px; }
+    .dt-hub-chart { background:var(--surface); border:1px solid rgba(148,163,184,.2); border-radius:12px; padding:12px; }
+    .dt-hub-chart h4 { margin:0 0 8px; font-size:12px; }
+    .dt-hub-chart .box { height:230px; position:relative; }
+    .dt-cal-grid { display:grid; grid-template-columns:repeat(7,minmax(0,1fr)); gap:4px; }
+    .dt-cal-head { font-size:10px; color:var(--muted); text-align:center; font-weight:700; padding:4px 0; }
+    .dt-cal-day { min-height:44px; border-radius:8px; display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:700; }
+    .dt-cal-empty { background:rgba(148,163,184,.08); color:transparent; }
+    .dt-cal-zero { background:rgba(148,163,184,.12); color:var(--muted); }
+    .dt-cal-pos { background:rgba(34,197,94,.22); color:#166534; }
+    .dt-cal-neg { background:rgba(239,68,68,.2); color:#991b1b; }
+    @media(max-width:980px){ .dt-hub-grid{grid-template-columns:1fr;} }
 
     .inv-trade-tabs { display:inline-flex; gap:0; border-radius:10px; overflow:hidden; border:1px solid rgba(148,163,184,.3); }
     .inv-trade-tab { border:none; background:transparent; padding:8px 20px; font-weight:600; font-size:13px; cursor:pointer; color:var(--muted); transition:all .2s; }
@@ -5147,6 +5162,36 @@
                 </table>
               </div>
             </div>
+
+            <div class="card stack dt-span-2">
+              <div class="row" style="justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">
+                <strong>Hub analityczny day-trading</strong>
+                <div class="dt-hub-tabs">
+                  <button type="button" class="dt-hub-tab is-active" data-dt-hub-mode="daily">Dzienny</button>
+                  <button type="button" class="dt-hub-tab" data-dt-hub-mode="weekly">Tygodniowy</button>
+                  <button type="button" class="dt-hub-tab" data-dt-hub-mode="monthly">Miesięczny</button>
+                </div>
+              </div>
+              <div class="dt-hub-grid">
+                <div class="dt-hub-chart">
+                  <h4>ROI w czasie</h4>
+                  <div class="box"><canvas id="dt-hub-roi-chart"></canvas></div>
+                </div>
+                <div class="dt-hub-chart">
+                  <h4>PnL w czasie</h4>
+                  <div class="box"><canvas id="dt-hub-pnl-chart"></canvas></div>
+                </div>
+              </div>
+              <div class="row" style="justify-content:space-between;align-items:center;margin-top:6px">
+                <h4 style="margin:0;font-size:12px">Kalendarz zamknięć PnL</h4>
+                <div class="row" style="gap:8px;align-items:center">
+                  <button type="button" class="btn ghost" id="dt-cal-prev" style="font-size:11px">‹</button>
+                  <span class="tiny muted" id="dt-cal-label"></span>
+                  <button type="button" class="btn ghost" id="dt-cal-next" style="font-size:11px">›</button>
+                </div>
+              </div>
+              <div id="dt-cal-grid-wrap"></div>
+            </div>
             </div>
           </div>
           <div id="dt-close-modal-backdrop" class="dt-close-modal-backdrop"></div>
@@ -7614,6 +7659,10 @@
   let invHoldingsSort={key:'value',dir:'desc'};
   const invCollapsedGroups=new Set();
   let dtEquityChart=null;
+  let dtHubRoiChart=null;
+  let dtHubPnlChart=null;
+  let dtHubMode='daily';
+  let dtCalMonth=monthKey();
   let dtCloseTargetId=null;
 
   const investments=()=>{
@@ -11081,16 +11130,15 @@
     const dash=document.getElementById('dt-dashboard');
     if(!dash) return;
     const dailyLimit=Math.abs(num(dt.limits.dailyLoss)||0);
-    const weeklyLimit=Math.abs(num(dt.limits.weeklyLoss)||0);
     const dailyHit=dailyLimit>0 && stats.todayPnl<=-dailyLimit;
-    const weeklyHit=weeklyLimit>0 && stats.weeklyPnl<=-weeklyLimit;
-    const totalPnl=stats.equity-stats.netFlows;
+    const todayCloses=(dt.closes||[]).filter(c=>String(c.date||'')===new Date().toISOString().slice(0,10));
+    const todayFees=todayCloses.reduce((s,c)=>s+Math.abs(num(c.fee)),0);
+    const avgTodayRr=todayCloses.length?todayCloses.reduce((s,c)=>s+(num(c.rr)||0),0)/todayCloses.length:0;
     dash.innerHTML=`
-      <div class="dt-kpi accent"><span class="label">Equity rachunku</span><span class="value">${fmt(stats.equity,'USD')}</span><span class="sub">Baza: ${fmt(stats.netFlows,'USD')} | P/L: ${fmt(totalPnl,'USD')}</span></div>
-      <div class="dt-kpi ${stats.roi>=0?'positive':'negative'}"><span class="label">ROI całkowity</span><span class="value">${stats.roi.toFixed(2)}%</span><span class="sub">Realized: ${fmt(stats.realized,'USD')} | Unrealized: ${fmt(stats.unrealized,'USD')}</span></div>
-      <div class="dt-kpi ${(stats.todayPnl+stats.weeklyPnl)>=0?'positive':'negative'} ${(dailyHit||weeklyHit)?'alert':''}"><span class="label">PnL dzisiaj / tydzień</span><span class="value">${fmt(stats.todayPnl,'USD')} / ${fmt(stats.weeklyPnl,'USD')}</span><span class="sub">Limity: D ${dailyLimit?fmt(-dailyLimit,'USD'):'—'} | T ${weeklyLimit?fmt(-weeklyLimit,'USD'):'—'}</span></div>
-      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Wallet / Free cash</span><span class="value">${fmt(stats.walletBalance,'USD')} / ${fmt(stats.freeCash,'USD')}</span><span class="sub">Locked margin: ${fmt(stats.lockedMargin,'USD')} | Open: ${stats.openPositions.length}</span></div>
-      <div class="dt-kpi"><span class="label">Win rate</span><span class="value">${stats.winRate.toFixed(1)}%</span><span class="sub">W: ${stats.win} | L: ${stats.loss} | Wpłaty: ${fmt(stats.deposits,'USD')}</span></div>
+      <div class="dt-kpi accent"><span class="label">Dzisiaj: PnL netto</span><span class="value">${fmt(stats.todayPnl,'USD')}</span><span class="sub">Limit dzienny: ${dailyLimit?fmt(-dailyLimit,'USD'):'—'}</span></div>
+      <div class="dt-kpi ${stats.todayPnl>=0?'positive':'negative'} ${dailyHit?'alert':''}"><span class="label">Dzisiejsze zamknięcia</span><span class="value">${todayCloses.length}</span><span class="sub">Śr. RR: ${todayCloses.length?avgTodayRr.toFixed(2):'—'}</span></div>
+      <div class="dt-kpi"><span class="label">Dzisiaj: prowizje</span><span class="value">${fmt(-todayFees,'USD')}</span><span class="sub">Tydzień PnL: ${fmt(stats.weeklyPnl,'USD')}</span></div>
+      <div class="dt-kpi ${stats.freeCash>=0?'positive':'negative'}"><span class="label">Dostępny margin</span><span class="value">${fmt(stats.freeCash,'USD')}</span><span class="sub">Locked: ${fmt(stats.lockedMargin,'USD')} | Equity: ${fmt(stats.equity,'USD')}</span></div>
     `;
   }
 
@@ -11264,6 +11312,97 @@
     });
   }
 
+  function dtPeriodKey(dateStr,mode){
+    if(mode==='daily') return dateStr;
+    if(mode==='monthly') return String(dateStr||'').slice(0,7);
+    const ws=dtWeekStart(dateStr);
+    return ws;
+  }
+
+  function dtBuildSeries(mode='daily'){
+    const dt=dayTrading();
+    const closes=[...(dt.closes||[])].sort((a,b)=>String(a.date||'').localeCompare(String(b.date||'')));
+    const map={};
+    for(const c of closes){
+      const k=dtPeriodKey(String(c.date||''),mode);
+      if(!k) continue;
+      if(!map[k]) map[k]={pnl:0, fees:0};
+      map[k].pnl+=num(c.netPnl);
+      map[k].fees+=Math.abs(num(c.fee));
+    }
+    const labels=Object.keys(map).sort();
+    let cumulative=0;
+    const base=Math.max(1,Math.abs(dtComputeStats().netFlows));
+    const pnl=labels.map(k=>+map[k].pnl.toFixed(2));
+    const roi=labels.map((k,i)=>{cumulative+=pnl[i]; return +((cumulative/base)*100).toFixed(2);});
+    return {labels,pnl,roi};
+  }
+
+  function renderDtHubCharts(){
+    if(dtHubRoiChart){dtHubRoiChart.destroy();dtHubRoiChart=null;}
+    if(dtHubPnlChart){dtHubPnlChart.destroy();dtHubPnlChart=null;}
+    const roiCanvas=document.getElementById('dt-hub-roi-chart');
+    const pnlCanvas=document.getElementById('dt-hub-pnl-chart');
+    if(!roiCanvas||!pnlCanvas) return;
+    const s=dtBuildSeries(dtHubMode);
+    if(!s.labels.length) return;
+    dtHubRoiChart=new Chart(roiCanvas.getContext('2d'),{
+      type:'line',
+      data:{labels:s.labels,datasets:[{label:'ROI %',data:s.roi,borderColor:'#2563eb',backgroundColor:'rgba(37,99,235,.12)',fill:true,tension:.25,pointRadius:2}]},
+      options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{grid:{display:false}},y:{ticks:{callback:v=>v+'%'}}}}
+    });
+    dtHubPnlChart=new Chart(pnlCanvas.getContext('2d'),{
+      type:'bar',
+      data:{labels:s.labels,datasets:[{label:'PnL',data:s.pnl,backgroundColor:s.pnl.map(v=>v>=0?'rgba(34,197,94,.72)':'rgba(239,68,68,.72)'),borderRadius:4}]},
+      options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{grid:{display:false}},y:{ticks:{callback:v=>currencyTicks(v)}}}}
+    });
+  }
+
+  function renderDtHubCalendar(){
+    const wrap=document.getElementById('dt-cal-grid-wrap');
+    const label=document.getElementById('dt-cal-label');
+    if(!wrap||!label) return;
+    const closes=dayTrading().closes||[];
+    const byDate={};
+    for(const c of closes){
+      const d=String(c.date||'');
+      byDate[d]=(byDate[d]||0)+num(c.netPnl);
+    }
+    const [y,m]=dtCalMonth.split('-').map(Number);
+    if(!y||!m) return;
+    label.textContent=dtCalMonth;
+    const first=new Date(y,m-1,1);
+    const start=(first.getDay()+6)%7;
+    const days=new Date(y,m,0).getDate();
+    const heads=['Pn','Wt','Śr','Cz','Pt','So','Nd'];
+    let html='<div class="dt-cal-grid">';
+    for(const h of heads) html+=`<div class="dt-cal-head">${h}</div>`;
+    for(let i=0;i<start;i++) html+='<div class="dt-cal-day dt-cal-empty">.</div>';
+    for(let d=1;d<=days;d++){
+      const ds=`${dtCalMonth}-${String(d).padStart(2,'0')}`;
+      const val=byDate[ds]||0;
+      const cls=val===0?'dt-cal-zero':val>0?'dt-cal-pos':'dt-cal-neg';
+      html+=`<div class="dt-cal-day ${cls}" title="${ds}: ${fmt(val,'USD')}">${d}<br>${val!==0?Math.round(val):''}</div>`;
+    }
+    html+='</div>';
+    wrap.innerHTML=html;
+  }
+
+  function bindDtHub(){
+    document.querySelectorAll('[data-dt-hub-mode]').forEach(btn=>{
+      if(btn._bound) return; btn._bound=true;
+      btn.onclick=()=>{
+        dtHubMode=btn.dataset.dtHubMode||'daily';
+        document.querySelectorAll('[data-dt-hub-mode]').forEach(x=>x.classList.toggle('is-active',x===btn));
+        renderDtHubCharts();
+      };
+    });
+    const prev=document.getElementById('dt-cal-prev');
+    const next=document.getElementById('dt-cal-next');
+    if(prev&&!prev._bound){prev._bound=true;prev.onclick=()=>{dtCalMonth=ymAdd(dtCalMonth,-1);renderDtHubCalendar();};}
+    if(next&&!next._bound){next._bound=true;next.onclick=()=>{dtCalMonth=ymAdd(dtCalMonth,1);renderDtHubCalendar();};}
+  }
+
   function bindDayTrading(){
     const dt=dayTrading();
     const capitalForm=document.getElementById('dt-capital-form');
@@ -11430,6 +11569,9 @@
       renderDayTradingOpenPositions();
       renderDayTradingCloseLog();
       renderDayTradingChart();
+      bindDtHub();
+      renderDtHubCharts();
+      renderDtHubCalendar();
     }
     if(invInvestMode!=='longterm'){
       bindMoneyInputs(document.getElementById('tab-investments'));


### PR DESCRIPTION
### Motivation
- Provide a compact, distraction-free day-trading dashboard inside the existing Investments module so desktop/local users can plan and manage short-term crypto trades alongside long-term portfolio tracking. 
- Surface the exact KPIs the trader requested (USD capital, ROI, PnL, RR, SL/TP planning, partial closes, fees and discipline limits) in a UI consistent with the `budget.html` investment module.

### Description
- Added a mode switch and two panels in `budget.html`: a new day-trading panel (`#inv-daytrade-panel`) and the existing long-term panel (`#inv-longterm-panel`), plus the toggle UI (`.inv-mode-switch` / `.inv-mode-btn`).
- Introduced styles for the day-trader dashboard (`.dt-*` classes) to match the Investment module look-and-feel and keep the interface clean and professional.
- Persisted day-trading state under `state.modules.budget.dayTrading` and extended migration/`def()` defaults to include `dayTrading` with `positions`, `closes` and `limits` so existing data remains compatible.
- Implemented day-trading logic in JavaScript: `dayTrading()`, `dtComputePlanMetrics()`, `dtComputeStats()`, `renderDayTradingDashboard()`, `renderDtPlanPreview()`, `dtRecordClose()`, `renderDayTradingOpenPositions()`, `renderDayTradingCloseLog()`, `renderDayTradingChart()`, `bindDayTrading()` and `setInvestmentMode()`; integrated these into `renderInvestments()` so switching between modes is safe and self-contained.
- Position flow includes plan form (ticker, side, size USD, entry, SL, TP, note), live RR/risk/reward preview, adding positions, manual mark-price updates for unrealized PnL, partial/full closes with fee handling, close log, and an equity curve chart built from close history.
- Existing long-term flows (asset manager, buy/sell, analytics, snapshots) are left intact and are shown when `Inwestycje long-term` is selected.

### Testing
- Ran `git diff --check` to validate there are no trailing/whitespace errors, and it passed with no issues.
- Ran `git diff --stat` to confirm the change footprint (`budget.html` updated with the new UI and logic) and verified the diff summary.
- Inspected the modified `budget.html` file to ensure new DOM nodes and functions are wired into `renderInvestments()` and that migration/defaults for `dayTrading` were added; no automated runtime tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e091e4a16483319d85461f7cbefda8)