### PR TITLE
Usuń pre-trade checklistę i dodaj sizing z dźwignią w Risk Lab

### DIFF
--- a/trading.html
+++ b/trading.html
@@ -912,7 +912,7 @@
                     <div class="soft-panel">
                       <h3 class="title">Sygnał dyscypliny</h3>
                       <div class="big" id="discipline-score">—</div>
-                      <div class="copy" id="discipline-score-note">Ocena oparta o limity ryzyka, checklistę i zachowanie planu.</div>
+                      <div class="copy" id="discipline-score-note">Ocena oparta o limity ryzyka i zachowanie planu.</div>
                       <div style="margin-top:12px;" id="discipline-badge"></div>
                     </div>
                   </section>
@@ -923,7 +923,7 @@
                     <div class="section-heading">
                       <div>
                         <h2 class="title">Risk lab</h2>
-                        <div class="tiny muted">Planer pozycji na sucho — wylicza size, SL, RR, potencjalny PnL i ryzyko depo.</div>
+                        <div class="tiny muted">Kalkulator pozycji: wpisz entry, SL i dźwignię, aby policzyć size pod % depo w SL.</div>
                       </div>
                       <div class="switch-pill" id="planner-mode-switch" role="group" aria-label="Tryb kalkulatora">
                         <button type="button" class="active" data-planner-mode="size">Wylicz size</button>
@@ -936,7 +936,8 @@
                           <div class="form-group"><label class="form-label">Symbol</label><input id="planner-symbol" class="form-input" placeholder="BTCUSDT"></div>
                           <div class="form-group"><label class="form-label">Kierunek</label><select id="planner-side" class="form-select"><option value="long">Long</option><option value="short">Short</option></select></div>
                           <div class="form-group"><label class="form-label">Kapitał bazowy</label><input id="planner-capital" type="number" step="0.01" class="form-input"></div>
-                          <div class="form-group"><label class="form-label">Ryzyko %</label><input id="planner-risk-pct" type="number" step="0.01" class="form-input"></div>
+                          <div class="form-group"><label class="form-label">% depo w SL</label><input id="planner-risk-pct" type="number" step="0.01" class="form-input"></div>
+                          <div class="form-group"><label class="form-label">Dźwignia (max)</label><input id="planner-leverage" type="number" step="1" class="form-input"></div>
                           <div class="form-group"><label class="form-label">Entry</label><input id="planner-entry" type="number" step="0.0001" class="form-input"></div>
                           <div class="form-group"><label class="form-label">Stop loss</label><input id="planner-stop" type="number" step="0.0001" class="form-input"></div>
                           <div class="form-group"><label class="form-label">Qty</label><input id="planner-qty" type="number" step="0.0001" class="form-input"></div>
@@ -966,10 +967,6 @@
                       <article class="rule-card"><h3 class="title">Daily loss</h3><div class="value" id="rule-daily-loss">—</div><div class="note">Po przekroczeniu — koniec sesji.</div></article>
                       <article class="rule-card"><h3 class="title">Max open risk</h3><div class="value" id="rule-open-risk">—</div><div class="note">Łączny risk na otwartych setupach.</div></article>
                     </div>
-                    <div>
-                      <h3 class="title" style="margin-bottom:10px;">Checklista pre-trade</h3>
-                      <div class="check-grid" id="overview-checklist"></div>
-                    </div>
                     <div class="insight-list" id="overview-insights"></div>
                   </section>
                 </div>
@@ -980,7 +977,7 @@
                   <div class="section-heading">
                     <div>
                       <h2 class="title">Dziennik pozycji</h2>
-                      <div class="tiny muted">Filtruj, edytuj i analizuj każdą pozycję wraz z RR, sizingiem, checklistą i błędami procesu.</div>
+                      <div class="tiny muted">Filtruj, edytuj i analizuj każdą pozycję wraz z RR, sizingiem i błędami procesu.</div>
                     </div>
                     <div class="journal-filter-bar" id="journal-filter-bar"></div>
                   </div>
@@ -1068,7 +1065,7 @@
                     <div class="section-heading">
                       <div>
                         <h2 class="title">Co poprawić</h2>
-                        <div class="tiny muted">Syntetyczne wnioski z dziennika i checklisty.</div>
+                        <div class="tiny muted">Syntetyczne wnioski z dziennika i błędów procesu.</div>
                       </div>
                     </div>
                     <div class="stats-mini-grid" id="discipline-notes"></div>
@@ -1111,14 +1108,6 @@
 </script>
 <script>
 const STORAGE_KEY = 'lifeos_trading_v1';
-const DEFAULT_CHECKLIST = [
-  'Bias z HTF jest zgodny z setupem',
-  'Entry ma jasny trigger i invalidation',
-  'RR spełnia minimalne wymaganie',
-  'Size wynika z risku, nie z emocji',
-  'Plan wyjścia i częściowych TP jest zapisany',
-  'Trade nie jest revenge / FOMO'
-];
 const DEFAULT_STRATEGIES = ['Breakout', 'Pullback', 'Range scalp', 'Liquidity sweep', 'Trend continuation'];
 const DEFAULT_SESSIONS = ['Asia', 'London', 'New York', 'Overlap', 'Weekend'];
 
@@ -1132,6 +1121,7 @@ const defaultState = {
     side: 'long',
     capital: 0,
     riskPct: 1,
+    leverage: 100,
     entry: '',
     stop: '',
     qty: '',
@@ -1207,7 +1197,6 @@ function defaultProfile() {
     currency: 'USDT',
     strategies: [...DEFAULT_STRATEGIES],
     sessions: [...DEFAULT_SESSIONS],
-    checklist: [...DEFAULT_CHECKLIST],
     createdAt: new Date().toISOString()
   };
 }
@@ -1245,7 +1234,6 @@ function normalizeTrade(trade) {
     : String(normalized.mistakes || '').split(',').map(t => t.trim()).filter(Boolean);
   normalized.notes = normalized.notes || '';
   normalized.thesis = normalized.thesis || '';
-  normalized.checklistDone = Boolean(normalized.checklistDone);
   normalized.outsidePlan = Boolean(normalized.outsidePlan);
   normalized.revengeTrade = Boolean(normalized.revengeTrade);
   normalized.movedStopAgainstPlan = Boolean(normalized.movedStopAgainstPlan);
@@ -1555,14 +1543,22 @@ function getPlannerDraftAsTrade() {
   const planner = state.planner;
   const capital = n(planner.capital) || getCurrentEquity() || n(state.profile?.startingCapital);
   const riskPct = n(planner.riskPct) || n(state.profile?.riskPerTradePct);
+  const maxLeverage = n(planner.leverage);
   let stop = n(planner.stop);
   let qty = n(planner.qty);
   const entry = n(planner.entry);
   const riskAmount = capital * (riskPct / 100);
+  const riskPerUnit = Math.abs(entry - stop);
 
   if (planner.mode === 'stop' && entry > 0 && qty > 0 && riskAmount > 0) {
     const distance = riskAmount / qty;
     stop = planner.side === 'short' ? entry + distance : entry - distance;
+  }
+
+  if (planner.mode === 'size' && !qty && entry > 0 && stop > 0 && riskPerUnit > 0 && riskAmount > 0) {
+    const qtyFromRisk = riskAmount / riskPerUnit;
+    const qtyFromLeverage = maxLeverage > 0 ? (capital * maxLeverage) / entry : qtyFromRisk;
+    qty = Math.min(qtyFromRisk, qtyFromLeverage);
   }
 
   const targets = [];
@@ -1596,7 +1592,6 @@ function isRuleViolation(trade) {
     if (metrics.weightedRR === 0 && trade.status !== 'cancelled') violations.push('Brak zdefiniowanego TP / RR');
     if (metrics.riskToDepositPct > n(state.profile.riskPerTradePct) + 0.0001) violations.push('Przekroczony % depo w SL');
   }
-  if (!trade.checklistDone) violations.push('Brak checklisty');
   if (trade.outsidePlan) violations.push('Poza planem');
   if (trade.revengeTrade) violations.push('Revenge trade');
   if (trade.movedStopAgainstPlan) violations.push('Przesuwany SL przeciwko planowi');
@@ -1607,13 +1602,12 @@ function getDisciplineSummary() {
   const trades = state.trades;
   const closed = getClosedTrades();
   const violationCount = trades.reduce((sum, trade) => sum + (isRuleViolation(trade).length > 0 ? 1 : 0), 0);
-  const checklistRate = trades.length ? (trades.filter(trade => trade.checklistDone).length / trades.length) * 100 : 0;
   const outsidePlanCount = trades.filter(trade => trade.outsidePlan).length;
   const revengeCount = trades.filter(trade => trade.revengeTrade).length;
   const movedStopCount = trades.filter(trade => trade.movedStopAgainstPlan).length;
   const lowRRCount = trades.filter(trade => calculateTradeMetrics(trade).weightedRR > 0 && calculateTradeMetrics(trade).weightedRR < n(state.profile?.minRR)).length;
   const avgViolationsPerTrade = trades.length ? violationCount / trades.length : 0;
-  const score = clamp(100 - (avgViolationsPerTrade * 30) - ((100 - checklistRate) * 0.35) - outsidePlanCount * 4 - revengeCount * 6 - movedStopCount * 5, 0, 100);
+  const score = clamp(100 - (avgViolationsPerTrade * 34) - outsidePlanCount * 4 - revengeCount * 6 - movedStopCount * 5, 0, 100);
 
   const mistakeMap = new Map();
   trades.forEach((trade) => {
@@ -1627,7 +1621,6 @@ function getDisciplineSummary() {
 
   return {
     score,
-    checklistRate,
     violationCount,
     outsidePlanCount,
     revengeCount,
@@ -1743,7 +1736,7 @@ function renderOverview() {
   $('#rail-week-count-note').textContent = `Closed: ${metrics.closedTrades.filter(trade => monthKey(trade.closedAt || trade.openedAt) === monthKey(new Date().toISOString())).length} w tym miesiącu`;
 
   $('#discipline-score').textContent = `${fmtNum(discipline.score, 0)}/100`;
-  $('#discipline-score-note').textContent = `Checklista ${fmtPct(discipline.checklistRate, 0)} • naruszenia ${discipline.violationCount}`;
+  $('#discipline-score-note').textContent = `Naruszenia ${discipline.violationCount} • revenge ${discipline.revengeCount}`;
   $('#discipline-badge').innerHTML = discipline.score >= 80
     ? '<span class="risk-badge good">Proces stabilny</span>'
     : discipline.score >= 60
@@ -1754,10 +1747,6 @@ function renderOverview() {
   $('#rule-risk-trade').textContent = fmtPct(profile.riskPerTradePct, 1);
   $('#rule-daily-loss').textContent = fmtPct(profile.maxDailyLossPct, 1);
   $('#rule-open-risk').textContent = fmtPct(profile.maxOpenRiskPct, 1);
-
-  $('#overview-checklist').innerHTML = (profile.checklist || []).map(item => `
-    <label class="check-chip"><input type="checkbox" disabled> <span>${item}</span></label>
-  `).join('');
 
   const insightRows = [];
   if (metrics.closedTrades.length === 0) {
@@ -1783,6 +1772,7 @@ function renderPlanner() {
   $('#planner-side').value = state.planner.side || 'long';
   $('#planner-capital').value = state.planner.capital || getCurrentEquity() || n(state.profile.startingCapital);
   $('#planner-risk-pct').value = state.planner.riskPct || n(state.profile.riskPerTradePct);
+  $('#planner-leverage').value = state.planner.leverage || 100;
   $('#planner-entry').value = state.planner.entry || '';
   $('#planner-stop').value = state.planner.stop || '';
   $('#planner-qty').value = state.planner.qty || '';
@@ -1796,14 +1786,17 @@ function renderPlanner() {
 
   const plannerTrade = getPlannerDraftAsTrade();
   const metrics = calculateTradeMetrics(plannerTrade);
+  const rawRiskQty = metrics.riskPerUnit > 0 ? metrics.riskAmount / metrics.riskPerUnit : 0;
+  const leverageQtyCap = plannerTrade.entry > 0 && n(state.planner.leverage) > 0 ? (metrics.capitalBase * n(state.planner.leverage)) / plannerTrade.entry : 0;
+  const leverageLimited = rawRiskQty > 0 && leverageQtyCap > 0 && rawRiskQty > leverageQtyCap + 0.0000001;
   const firstTarget = metrics.targetBreakdown[0];
   const secondTarget = metrics.targetBreakdown[1];
   const stopRecommendation = metrics.riskPerUnit > 0 ? fmtPct(metrics.stopDistancePct, 2) : '—';
   const cards = [
     { label: 'Risk kwotowo', value: fmtMoney(metrics.riskAmount), note: `${fmtPct(metrics.riskPct, 2)} kapitału` },
-    { label: 'Rekomendowany size', value: metrics.qty ? fmtNum(metrics.qty, 4) : '—', note: metrics.qty ? `Notional ${fmtMoney(metrics.notional)}` : 'Podaj entry i SL' },
+    { label: 'Rekomendowany size (BTC)', value: metrics.qty ? fmtNum(metrics.qty, 4) : '—', note: metrics.qty ? (leverageLimited ? `Limit dźwigni ucina size (max ${fmtNum(leverageQtyCap, 4)} BTC)` : `Notional ${fmtMoney(metrics.notional)}`) : 'Podaj entry i SL' },
     { label: 'SL distance', value: stopRecommendation, note: plannerTrade.stopLoss > 0 ? `Entry → SL ${fmtNum(Math.abs(plannerTrade.entry - plannerTrade.stopLoss), 4)}` : 'Brak danych' },
-    { label: 'Leverage efektywny', value: metrics.leverage ? `${fmtNum(metrics.leverage, 2)}x` : '—', note: 'Notional / kapitał bazowy' },
+    { label: 'Leverage efektywny', value: metrics.leverage ? `${fmtNum(metrics.leverage, 2)}x` : '—', note: `Limit ustawiony: ${fmtNum(n(state.planner.leverage) || 0, 0)}x` },
     { label: 'Planowane RR', value: metrics.weightedRR ? fmtR(metrics.weightedRR) : '—', note: metrics.weightedNetRR ? `Po fee ~ ${fmtR(metrics.weightedNetRR)}` : 'Dodaj TP' },
     { label: 'Max loss net', value: fmtMoney(metrics.maxLossNet), note: `Fee + slippage ${fmtMoney(metrics.entryFees + metrics.exitFeesAtStop + metrics.slippageCost)}` },
     { label: 'TP1', value: firstTarget ? fmtMoney(firstTarget.net) : '—', note: firstTarget ? `${firstTarget.label} • ${fmtR(firstTarget.rr)}` : 'Brak TP1' },
@@ -1896,9 +1889,9 @@ function renderDiscipline() {
   const todayLossLimit = metrics.equity * (n(state.profile.maxDailyLossPct) / 100);
   const rules = [
     {
-      title: 'Checklist completion',
-      value: fmtPct(discipline.checklistRate, 0),
-      note: `${state.trades.filter(trade => trade.checklistDone).length}/${state.trades.length || 0} pozycji miało pełną checklistę.`
+      title: 'Revenge trades',
+      value: `${discipline.revengeCount}`,
+      note: discipline.revengeCount > 0 ? 'Ogranicz wejścia emocjonalne i overtrading.' : 'Brak oznaczonych wejść emocjonalnych.'
     },
     {
       title: 'Violation density',
@@ -2165,12 +2158,11 @@ function openSetupModal() {
           <div class="form-group"><label class="form-label">Slippage %</label><input id="profile-slippage-pct" type="number" step="0.0001" class="form-input" value="${profile.slippagePct}"></div>
         </div>
         <div class="form-group"><label class="form-label">Strategie (oddziel przecinkami)</label><textarea id="profile-strategies" class="form-textarea">${(profile.strategies || []).join(', ')}</textarea></div>
-        <div class="form-group"><label class="form-label">Checklista (każdy punkt w nowej linii)</label><textarea id="profile-checklist" class="form-textarea">${(profile.checklist || []).join('\n')}</textarea></div>
       </div>
       <div class="modal-side-stack">
         <div class="soft-panel">
           <h3 class="title">Co ustalasz teraz</h3>
-          <div class="copy">Ten profil staje się źródłem prawdy dla kalkulatora i rule engine. Każdy nowy trade domyślnie dziedziczy risk %, fee, minimalne RR i checklistę.</div>
+          <div class="copy">Ten profil staje się źródłem prawdy dla kalkulatora i rule engine. Każdy nowy trade domyślnie dziedziczy risk %, fee i minimalne RR.</div>
         </div>
         <div class="soft-panel">
           <h3 class="title">Tip</h3>
@@ -2199,8 +2191,7 @@ function saveProfile() {
     minRR: n($('#profile-min-rr').value),
     feePct: n($('#profile-fee-pct').value),
     slippagePct: n($('#profile-slippage-pct').value),
-    strategies: $('#profile-strategies').value.split(',').map(item => item.trim()).filter(Boolean),
-    checklist: $('#profile-checklist').value.split('\n').map(item => item.trim()).filter(Boolean)
+    strategies: $('#profile-strategies').value.split(',').map(item => item.trim()).filter(Boolean)
   };
   state.planner.capital = state.planner.capital || state.profile.startingCapital;
   state.planner.riskPct = state.planner.riskPct || state.profile.riskPerTradePct;
@@ -2270,7 +2261,6 @@ function openTradeModal(tradeId = null, seed = null) {
         </div>
 
         <div class="check-grid">
-          <label class="check-chip"><input id="trade-checklist-done" type="checkbox" ${draft.checklistDone ? 'checked' : ''}><span>Checklista kompletna</span></label>
           <label class="check-chip"><input id="trade-outside-plan" type="checkbox" ${draft.outsidePlan ? 'checked' : ''}><span>Trade poza planem</span></label>
           <label class="check-chip"><input id="trade-revenge" type="checkbox" ${draft.revengeTrade ? 'checked' : ''}><span>Revenge / overtrading</span></label>
           <label class="check-chip"><input id="trade-moved-stop" type="checkbox" ${draft.movedStopAgainstPlan ? 'checked' : ''}><span>Przesuwany SL przeciw planowi</span></label>
@@ -2348,7 +2338,6 @@ function collectTradeFromModal(existingId = null) {
     finalExitPrice: $('#trade-final-exit-price').value,
     tags: $('#trade-tags').value.split(',').map(item => item.trim()).filter(Boolean),
     mistakes: $('#trade-mistakes').value.split(',').map(item => item.trim()).filter(Boolean),
-    checklistDone: $('#trade-checklist-done').checked,
     outsidePlan: $('#trade-outside-plan').checked,
     revengeTrade: $('#trade-revenge').checked,
     movedStopAgainstPlan: $('#trade-moved-stop').checked,
@@ -2441,6 +2430,7 @@ function syncPlannerFromInputs() {
     side: $('#planner-side').value,
     capital: n($('#planner-capital').value),
     riskPct: n($('#planner-risk-pct').value),
+    leverage: n($('#planner-leverage').value),
     entry: $('#planner-entry').value,
     stop: $('#planner-stop').value,
     qty: $('#planner-qty').value,
@@ -2510,7 +2500,7 @@ function setupEventListeners() {
     }
   });
 
-  ['planner-symbol','planner-side','planner-capital','planner-risk-pct','planner-entry','planner-stop','planner-qty','planner-tp1','planner-tp2','planner-tp1-share'].forEach(id => {
+  ['planner-symbol','planner-side','planner-capital','planner-risk-pct','planner-leverage','planner-entry','planner-stop','planner-qty','planner-tp1','planner-tp2','planner-tp1-share'].forEach(id => {
     const node = document.getElementById(id);
     if (node) {
       node.addEventListener('input', syncPlannerFromInputs);

--- a/trading.html
+++ b/trading.html
@@ -928,18 +928,29 @@
                     </div>
                     <div class="planner-layout">
                       <div>
+                        <div class="soft-panel" style="margin-bottom:12px;">
+                          <h3 class="title" style="margin-bottom:8px;">Twoje wejście</h3>
+                          <div class="copy">Podajesz ticker, kierunek, entry, SL i dźwignię. Kapitał bazowy pobierany jest automatycznie z depozytu.</div>
+                        </div>
                         <div class="planner-form-grid">
                           <div class="form-group"><label class="form-label">Symbol</label><input id="planner-symbol" class="form-input" placeholder="BTCUSDT"></div>
                           <div class="form-group"><label class="form-label">Kierunek</label><select id="planner-side" class="form-select"><option value="long">Long</option><option value="short">Short</option></select></div>
-                          <div class="form-group"><label class="form-label">Kapitał bazowy</label><input id="planner-capital" type="number" step="0.01" class="form-input"></div>
-                          <div class="form-group"><label class="form-label">% depo w SL</label><input id="planner-risk-pct" type="number" step="0.01" class="form-input"></div>
                           <div class="form-group"><label class="form-label">Dźwignia (max)</label><input id="planner-leverage" type="number" step="1" class="form-input"></div>
                           <div class="form-group"><label class="form-label">Entry</label><input id="planner-entry" type="number" step="0.0001" class="form-input"></div>
                           <div class="form-group"><label class="form-label">Stop loss</label><input id="planner-stop" type="number" step="0.0001" class="form-input"></div>
+                        </div>
+                        <div class="row-inline" style="margin-top:8px;">
+                          <button class="btn primary" id="planner-calc-btn" type="button">Wylicz pozycję</button>
+                        </div>
+                        <div class="soft-panel" style="margin-top:12px;">
+                          <h3 class="title" style="margin-bottom:8px;">Twoje ustawienia po zmianach</h3>
+                          <div class="copy" style="margin-bottom:10px;">Po kliknięciu „Wylicz pozycję” te pola wypełnią się rekomendacją i możesz je nadpisać.</div>
+                          <div class="planner-form-grid">
                           <div class="form-group"><label class="form-label">Position size (BTC)</label><input id="planner-qty" type="number" step="0.0001" class="form-input"></div>
                           <div class="form-group"><label class="form-label">TP (2R)</label><input id="planner-tp" type="number" step="0.0001" class="form-input"></div>
+                          </div>
                         </div>
-                        <div class="row-inline" style="margin-top:6px;">
+                        <div class="row-inline" style="margin-top:10px;">
                           <button class="btn soft" id="planner-reset-btn" type="button">Reset planner</button>
                           <button class="btn primary" id="planner-to-trade-btn" type="button">Przenieś do pozycji</button>
                         </div>
@@ -1112,15 +1123,14 @@ const defaultState = {
   planner: {
     symbol: '',
     side: 'long',
-    capital: 0,
-    riskPct: 1,
     leverage: 100,
     entry: '',
     stop: '',
+    recommendedQty: '',
+    recommendedTp: '',
     qty: '',
-    qtyManual: false,
     tp: '',
-    tpManual: false
+    riskPct: 1
   },
   ui: {
     activePageTab: 'overview',
@@ -1247,8 +1257,8 @@ function loadState() {
   state.cashFlows = Array.isArray(state.cashFlows) ? state.cashFlows : [];
   state.planner = { ...deepClone(defaultState).planner, ...(state.planner || {}) };
   if (!state.planner.tp && state.planner.tp1) state.planner.tp = state.planner.tp1;
-  state.planner.qtyManual = Boolean(state.planner.qtyManual);
-  state.planner.tpManual = Boolean(state.planner.tpManual);
+  state.planner.recommendedQty = state.planner.recommendedQty || '';
+  state.planner.recommendedTp = state.planner.recommendedTp || '';
   state.ui = {
     activePageTab: state.ui?.activePageTab || 'overview',
     activeAnalyticsTab: state.ui?.activeAnalyticsTab || 'equity',
@@ -1260,10 +1270,7 @@ function loadState() {
     }
   };
 
-  if (!state.profile && state.planner.capital === 0) {
-    state.planner.capital = defaultProfile().startingCapital;
-    state.planner.riskPct = defaultProfile().riskPerTradePct;
-  }
+  state.planner.riskPct = n(state.planner.riskPct) || n(state.profile?.riskPerTradePct) || defaultProfile().riskPerTradePct;
 }
 
 function saveState() {
@@ -1537,8 +1544,8 @@ function getAnalyticsMetrics() {
 
 function getPlannerDraftAsTrade() {
   const planner = state.planner;
-  const capital = n(planner.capital) || getCurrentEquity() || n(state.profile?.startingCapital);
-  const riskPct = n(planner.riskPct) || n(state.profile?.riskPerTradePct);
+  const capital = getCurrentEquity() || n(state.profile?.startingCapital);
+  const riskPct = n(state.profile?.riskPerTradePct) || n(planner.riskPct);
   const stop = n(planner.stop);
   const qty = n(planner.qty);
   const entry = n(planner.entry);
@@ -1562,8 +1569,8 @@ function getPlannerDraftAsTrade() {
 }
 
 function computePlannerAutoValues(plannerLike = state.planner) {
-  const capital = n(plannerLike.capital) || getCurrentEquity() || n(state.profile?.startingCapital);
-  const riskPct = n(plannerLike.riskPct) || n(state.profile?.riskPerTradePct);
+  const capital = getCurrentEquity() || n(state.profile?.startingCapital);
+  const riskPct = n(state.profile?.riskPerTradePct) || n(plannerLike.riskPct);
   const leverage = n(plannerLike.leverage);
   const entry = n(plannerLike.entry);
   const stop = n(plannerLike.stop);
@@ -1764,14 +1771,8 @@ function renderOverview() {
 
 function renderPlanner() {
   if (!state.profile) return;
-  const auto = computePlannerAutoValues(state.planner);
-  if (!state.planner.qtyManual) state.planner.qty = auto.qty > 0 ? String(auto.qty) : '';
-  if (!state.planner.tpManual) state.planner.tp = auto.tp > 0 ? String(auto.tp) : '';
-
   $('#planner-symbol').value = state.planner.symbol || '';
   $('#planner-side').value = state.planner.side || 'long';
-  $('#planner-capital').value = state.planner.capital || getCurrentEquity() || n(state.profile.startingCapital);
-  $('#planner-risk-pct').value = state.planner.riskPct || n(state.profile.riskPerTradePct);
   $('#planner-leverage').value = state.planner.leverage || 100;
   $('#planner-entry').value = state.planner.entry || '';
   $('#planner-stop').value = state.planner.stop || '';
@@ -1780,20 +1781,21 @@ function renderPlanner() {
 
   const plannerTrade = getPlannerDraftAsTrade();
   const metrics = calculateTradeMetrics(plannerTrade);
-  const rawRiskQty = metrics.riskPerUnit > 0 ? metrics.riskAmount / metrics.riskPerUnit : 0;
+  const recommendedQty = n(state.planner.recommendedQty);
+  const recommendedTp = n(state.planner.recommendedTp);
+  const rawRiskQty = recommendedQty || (metrics.riskPerUnit > 0 ? metrics.riskAmount / metrics.riskPerUnit : 0);
   const leverageQtyCap = plannerTrade.entry > 0 && n(state.planner.leverage) > 0 ? (metrics.capitalBase * n(state.planner.leverage)) / plannerTrade.entry : 0;
   const leverageLimited = rawRiskQty > 0 && leverageQtyCap > 0 && rawRiskQty > leverageQtyCap + 0.0000001;
   const primaryTarget = metrics.targetBreakdown[0];
-  const stopRecommendation = metrics.riskPerUnit > 0 ? fmtPct(metrics.stopDistancePct, 2) : '—';
+  const customQty = n(state.planner.qty);
+  const customTp = n(state.planner.tp);
   const cards = [
-    { label: 'Risk kwotowo', value: fmtMoney(metrics.riskAmount), note: `${fmtPct(metrics.riskPct, 2)} kapitału` },
-    { label: 'Rekomendowany size (BTC)', value: metrics.qty ? fmtNum(metrics.qty, 4) : '—', note: metrics.qty ? (leverageLimited ? `Limit dźwigni ucina size (max ${fmtNum(leverageQtyCap, 4)} BTC)` : `Notional ${fmtMoney(metrics.notional)}`) : 'Podaj entry i SL' },
-    { label: 'SL distance', value: stopRecommendation, note: plannerTrade.stopLoss > 0 ? `Entry → SL ${fmtNum(Math.abs(plannerTrade.entry - plannerTrade.stopLoss), 4)}` : 'Brak danych' },
+    { label: 'Rekomendowany size (BTC)', value: recommendedQty > 0 ? fmtNum(recommendedQty, 4) : '—', note: recommendedQty > 0 ? (leverageLimited ? `Limit dźwigni ucina size (max ${fmtNum(leverageQtyCap, 4)} BTC)` : `Risk ${fmtPct(n(state.profile?.riskPerTradePct), 2)} depo`) : 'Kliknij „Wylicz pozycję”' },
+    { label: 'Rekomendowany TP price', value: recommendedTp > 0 ? fmtNum(recommendedTp, 4) : '—', note: 'Target liczony automatycznie jako 2R od SL' },
+    { label: 'Mój size (BTC)', value: customQty > 0 ? fmtNum(customQty, 4) : '—', note: customQty > 0 ? `Notional ${fmtMoney(metrics.notional)}` : 'Możesz nadpisać po kalkulacji' },
+    { label: 'Mój TP price', value: customTp > 0 ? fmtNum(customTp, 4) : '—', note: primaryTarget ? `Planowane RR ${fmtR(primaryTarget.rr)}` : 'Możesz nadpisać po kalkulacji' },
     { label: 'Leverage efektywny', value: metrics.leverage ? `${fmtNum(metrics.leverage, 2)}x` : '—', note: `Limit ustawiony: ${fmtNum(n(state.planner.leverage) || 0, 0)}x` },
-    { label: 'Planowane RR', value: metrics.weightedRR ? fmtR(metrics.weightedRR) : '—', note: metrics.weightedNetRR ? `Po fee ~ ${fmtR(metrics.weightedNetRR)}` : 'Dodaj TP' },
-    { label: 'Max loss net', value: fmtMoney(metrics.maxLossNet), note: `Fee + slippage ${fmtMoney(metrics.entryFees + metrics.exitFeesAtStop + metrics.slippageCost)}` },
-    { label: 'TP @ 2R', value: n(state.planner.tp) > 0 ? fmtNum(n(state.planner.tp), 4) : '—', note: 'Wyliczany automatycznie z entry i SL (2R).' },
-    { label: 'PnL na TP', value: primaryTarget ? fmtMoney(primaryTarget.net) : '—', note: primaryTarget ? `${primaryTarget.label} • ${fmtR(primaryTarget.rr)}` : 'Brak TP' }
+    { label: 'Max loss net', value: fmtMoney(metrics.maxLossNet), note: `Fee + slippage ${fmtMoney(metrics.entryFees + metrics.exitFeesAtStop + metrics.slippageCost)}` }
   ];
   $('#planner-results').innerHTML = cards.map(card => `
     <article class="planner-card">
@@ -2416,30 +2418,28 @@ function duplicateTrade(tradeId) {
   openTradeModal(null, duplicate);
 }
 
-function syncPlannerFromInputs(event) {
-  const changedId = event?.target?.id || '';
-  const keyInputs = ['planner-side', 'planner-capital', 'planner-risk-pct', 'planner-leverage', 'planner-entry', 'planner-stop'];
+function syncPlannerFromInputs() {
   state.planner = {
     ...state.planner,
     symbol: $('#planner-symbol').value.trim().toUpperCase(),
     side: $('#planner-side').value,
-    capital: n($('#planner-capital').value),
-    riskPct: n($('#planner-risk-pct').value),
     leverage: n($('#planner-leverage').value),
     entry: $('#planner-entry').value,
     stop: $('#planner-stop').value,
     qty: $('#planner-qty').value,
     tp: $('#planner-tp').value
   };
+  saveState();
+  renderPlanner();
+}
 
-  if (changedId === 'planner-qty') state.planner.qtyManual = Boolean($('#planner-qty').value);
-  if (changedId === 'planner-tp') state.planner.tpManual = Boolean($('#planner-tp').value);
-
-  if (!changedId || keyInputs.includes(changedId)) {
-    const auto = computePlannerAutoValues(state.planner);
-    if (!state.planner.qtyManual) state.planner.qty = auto.qty > 0 ? String(auto.qty) : '';
-    if (!state.planner.tpManual) state.planner.tp = auto.tp > 0 ? String(auto.tp) : '';
-  }
+function calculatePlanner() {
+  syncPlannerFromInputs();
+  const auto = computePlannerAutoValues(state.planner);
+  state.planner.recommendedQty = auto.qty > 0 ? String(auto.qty) : '';
+  state.planner.recommendedTp = auto.tp > 0 ? String(auto.tp) : '';
+  state.planner.qty = state.planner.recommendedQty;
+  state.planner.tp = state.planner.recommendedTp;
   saveState();
   renderPlanner();
 }
@@ -2447,7 +2447,6 @@ function syncPlannerFromInputs(event) {
 function resetPlanner() {
   state.planner = {
     ...deepClone(defaultState).planner,
-    capital: getCurrentEquity() || n(state.profile?.startingCapital),
     riskPct: n(state.profile?.riskPerTradePct)
   };
   saveState();
@@ -2496,13 +2495,14 @@ function setupEventListeners() {
 
   });
 
-  ['planner-symbol','planner-side','planner-capital','planner-risk-pct','planner-leverage','planner-entry','planner-stop','planner-qty','planner-tp'].forEach(id => {
+  ['planner-symbol','planner-side','planner-leverage','planner-entry','planner-stop','planner-qty','planner-tp'].forEach(id => {
     const node = document.getElementById(id);
     if (node) {
       node.addEventListener('input', syncPlannerFromInputs);
       node.addEventListener('change', syncPlannerFromInputs);
     }
   });
+  $('#planner-calc-btn').addEventListener('click', calculatePlanner);
   $('#planner-reset-btn').addEventListener('click', resetPlanner);
   $('#planner-to-trade-btn').addEventListener('click', openPlannerAsTrade);
 

--- a/trading.html
+++ b/trading.html
@@ -1578,11 +1578,11 @@ function computePlannerAutoValues(plannerLike = state.planner) {
   const entry = n(plannerLike.entry);
   const stop = n(plannerLike.stop);
   const riskPerUnit = Math.abs(entry - stop);
-  const marginAllocation = capital * (riskPct / 100);
-  if (!(capital > 0 && entry > 0 && leverage > 0 && stop > 0 && riskPerUnit > 0 && marginAllocation > 0)) {
+  const riskAmount = capital * (riskPct / 100);
+  if (!(capital > 0 && entry > 0 && leverage > 0 && stop > 0 && riskPerUnit > 0 && riskAmount > 0)) {
     return { qty: 0, tp: 0 };
   }
-  const qty = (marginAllocation * leverage) / entry;
+  const qty = (riskAmount * leverage) / riskPerUnit;
   const tp = plannerLike.side === 'short' ? entry - (riskPerUnit * 2) : entry + (riskPerUnit * 2);
   return { qty, tp };
 }
@@ -1789,10 +1789,11 @@ function renderPlanner() {
   const customTp = n(state.planner.tp);
   const entry = n(state.planner.entry);
   const stop = n(state.planner.stop);
-  const recommendedSlUsd = (recommendedQty > 0 && entry > 0 && stop > 0) ? Math.abs(entry - stop) * recommendedQty : 0;
-  const recommendedTpUsd = (recommendedQty > 0 && recommendedTp > 0 && entry > 0) ? Math.abs(recommendedTp - entry) * recommendedQty : 0;
-  const customSlUsd = (customQty > 0 && entry > 0 && stop > 0) ? Math.abs(entry - stop) * customQty : 0;
-  const customTpUsd = (customQty > 0 && customTp > 0 && entry > 0) ? Math.abs(customTp - entry) * customQty : 0;
+  const leverageValue = Math.max(n(state.planner.leverage), 1);
+  const recommendedSlUsd = (recommendedQty > 0 && entry > 0 && stop > 0) ? (Math.abs(entry - stop) * recommendedQty) / leverageValue : 0;
+  const recommendedTpUsd = (recommendedQty > 0 && recommendedTp > 0 && entry > 0) ? (Math.abs(recommendedTp - entry) * recommendedQty) / leverageValue : 0;
+  const customSlUsd = (customQty > 0 && entry > 0 && stop > 0) ? (Math.abs(entry - stop) * customQty) / leverageValue : 0;
+  const customTpUsd = (customQty > 0 && customTp > 0 && entry > 0) ? (Math.abs(customTp - entry) * customQty) / leverageValue : 0;
   const diffQty = customQty - recommendedQty;
   const diffTpPrice = customTp - recommendedTp;
   const diffSlUsd = customSlUsd - recommendedSlUsd;
@@ -1827,7 +1828,7 @@ function renderPlanner() {
       : 'Pozycja mieszana — poprawa jednego parametru kosztem drugiego.';
   const balanceLine = `ΔRR ${fmtDiff(rrDiff)} • ΔSL ${fmtDiffMoney(diffSlUsd)} • ΔTP ${fmtDiffMoney(diffTpUsd)}`;
   const cards = [
-    { label: 'Rekomendowany size (BTC)', value: recommendedQty > 0 ? fmtNum(recommendedQty, 4) : '—', note: recommendedQty > 0 ? `Size liczony dynamicznie z dźwigni ${fmtNum(n(state.planner.leverage), 0)}x` : 'Kliknij „Wylicz pozycję”' },
+    { label: 'Rekomendowany size (BTC)', value: recommendedQty > 0 ? fmtNum(recommendedQty, 4) : '—', note: recommendedQty > 0 ? `SL ≈ ${fmtPct(n(state.profile?.riskPerTradePct), 2)} depo przy dźwigni ${fmtNum(n(state.planner.leverage), 0)}x` : 'Kliknij „Wylicz pozycję”' },
     { label: 'Rekomendowany TP price', value: recommendedTp > 0 ? fmtNum(recommendedTp, 4) : '—', note: 'Target liczony automatycznie jako 2R od SL' },
     { label: 'Rekomendowany SL (USD)', value: recommendedSlUsd > 0 ? fmtMoney(recommendedSlUsd) : '—', note: 'Strata do SL przy rekomendowanym size' },
     { label: 'Rekomendowany TP (USD)', value: recommendedTpUsd > 0 ? fmtMoney(recommendedTpUsd) : '—', note: 'Potencjalny zysk do TP przy rekomendacji' },

--- a/trading.html
+++ b/trading.html
@@ -1578,13 +1578,11 @@ function computePlannerAutoValues(plannerLike = state.planner) {
   const entry = n(plannerLike.entry);
   const stop = n(plannerLike.stop);
   const riskPerUnit = Math.abs(entry - stop);
-  const riskAmount = capital * (riskPct / 100);
-  if (!(capital > 0 && entry > 0 && stop > 0 && riskPerUnit > 0 && riskAmount > 0)) {
+  const marginAllocation = capital * (riskPct / 100);
+  if (!(capital > 0 && entry > 0 && leverage > 0 && stop > 0 && riskPerUnit > 0 && marginAllocation > 0)) {
     return { qty: 0, tp: 0 };
   }
-  const qtyFromRisk = riskAmount / riskPerUnit;
-  const qtyFromLeverage = leverage > 0 ? (capital * leverage) / entry : qtyFromRisk;
-  const qty = Math.min(qtyFromRisk, qtyFromLeverage);
+  const qty = (marginAllocation * leverage) / entry;
   const tp = plannerLike.side === 'short' ? entry - (riskPerUnit * 2) : entry + (riskPerUnit * 2);
   return { qty, tp };
 }
@@ -1786,9 +1784,6 @@ function renderPlanner() {
   const metrics = calculateTradeMetrics(plannerTrade);
   const recommendedQty = n(state.planner.recommendedQty);
   const recommendedTp = n(state.planner.recommendedTp);
-  const rawRiskQty = recommendedQty || (metrics.riskPerUnit > 0 ? metrics.riskAmount / metrics.riskPerUnit : 0);
-  const leverageQtyCap = plannerTrade.entry > 0 && n(state.planner.leverage) > 0 ? (metrics.capitalBase * n(state.planner.leverage)) / plannerTrade.entry : 0;
-  const leverageLimited = rawRiskQty > 0 && leverageQtyCap > 0 && rawRiskQty > leverageQtyCap + 0.0000001;
   const primaryTarget = metrics.targetBreakdown[0];
   const customQty = n(state.planner.qty);
   const customTp = n(state.planner.tp);
@@ -1832,7 +1827,7 @@ function renderPlanner() {
       : 'Pozycja mieszana — poprawa jednego parametru kosztem drugiego.';
   const balanceLine = `ΔRR ${fmtDiff(rrDiff)} • ΔSL ${fmtDiffMoney(diffSlUsd)} • ΔTP ${fmtDiffMoney(diffTpUsd)}`;
   const cards = [
-    { label: 'Rekomendowany size (BTC)', value: recommendedQty > 0 ? fmtNum(recommendedQty, 4) : '—', note: recommendedQty > 0 ? (leverageLimited ? `Limit dźwigni ucina size (max ${fmtNum(leverageQtyCap, 4)} BTC)` : `Risk ${fmtPct(n(state.profile?.riskPerTradePct), 2)} depo • limit lewaru ${fmtNum(leverageQtyCap, 4)} BTC`) : 'Kliknij „Wylicz pozycję”' },
+    { label: 'Rekomendowany size (BTC)', value: recommendedQty > 0 ? fmtNum(recommendedQty, 4) : '—', note: recommendedQty > 0 ? `Size liczony dynamicznie z dźwigni ${fmtNum(n(state.planner.leverage), 0)}x` : 'Kliknij „Wylicz pozycję”' },
     { label: 'Rekomendowany TP price', value: recommendedTp > 0 ? fmtNum(recommendedTp, 4) : '—', note: 'Target liczony automatycznie jako 2R od SL' },
     { label: 'Rekomendowany SL (USD)', value: recommendedSlUsd > 0 ? fmtMoney(recommendedSlUsd) : '—', note: 'Strata do SL przy rekomendowanym size' },
     { label: 'Rekomendowany TP (USD)', value: recommendedTpUsd > 0 ? fmtMoney(recommendedTpUsd) : '—', note: 'Potencjalny zysk do TP przy rekomendacji' },

--- a/trading.html
+++ b/trading.html
@@ -439,6 +439,7 @@
     }
     .planner-card .value { font-size: 18px; font-weight: 800; color: var(--ink); letter-spacing: -0.03em; }
     .planner-card .note { font-size: 12px; color: var(--muted); }
+    .planner-card--wide { grid-column: span 2; }
 
     .form-group { margin-bottom: 14px; }
     .form-label { display: block; font-size: 12px; font-weight: 600; color: var(--muted); margin-bottom: 6px; }
@@ -932,10 +933,12 @@
                           <h3 class="title" style="margin-bottom:8px;">Twoje wejście</h3>
                           <div class="copy">Podajesz ticker, kierunek, entry, SL i dźwignię. Kapitał bazowy pobierany jest automatycznie z depozytu.</div>
                         </div>
-                        <div class="planner-form-grid">
+                        <div class="planner-form-grid" style="grid-template-columns:repeat(3,minmax(0,1fr));">
                           <div class="form-group"><label class="form-label">Symbol</label><input id="planner-symbol" class="form-input" placeholder="BTCUSDT"></div>
                           <div class="form-group"><label class="form-label">Kierunek</label><select id="planner-side" class="form-select"><option value="long">Long</option><option value="short">Short</option></select></div>
                           <div class="form-group"><label class="form-label">Dźwignia (max)</label><input id="planner-leverage" type="number" step="1" class="form-input"></div>
+                        </div>
+                        <div class="planner-form-grid" style="grid-template-columns:repeat(2,minmax(0,1fr)); margin-top:8px;">
                           <div class="form-group"><label class="form-label">Entry</label><input id="planner-entry" type="number" step="0.0001" class="form-input"></div>
                           <div class="form-group"><label class="form-label">Stop loss</label><input id="planner-stop" type="number" step="0.0001" class="form-input"></div>
                         </div>
@@ -1822,8 +1825,14 @@ function renderPlanner() {
   const tpUsdContext = diffTpUsd < 0 && rrDiff > 0 && diffSlUsd < 0
     ? 'Mniej $ TP wynika z mniejszego size — jednocześnie RR wzrósł i SL jest ciaśniejszy.'
     : 'Porównaj TP USD razem z RR i SL USD, nie osobno.';
+  const setupComment = diffSlUsd < 0 && rrDiff >= 0
+    ? 'Pozycja bezpieczniejsza niż sugerowana (niższy SL i nie gorszy RR).'
+    : diffSlUsd > 0 && rrDiff <= 0
+      ? 'Pozycja bardziej agresywna niż sugerowana (większy SL i słabszy RR).'
+      : 'Pozycja mieszana — poprawa jednego parametru kosztem drugiego.';
+  const balanceLine = `ΔRR ${fmtDiff(rrDiff)} • ΔSL ${fmtDiffMoney(diffSlUsd)} • ΔTP ${fmtDiffMoney(diffTpUsd)}`;
   const cards = [
-    { label: 'Rekomendowany size (BTC)', value: recommendedQty > 0 ? fmtNum(recommendedQty, 4) : '—', note: recommendedQty > 0 ? (leverageLimited ? `Limit dźwigni ucina size (max ${fmtNum(leverageQtyCap, 4)} BTC)` : `Risk ${fmtPct(n(state.profile?.riskPerTradePct), 2)} depo`) : 'Kliknij „Wylicz pozycję”' },
+    { label: 'Rekomendowany size (BTC)', value: recommendedQty > 0 ? fmtNum(recommendedQty, 4) : '—', note: recommendedQty > 0 ? (leverageLimited ? `Limit dźwigni ucina size (max ${fmtNum(leverageQtyCap, 4)} BTC)` : `Risk ${fmtPct(n(state.profile?.riskPerTradePct), 2)} depo • limit lewaru ${fmtNum(leverageQtyCap, 4)} BTC`) : 'Kliknij „Wylicz pozycję”' },
     { label: 'Rekomendowany TP price', value: recommendedTp > 0 ? fmtNum(recommendedTp, 4) : '—', note: 'Target liczony automatycznie jako 2R od SL' },
     { label: 'Rekomendowany SL (USD)', value: recommendedSlUsd > 0 ? fmtMoney(recommendedSlUsd) : '—', note: 'Strata do SL przy rekomendowanym size' },
     { label: 'Rekomendowany TP (USD)', value: recommendedTpUsd > 0 ? fmtMoney(recommendedTpUsd) : '—', note: 'Potencjalny zysk do TP przy rekomendacji' },
@@ -1831,10 +1840,10 @@ function renderPlanner() {
     { label: 'Mój TP price', value: customTp > 0 ? fmtNum(customTp, 4) : '—', note: customTp > 0 ? `${diffLine('Diff vs rekomendacja', fmtDiff(diffTpPrice), tpPriceDiffColor)}${diffLine('RR', fmtNum(customRR, 2), rrDiffColor)}` : (primaryTarget ? `Planowane RR ${fmtR(primaryTarget.rr)}` : 'Możesz nadpisać po kalkulacji') },
     { label: 'Mój SL (USD)', value: customSlUsd > 0 ? fmtMoney(customSlUsd) : '—', note: customSlUsd > 0 ? diffLine('Diff vs rekomendacja', fmtDiffMoney(diffSlUsd), slDiffColor) : 'Wynika z Twojego size i SL' },
     { label: 'Mój TP (USD)', value: customTpUsd > 0 ? fmtMoney(customTpUsd) : '—', note: customTpUsd > 0 ? `${diffLine('Diff vs rekomendacja', fmtDiffMoney(diffTpUsd), tpUsdDiffColor)}<div style="margin-top:4px; color:#64748b;">${tpUsdContext}</div>` : 'Wynika z Twojego size i TP' },
-    { label: 'Balans setupu', value: customTp > 0 && customSlUsd > 0 ? 'Porównanie' : '—', note: customTp > 0 && customSlUsd > 0 ? `${diffLine('ΔRR', fmtDiff(rrDiff), rrDiffColor)}${diffLine('ΔSL USD', fmtDiffMoney(diffSlUsd), slDiffColor)}${diffLine('ΔTP USD', fmtDiffMoney(diffTpUsd), tpUsdDiffColor)}` : 'Wpisz własny size/TP aby zobaczyć porównanie.' }
+    { label: 'Balans setupu', value: customTp > 0 && customSlUsd > 0 ? balanceLine : '—', note: customTp > 0 && customSlUsd > 0 ? `<div style="margin-top:4px; color:${(diffSlUsd < 0 && rrDiff >= 0) ? '#059669' : (diffSlUsd > 0 && rrDiff <= 0) ? '#dc2626' : '#d97706'}; font-weight:700;">${setupComment}</div>` : 'Wpisz własny size/TP aby zobaczyć porównanie.', wide: true }
   ];
   $('#planner-results').innerHTML = cards.map(card => `
-    <article class="planner-card">
+    <article class="planner-card ${card.wide ? 'planner-card--wide' : ''}">
       <span class="label">${card.label}</span>
       <strong class="value">${card.value}</strong>
       <span class="note">${card.note}</span>
@@ -2455,6 +2464,7 @@ function duplicateTrade(tradeId) {
 }
 
 function syncPlannerFromInputs() {
+  const hadRecommendation = Boolean(state.planner.recommendedQty || state.planner.recommendedTp);
   state.planner = {
     ...state.planner,
     symbol: $('#planner-symbol').value.trim().toUpperCase(),
@@ -2465,6 +2475,11 @@ function syncPlannerFromInputs() {
     qty: $('#planner-qty').value,
     tp: $('#planner-tp').value
   };
+  if (hadRecommendation) {
+    const auto = computePlannerAutoValues(state.planner);
+    state.planner.recommendedQty = auto.qty > 0 ? String(auto.qty) : '';
+    state.planner.recommendedTp = auto.tp > 0 ? String(auto.tp) : '';
+  }
   saveState();
   renderPlanner();
 }

--- a/trading.html
+++ b/trading.html
@@ -1582,7 +1582,7 @@ function computePlannerAutoValues(plannerLike = state.planner) {
   if (!(capital > 0 && entry > 0 && leverage > 0 && stop > 0 && riskPerUnit > 0 && riskAmount > 0)) {
     return { qty: 0, tp: 0 };
   }
-  const qty = (riskAmount * leverage) / riskPerUnit;
+  const qty = riskAmount / (riskPerUnit * leverage);
   const tp = plannerLike.side === 'short' ? entry - (riskPerUnit * 2) : entry + (riskPerUnit * 2);
   return { qty, tp };
 }
@@ -1790,10 +1790,10 @@ function renderPlanner() {
   const entry = n(state.planner.entry);
   const stop = n(state.planner.stop);
   const leverageValue = Math.max(n(state.planner.leverage), 1);
-  const recommendedSlUsd = (recommendedQty > 0 && entry > 0 && stop > 0) ? (Math.abs(entry - stop) * recommendedQty) / leverageValue : 0;
-  const recommendedTpUsd = (recommendedQty > 0 && recommendedTp > 0 && entry > 0) ? (Math.abs(recommendedTp - entry) * recommendedQty) / leverageValue : 0;
-  const customSlUsd = (customQty > 0 && entry > 0 && stop > 0) ? (Math.abs(entry - stop) * customQty) / leverageValue : 0;
-  const customTpUsd = (customQty > 0 && customTp > 0 && entry > 0) ? (Math.abs(customTp - entry) * customQty) / leverageValue : 0;
+  const recommendedSlUsd = (recommendedQty > 0 && entry > 0 && stop > 0) ? (Math.abs(entry - stop) * recommendedQty) * leverageValue : 0;
+  const recommendedTpUsd = (recommendedQty > 0 && recommendedTp > 0 && entry > 0) ? (Math.abs(recommendedTp - entry) * recommendedQty) * leverageValue : 0;
+  const customSlUsd = (customQty > 0 && entry > 0 && stop > 0) ? (Math.abs(entry - stop) * customQty) * leverageValue : 0;
+  const customTpUsd = (customQty > 0 && customTp > 0 && entry > 0) ? (Math.abs(customTp - entry) * customQty) * leverageValue : 0;
   const diffQty = customQty - recommendedQty;
   const diffTpPrice = customTp - recommendedTp;
   const diffSlUsd = customSlUsd - recommendedSlUsd;

--- a/trading.html
+++ b/trading.html
@@ -1789,11 +1789,35 @@ function renderPlanner() {
   const primaryTarget = metrics.targetBreakdown[0];
   const customQty = n(state.planner.qty);
   const customTp = n(state.planner.tp);
+  const entry = n(state.planner.entry);
+  const stop = n(state.planner.stop);
+  const recommendedSlUsd = (recommendedQty > 0 && entry > 0 && stop > 0) ? Math.abs(entry - stop) * recommendedQty : 0;
+  const recommendedTpUsd = (recommendedQty > 0 && recommendedTp > 0 && entry > 0) ? Math.abs(recommendedTp - entry) * recommendedQty : 0;
+  const customSlUsd = (customQty > 0 && entry > 0 && stop > 0) ? Math.abs(entry - stop) * customQty : 0;
+  const customTpUsd = (customQty > 0 && customTp > 0 && entry > 0) ? Math.abs(customTp - entry) * customQty : 0;
+  const diffQty = customQty - recommendedQty;
+  const diffTpPrice = customTp - recommendedTp;
+  const diffSlUsd = customSlUsd - recommendedSlUsd;
+  const diffTpUsd = customTpUsd - recommendedTpUsd;
+  const fmtDiff = (value, suffix = '') => {
+    if (!Number.isFinite(value) || Math.abs(value) < 0.0000001) return `0${suffix}`;
+    const sign = value > 0 ? '+' : '';
+    return `${sign}${fmtNum(value, 4)}${suffix}`;
+  };
+  const fmtDiffMoney = (value) => {
+    if (!Number.isFinite(value) || Math.abs(value) < 0.0000001) return fmtMoney(0);
+    const sign = value > 0 ? '+' : '';
+    return `${sign}${fmtMoney(value)}`;
+  };
   const cards = [
     { label: 'Rekomendowany size (BTC)', value: recommendedQty > 0 ? fmtNum(recommendedQty, 4) : '—', note: recommendedQty > 0 ? (leverageLimited ? `Limit dźwigni ucina size (max ${fmtNum(leverageQtyCap, 4)} BTC)` : `Risk ${fmtPct(n(state.profile?.riskPerTradePct), 2)} depo`) : 'Kliknij „Wylicz pozycję”' },
     { label: 'Rekomendowany TP price', value: recommendedTp > 0 ? fmtNum(recommendedTp, 4) : '—', note: 'Target liczony automatycznie jako 2R od SL' },
-    { label: 'Mój size (BTC)', value: customQty > 0 ? fmtNum(customQty, 4) : '—', note: customQty > 0 ? `Notional ${fmtMoney(metrics.notional)}` : 'Możesz nadpisać po kalkulacji' },
-    { label: 'Mój TP price', value: customTp > 0 ? fmtNum(customTp, 4) : '—', note: primaryTarget ? `Planowane RR ${fmtR(primaryTarget.rr)}` : 'Możesz nadpisać po kalkulacji' },
+    { label: 'Rekomendowany SL (USD)', value: recommendedSlUsd > 0 ? fmtMoney(recommendedSlUsd) : '—', note: 'Strata do SL przy rekomendowanym size' },
+    { label: 'Rekomendowany TP (USD)', value: recommendedTpUsd > 0 ? fmtMoney(recommendedTpUsd) : '—', note: 'Potencjalny zysk do TP przy rekomendacji' },
+    { label: 'Mój size (BTC)', value: customQty > 0 ? fmtNum(customQty, 4) : '—', note: customQty > 0 ? `Diff vs rekomendacja: ${fmtDiff(diffQty, ' BTC')}` : 'Możesz nadpisać po kalkulacji' },
+    { label: 'Mój TP price', value: customTp > 0 ? fmtNum(customTp, 4) : '—', note: customTp > 0 ? `Diff vs rekomendacja: ${fmtDiff(diffTpPrice)}` : (primaryTarget ? `Planowane RR ${fmtR(primaryTarget.rr)}` : 'Możesz nadpisać po kalkulacji') },
+    { label: 'Mój SL (USD)', value: customSlUsd > 0 ? fmtMoney(customSlUsd) : '—', note: customSlUsd > 0 ? `Diff vs rekomendacja: ${fmtDiffMoney(diffSlUsd)}` : 'Wynika z Twojego size i SL' },
+    { label: 'Mój TP (USD)', value: customTpUsd > 0 ? fmtMoney(customTpUsd) : '—', note: customTpUsd > 0 ? `Diff vs rekomendacja: ${fmtDiffMoney(diffTpUsd)}` : 'Wynika z Twojego size i TP' },
     { label: 'Leverage efektywny', value: metrics.leverage ? `${fmtNum(metrics.leverage, 2)}x` : '—', note: `Limit ustawiony: ${fmtNum(n(state.planner.leverage) || 0, 0)}x` },
     { label: 'Max loss net', value: fmtMoney(metrics.maxLossNet), note: `Fee + slippage ${fmtMoney(metrics.entryFees + metrics.exitFeesAtStop + metrics.slippageCost)}` }
   ];

--- a/trading.html
+++ b/trading.html
@@ -925,10 +925,6 @@
                         <h2 class="title">Risk lab</h2>
                         <div class="tiny muted">Kalkulator pozycji: wpisz entry, SL i dźwignię, aby policzyć size pod % depo w SL.</div>
                       </div>
-                      <div class="switch-pill" id="planner-mode-switch" role="group" aria-label="Tryb kalkulatora">
-                        <button type="button" class="active" data-planner-mode="size">Wylicz size</button>
-                        <button type="button" data-planner-mode="stop">Wylicz SL</button>
-                      </div>
                     </div>
                     <div class="planner-layout">
                       <div>
@@ -940,10 +936,8 @@
                           <div class="form-group"><label class="form-label">Dźwignia (max)</label><input id="planner-leverage" type="number" step="1" class="form-input"></div>
                           <div class="form-group"><label class="form-label">Entry</label><input id="planner-entry" type="number" step="0.0001" class="form-input"></div>
                           <div class="form-group"><label class="form-label">Stop loss</label><input id="planner-stop" type="number" step="0.0001" class="form-input"></div>
-                          <div class="form-group"><label class="form-label">Qty</label><input id="planner-qty" type="number" step="0.0001" class="form-input"></div>
-                          <div class="form-group"><label class="form-label">TP1</label><input id="planner-tp1" type="number" step="0.0001" class="form-input"></div>
-                          <div class="form-group"><label class="form-label">TP2</label><input id="planner-tp2" type="number" step="0.0001" class="form-input"></div>
-                          <div class="form-group"><label class="form-label">TP1 udział %</label><input id="planner-tp1-share" type="number" step="0.01" class="form-input"></div>
+                          <div class="form-group"><label class="form-label">Position size (BTC)</label><input id="planner-qty" type="number" step="0.0001" class="form-input"></div>
+                          <div class="form-group"><label class="form-label">TP (2R)</label><input id="planner-tp" type="number" step="0.0001" class="form-input"></div>
                         </div>
                         <div class="row-inline" style="margin-top:6px;">
                           <button class="btn soft" id="planner-reset-btn" type="button">Reset planner</button>
@@ -1116,7 +1110,6 @@ const defaultState = {
   trades: [],
   cashFlows: [],
   planner: {
-    mode: 'size',
     symbol: '',
     side: 'long',
     capital: 0,
@@ -1125,9 +1118,9 @@ const defaultState = {
     entry: '',
     stop: '',
     qty: '',
-    tp1: '',
-    tp2: '',
-    tp1Share: 50
+    qtyManual: false,
+    tp: '',
+    tpManual: false
   },
   ui: {
     activePageTab: 'overview',
@@ -1253,6 +1246,9 @@ function loadState() {
   state.trades = Array.isArray(state.trades) ? state.trades.map(normalizeTrade) : [];
   state.cashFlows = Array.isArray(state.cashFlows) ? state.cashFlows : [];
   state.planner = { ...deepClone(defaultState).planner, ...(state.planner || {}) };
+  if (!state.planner.tp && state.planner.tp1) state.planner.tp = state.planner.tp1;
+  state.planner.qtyManual = Boolean(state.planner.qtyManual);
+  state.planner.tpManual = Boolean(state.planner.tpManual);
   state.ui = {
     activePageTab: state.ui?.activePageTab || 'overview',
     activeAnalyticsTab: state.ui?.activeAnalyticsTab || 'equity',
@@ -1543,31 +1539,13 @@ function getPlannerDraftAsTrade() {
   const planner = state.planner;
   const capital = n(planner.capital) || getCurrentEquity() || n(state.profile?.startingCapital);
   const riskPct = n(planner.riskPct) || n(state.profile?.riskPerTradePct);
-  const maxLeverage = n(planner.leverage);
-  let stop = n(planner.stop);
-  let qty = n(planner.qty);
+  const stop = n(planner.stop);
+  const qty = n(planner.qty);
   const entry = n(planner.entry);
-  const riskAmount = capital * (riskPct / 100);
-  const riskPerUnit = Math.abs(entry - stop);
-
-  if (planner.mode === 'stop' && entry > 0 && qty > 0 && riskAmount > 0) {
-    const distance = riskAmount / qty;
-    stop = planner.side === 'short' ? entry + distance : entry - distance;
-  }
-
-  if (planner.mode === 'size' && !qty && entry > 0 && stop > 0 && riskPerUnit > 0 && riskAmount > 0) {
-    const qtyFromRisk = riskAmount / riskPerUnit;
-    const qtyFromLeverage = maxLeverage > 0 ? (capital * maxLeverage) / entry : qtyFromRisk;
-    qty = Math.min(qtyFromRisk, qtyFromLeverage);
-  }
+  const tp = n(planner.tp);
 
   const targets = [];
-  if (n(planner.tp1) > 0) {
-    targets.push({ label: 'TP1', price: n(planner.tp1), sharePct: n(planner.tp1Share) || 50, hit: false });
-  }
-  if (n(planner.tp2) > 0) {
-    targets.push({ label: 'TP2', price: n(planner.tp2), sharePct: 100 - (n(planner.tp1Share) || 50), hit: false });
-  }
+  if (tp > 0) targets.push({ label: 'TP 2R', price: tp, sharePct: 100, hit: false });
 
   return normalizeTrade({
     symbol: planner.symbol || '',
@@ -1581,6 +1559,24 @@ function getPlannerDraftAsTrade() {
     qty,
     targets
   });
+}
+
+function computePlannerAutoValues(plannerLike = state.planner) {
+  const capital = n(plannerLike.capital) || getCurrentEquity() || n(state.profile?.startingCapital);
+  const riskPct = n(plannerLike.riskPct) || n(state.profile?.riskPerTradePct);
+  const leverage = n(plannerLike.leverage);
+  const entry = n(plannerLike.entry);
+  const stop = n(plannerLike.stop);
+  const riskPerUnit = Math.abs(entry - stop);
+  const riskAmount = capital * (riskPct / 100);
+  if (!(capital > 0 && entry > 0 && stop > 0 && riskPerUnit > 0 && riskAmount > 0)) {
+    return { qty: 0, tp: 0 };
+  }
+  const qtyFromRisk = riskAmount / riskPerUnit;
+  const qtyFromLeverage = leverage > 0 ? (capital * leverage) / entry : qtyFromRisk;
+  const qty = Math.min(qtyFromRisk, qtyFromLeverage);
+  const tp = plannerLike.side === 'short' ? entry - (riskPerUnit * 2) : entry + (riskPerUnit * 2);
+  return { qty, tp };
 }
 
 function isRuleViolation(trade) {
@@ -1768,6 +1764,10 @@ function renderOverview() {
 
 function renderPlanner() {
   if (!state.profile) return;
+  const auto = computePlannerAutoValues(state.planner);
+  if (!state.planner.qtyManual) state.planner.qty = auto.qty > 0 ? String(auto.qty) : '';
+  if (!state.planner.tpManual) state.planner.tp = auto.tp > 0 ? String(auto.tp) : '';
+
   $('#planner-symbol').value = state.planner.symbol || '';
   $('#planner-side').value = state.planner.side || 'long';
   $('#planner-capital').value = state.planner.capital || getCurrentEquity() || n(state.profile.startingCapital);
@@ -1776,21 +1776,14 @@ function renderPlanner() {
   $('#planner-entry').value = state.planner.entry || '';
   $('#planner-stop').value = state.planner.stop || '';
   $('#planner-qty').value = state.planner.qty || '';
-  $('#planner-tp1').value = state.planner.tp1 || '';
-  $('#planner-tp2').value = state.planner.tp2 || '';
-  $('#planner-tp1-share').value = state.planner.tp1Share || 50;
-
-  $$('#planner-mode-switch button').forEach(btn => btn.classList.toggle('active', btn.dataset.plannerMode === state.planner.mode));
-  $('#planner-stop').closest('.form-group').style.opacity = state.planner.mode === 'size' ? '1' : '0.88';
-  $('#planner-qty').closest('.form-group').style.opacity = state.planner.mode === 'stop' ? '1' : '0.88';
+  $('#planner-tp').value = state.planner.tp || '';
 
   const plannerTrade = getPlannerDraftAsTrade();
   const metrics = calculateTradeMetrics(plannerTrade);
   const rawRiskQty = metrics.riskPerUnit > 0 ? metrics.riskAmount / metrics.riskPerUnit : 0;
   const leverageQtyCap = plannerTrade.entry > 0 && n(state.planner.leverage) > 0 ? (metrics.capitalBase * n(state.planner.leverage)) / plannerTrade.entry : 0;
   const leverageLimited = rawRiskQty > 0 && leverageQtyCap > 0 && rawRiskQty > leverageQtyCap + 0.0000001;
-  const firstTarget = metrics.targetBreakdown[0];
-  const secondTarget = metrics.targetBreakdown[1];
+  const primaryTarget = metrics.targetBreakdown[0];
   const stopRecommendation = metrics.riskPerUnit > 0 ? fmtPct(metrics.stopDistancePct, 2) : '—';
   const cards = [
     { label: 'Risk kwotowo', value: fmtMoney(metrics.riskAmount), note: `${fmtPct(metrics.riskPct, 2)} kapitału` },
@@ -1799,8 +1792,8 @@ function renderPlanner() {
     { label: 'Leverage efektywny', value: metrics.leverage ? `${fmtNum(metrics.leverage, 2)}x` : '—', note: `Limit ustawiony: ${fmtNum(n(state.planner.leverage) || 0, 0)}x` },
     { label: 'Planowane RR', value: metrics.weightedRR ? fmtR(metrics.weightedRR) : '—', note: metrics.weightedNetRR ? `Po fee ~ ${fmtR(metrics.weightedNetRR)}` : 'Dodaj TP' },
     { label: 'Max loss net', value: fmtMoney(metrics.maxLossNet), note: `Fee + slippage ${fmtMoney(metrics.entryFees + metrics.exitFeesAtStop + metrics.slippageCost)}` },
-    { label: 'TP1', value: firstTarget ? fmtMoney(firstTarget.net) : '—', note: firstTarget ? `${firstTarget.label} • ${fmtR(firstTarget.rr)}` : 'Brak TP1' },
-    { label: 'TP2', value: secondTarget ? fmtMoney(secondTarget.net) : '—', note: secondTarget ? `${secondTarget.label} • ${fmtR(secondTarget.rr)}` : 'Brak TP2' }
+    { label: 'TP @ 2R', value: n(state.planner.tp) > 0 ? fmtNum(n(state.planner.tp), 4) : '—', note: 'Wyliczany automatycznie z entry i SL (2R).' },
+    { label: 'PnL na TP', value: primaryTarget ? fmtMoney(primaryTarget.net) : '—', note: primaryTarget ? `${primaryTarget.label} • ${fmtR(primaryTarget.rr)}` : 'Brak TP' }
   ];
   $('#planner-results').innerHTML = cards.map(card => `
     <article class="planner-card">
@@ -2423,7 +2416,9 @@ function duplicateTrade(tradeId) {
   openTradeModal(null, duplicate);
 }
 
-function syncPlannerFromInputs() {
+function syncPlannerFromInputs(event) {
+  const changedId = event?.target?.id || '';
+  const keyInputs = ['planner-side', 'planner-capital', 'planner-risk-pct', 'planner-leverage', 'planner-entry', 'planner-stop'];
   state.planner = {
     ...state.planner,
     symbol: $('#planner-symbol').value.trim().toUpperCase(),
@@ -2434,10 +2429,17 @@ function syncPlannerFromInputs() {
     entry: $('#planner-entry').value,
     stop: $('#planner-stop').value,
     qty: $('#planner-qty').value,
-    tp1: $('#planner-tp1').value,
-    tp2: $('#planner-tp2').value,
-    tp1Share: n($('#planner-tp1-share').value),
+    tp: $('#planner-tp').value
   };
+
+  if (changedId === 'planner-qty') state.planner.qtyManual = Boolean($('#planner-qty').value);
+  if (changedId === 'planner-tp') state.planner.tpManual = Boolean($('#planner-tp').value);
+
+  if (!changedId || keyInputs.includes(changedId)) {
+    const auto = computePlannerAutoValues(state.planner);
+    if (!state.planner.qtyManual) state.planner.qty = auto.qty > 0 ? String(auto.qty) : '';
+    if (!state.planner.tpManual) state.planner.tp = auto.tp > 0 ? String(auto.tp) : '';
+  }
   saveState();
   renderPlanner();
 }
@@ -2492,15 +2494,9 @@ function setupEventListeners() {
       renderJournal();
     }
 
-    const modeBtn = event.target.closest('[data-planner-mode]');
-    if (modeBtn) {
-      state.planner.mode = modeBtn.dataset.plannerMode;
-      saveState();
-      renderPlanner();
-    }
   });
 
-  ['planner-symbol','planner-side','planner-capital','planner-risk-pct','planner-leverage','planner-entry','planner-stop','planner-qty','planner-tp1','planner-tp2','planner-tp1-share'].forEach(id => {
+  ['planner-symbol','planner-side','planner-capital','planner-risk-pct','planner-leverage','planner-entry','planner-stop','planner-qty','planner-tp'].forEach(id => {
     const node = document.getElementById(id);
     if (node) {
       node.addEventListener('input', syncPlannerFromInputs);

--- a/trading.html
+++ b/trading.html
@@ -1799,6 +1799,10 @@ function renderPlanner() {
   const diffTpPrice = customTp - recommendedTp;
   const diffSlUsd = customSlUsd - recommendedSlUsd;
   const diffTpUsd = customTpUsd - recommendedTpUsd;
+  const riskPerUnit = Math.abs(entry - stop);
+  const recommendedRR = (recommendedTp > 0 && riskPerUnit > 0) ? Math.abs(recommendedTp - entry) / riskPerUnit : 0;
+  const customRR = (customTp > 0 && riskPerUnit > 0) ? Math.abs(customTp - entry) / riskPerUnit : 0;
+  const rrDiff = customRR - recommendedRR;
   const fmtDiff = (value, suffix = '') => {
     if (!Number.isFinite(value) || Math.abs(value) < 0.0000001) return `0${suffix}`;
     const sign = value > 0 ? '+' : '';
@@ -1809,17 +1813,25 @@ function renderPlanner() {
     const sign = value > 0 ? '+' : '';
     return `${sign}${fmtMoney(value)}`;
   };
+  const diffLine = (label, value, color) => `<div style="margin-top:4px; color:${color}; font-weight:700;">${label}: ${value}</div>`;
+  const sizeDiffColor = diffQty <= 0 ? '#059669' : '#dc2626';
+  const tpPriceDiffColor = diffTpPrice >= 0 ? '#059669' : '#d97706';
+  const slDiffColor = diffSlUsd <= 0 ? '#059669' : '#dc2626';
+  const tpUsdDiffColor = diffTpUsd >= 0 ? '#059669' : ((rrDiff > 0 && diffSlUsd < 0) ? '#2563eb' : '#d97706');
+  const rrDiffColor = rrDiff >= 0 ? '#059669' : '#dc2626';
+  const tpUsdContext = diffTpUsd < 0 && rrDiff > 0 && diffSlUsd < 0
+    ? 'Mniej $ TP wynika z mniejszego size — jednocześnie RR wzrósł i SL jest ciaśniejszy.'
+    : 'Porównaj TP USD razem z RR i SL USD, nie osobno.';
   const cards = [
     { label: 'Rekomendowany size (BTC)', value: recommendedQty > 0 ? fmtNum(recommendedQty, 4) : '—', note: recommendedQty > 0 ? (leverageLimited ? `Limit dźwigni ucina size (max ${fmtNum(leverageQtyCap, 4)} BTC)` : `Risk ${fmtPct(n(state.profile?.riskPerTradePct), 2)} depo`) : 'Kliknij „Wylicz pozycję”' },
     { label: 'Rekomendowany TP price', value: recommendedTp > 0 ? fmtNum(recommendedTp, 4) : '—', note: 'Target liczony automatycznie jako 2R od SL' },
     { label: 'Rekomendowany SL (USD)', value: recommendedSlUsd > 0 ? fmtMoney(recommendedSlUsd) : '—', note: 'Strata do SL przy rekomendowanym size' },
     { label: 'Rekomendowany TP (USD)', value: recommendedTpUsd > 0 ? fmtMoney(recommendedTpUsd) : '—', note: 'Potencjalny zysk do TP przy rekomendacji' },
-    { label: 'Mój size (BTC)', value: customQty > 0 ? fmtNum(customQty, 4) : '—', note: customQty > 0 ? `Diff vs rekomendacja: ${fmtDiff(diffQty, ' BTC')}` : 'Możesz nadpisać po kalkulacji' },
-    { label: 'Mój TP price', value: customTp > 0 ? fmtNum(customTp, 4) : '—', note: customTp > 0 ? `Diff vs rekomendacja: ${fmtDiff(diffTpPrice)}` : (primaryTarget ? `Planowane RR ${fmtR(primaryTarget.rr)}` : 'Możesz nadpisać po kalkulacji') },
-    { label: 'Mój SL (USD)', value: customSlUsd > 0 ? fmtMoney(customSlUsd) : '—', note: customSlUsd > 0 ? `Diff vs rekomendacja: ${fmtDiffMoney(diffSlUsd)}` : 'Wynika z Twojego size i SL' },
-    { label: 'Mój TP (USD)', value: customTpUsd > 0 ? fmtMoney(customTpUsd) : '—', note: customTpUsd > 0 ? `Diff vs rekomendacja: ${fmtDiffMoney(diffTpUsd)}` : 'Wynika z Twojego size i TP' },
-    { label: 'Leverage efektywny', value: metrics.leverage ? `${fmtNum(metrics.leverage, 2)}x` : '—', note: `Limit ustawiony: ${fmtNum(n(state.planner.leverage) || 0, 0)}x` },
-    { label: 'Max loss net', value: fmtMoney(metrics.maxLossNet), note: `Fee + slippage ${fmtMoney(metrics.entryFees + metrics.exitFeesAtStop + metrics.slippageCost)}` }
+    { label: 'Mój size (BTC)', value: customQty > 0 ? fmtNum(customQty, 4) : '—', note: customQty > 0 ? diffLine('Diff vs rekomendacja', fmtDiff(diffQty, ' BTC'), sizeDiffColor) : 'Możesz nadpisać po kalkulacji' },
+    { label: 'Mój TP price', value: customTp > 0 ? fmtNum(customTp, 4) : '—', note: customTp > 0 ? `${diffLine('Diff vs rekomendacja', fmtDiff(diffTpPrice), tpPriceDiffColor)}${diffLine('RR', fmtNum(customRR, 2), rrDiffColor)}` : (primaryTarget ? `Planowane RR ${fmtR(primaryTarget.rr)}` : 'Możesz nadpisać po kalkulacji') },
+    { label: 'Mój SL (USD)', value: customSlUsd > 0 ? fmtMoney(customSlUsd) : '—', note: customSlUsd > 0 ? diffLine('Diff vs rekomendacja', fmtDiffMoney(diffSlUsd), slDiffColor) : 'Wynika z Twojego size i SL' },
+    { label: 'Mój TP (USD)', value: customTpUsd > 0 ? fmtMoney(customTpUsd) : '—', note: customTpUsd > 0 ? `${diffLine('Diff vs rekomendacja', fmtDiffMoney(diffTpUsd), tpUsdDiffColor)}<div style="margin-top:4px; color:#64748b;">${tpUsdContext}</div>` : 'Wynika z Twojego size i TP' },
+    { label: 'Balans setupu', value: customTp > 0 && customSlUsd > 0 ? 'Porównanie' : '—', note: customTp > 0 && customSlUsd > 0 ? `${diffLine('ΔRR', fmtDiff(rrDiff), rrDiffColor)}${diffLine('ΔSL USD', fmtDiffMoney(diffSlUsd), slDiffColor)}${diffLine('ΔTP USD', fmtDiffMoney(diffTpUsd), tpUsdDiffColor)}` : 'Wpisz własny size/TP aby zobaczyć porównanie.' }
   ];
   $('#planner-results').innerHTML = cards.map(card => `
     <article class="planner-card">


### PR DESCRIPTION
### Motivation
- Uprościć proces planowania pozycji usuwając obowiązek checkowania listy pre-trade z UI i logiki scoringu.
- Dodać workflow kalkulacji rozmiaru pozycji tak, aby strata przy SL była równa zadanym procentom depozytu.
- Pozwolić na ograniczenie obliczonego `size` limitem dźwigni (np. 100x) i umożliwić szybkie nadpisanie procentu ryzyka w plannerze.

### Description
- Usunięto checklistę pre-trade: usunięte `DEFAULT_CHECKLIST`, pola/checkboxy i sekcje checklisty z widoków (`overview`, profile modal, trade modal) oraz z serializacji profilu/trybu planner.\
- Usunięto walidację i score zależne od pola checklisty (usunięto `checklistDone` z normalizacji i zliczania scoringu), oraz zaktualizowano teksty UI, by nie referowały checklisty.\
- Dodano pole planner `leverage` (domyślnie `100`) i UI input `#planner-leverage`, oraz zapis/odczyt i listenery (`syncPlannerFromInputs`) dla nowego pola.\
- Zmieniono logikę kalkulatora (`getPlannerDraftAsTrade` + `renderPlanner`): przy trybie `size` obliczany jest `qty` z wzoru `riskAmount / riskPerUnit` (gdzie `riskAmount = capital * riskPct/100`), a następnie przycinany do limitu wynikającego z `maxLeverage` (tj. `(capital * leverage) / entry`); wyniki i notyfikacje w `planner-results` pokazują teraz `Rekomendowany size (BTC)`, informację o ograniczeniu dźwignią i porównanie `leverage efektywny` vs limit.\
- Dostosowano scoring procesu (`getDisciplineSummary`) usuwając checklist rate z kalkulacji i lekko zmieniając wagowanie naruszeń; zaktualizowano karty/reguły w widoku `discipline` aby eksponować liczbę `revenge`/naruszeń.\

### Testing
- Uruchomiono `git diff --check` — bez błędów (sukces).\
- Sprawdzono status i zmiany przez `git status --short` i zatwierdzono zmianę — commit zakończony sukcesem.\
- Przejrzano plik zmieniony (`trading.html`) oraz wyszukano wystąpienia checklisty i nowych pól (`rg`) aby potwierdzić usunięcie/aktualizację referencji (sukces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0acc48fbc8331be0fafdf2e08744f)