### PR TITLE
Add position size & TP override with impact analysis to trade planner

### DIFF
--- a/trading.css
+++ b/trading.css
@@ -683,6 +683,63 @@ body[data-page="trading"] .site-header__title {
 .plan-notes li.warn::marker { color: var(--tc-warn); }
 .plan-notes li.good::marker { color: var(--tc-pos); }
 
+.plan-pill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 34px;
+  padding: 0 10px;
+  border-radius: var(--tc-radius-sm);
+  font-size: 12px;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  border: 1px solid var(--tc-line);
+  background: var(--tc-surface);
+  color: var(--tc-muted);
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.plan-pill strong { color: var(--tc-ink); font-weight: 700; }
+.plan-pill.good { background: var(--tc-pos-tint); color: var(--tc-pos); border-color: transparent; }
+.plan-pill.good strong { color: var(--tc-pos); }
+.plan-pill.warn { background: var(--tc-warn-tint); color: var(--tc-warn); border-color: transparent; }
+.plan-pill.bad { background: var(--tc-neg-tint); color: var(--tc-neg); border-color: transparent; }
+
+.plan-hint {
+  font-size: 11px;
+  color: var(--tc-muted);
+  line-height: 1.4;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+.plan-hint strong { color: var(--tc-ink); font-weight: 700; }
+
+.plan-impact {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.plan-impact-item {
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 8px 10px;
+  border-radius: var(--tc-radius-sm);
+  border: 1px solid var(--tc-line);
+  background: var(--tc-surface);
+  color: var(--tc-muted);
+}
+.plan-impact-item.good { background: var(--tc-pos-tint); color: var(--tc-pos); border-color: transparent; }
+.plan-impact-item.warn { background: var(--tc-warn-tint); color: var(--tc-warn); border-color: transparent; }
+.plan-impact-item.bad { background: var(--tc-neg-tint); color: var(--tc-neg); border-color: transparent; }
+
+.plan-summary.plan-final {
+  background: var(--tc-surface);
+}
+.plan-summary.plan-final .cell .k { color: var(--tc-accent, var(--tc-ink)); }
+.plan-summary.plan-final .cell .v { color: var(--tc-ink); }
+
 .price-track {
   position: relative;
   height: 56px;

--- a/trading.html
+++ b/trading.html
@@ -208,17 +208,34 @@
                 <div class="ff-grid cols-3">
                   <div class="ff"><label>Entry</label><input id="p-entry" type="number" step="any" placeholder="0.00"></div>
                   <div class="ff"><label>Stop Loss</label><input id="p-sl" type="number" step="any" placeholder="0.00"></div>
-                  <div class="ff"><label>Take Profit</label><input id="p-tp" type="number" step="any" placeholder="opcjonalnie"></div>
+                  <div class="ff"><label>Ryzyko % kapitału</label><input id="p-riskpct" type="number" step="0.01" placeholder="1.00"></div>
                 </div>
                 <div class="ff-grid cols-3" style="margin-top:10px;">
-                  <div class="ff"><label>Ryzyko % kapitału</label><input id="p-riskpct" type="number" step="0.01" placeholder="1.00"></div>
                   <div class="ff"><label>Dźwignia (×)</label><input id="p-lev" type="number" min="1" step="1" value="1"></div>
                   <div class="ff"><label>Data</label><input id="p-date" type="date"></div>
+                  <div class="ff"><label>&nbsp;</label><div id="p-suggest-tp" class="plan-pill neutral">Sugerowany TP pojawi się po ustawieniu Entry + SL</div></div>
                 </div>
                 <div class="ff" style="margin-top:10px;">
                   <label>Notatka setupu</label>
                   <input id="p-note" type="text" placeholder="Setup, trigger, invalidation…">
                 </div>
+              </div>
+
+              <div class="plan-section">
+                <div class="plan-section-title">Nadpisanie (opcjonalne) — trafia do logu transakcji</div>
+                <div class="ff-grid">
+                  <div class="ff">
+                    <label>Position size (USD, notional)</label>
+                    <input id="p-size-override" type="number" step="any" placeholder="auto">
+                    <div id="p-size-hint" class="plan-hint">Zostaw puste, aby użyć wartości obliczonej przez aplikację.</div>
+                  </div>
+                  <div class="ff">
+                    <label>Final TP</label>
+                    <input id="p-tp" type="number" step="any" placeholder="auto (sugerowany)">
+                    <div id="p-tp-hint" class="plan-hint">Puste = TP jak sugerowany (min RR z ustawień).</div>
+                  </div>
+                </div>
+                <div id="p-override-impact" class="plan-impact" style="margin-top:10px;"></div>
               </div>
             </section>
 
@@ -246,6 +263,11 @@
                 <div class="cell"><div class="k">Risk $</div><div class="v mono" id="p-riskusd">—</div></div>
                 <div class="cell"><div class="k">Reward $</div><div class="v mono" id="p-rewardusd">—</div></div>
                 <div class="cell"><div class="k">Breakeven po prowizji</div><div class="v mono" id="p-be">—</div></div>
+              </div>
+              <div class="plan-summary plan-final">
+                <div class="cell"><div class="k">Final TP → log</div><div class="v mono" id="p-final-tp">—</div></div>
+                <div class="cell"><div class="k">Final size (base) → log</div><div class="v mono" id="p-final-size">—</div></div>
+                <div class="cell"><div class="k">Final notional → log</div><div class="v mono" id="p-final-notional">—</div></div>
               </div>
 
               <div class="plan-verdict">

--- a/trading.js
+++ b/trading.js
@@ -614,7 +614,8 @@ function updatePlanner() {
   const el = id => document.getElementById(id);
   const entry = numberNullable(el('p-entry').value);
   const sl = numberNullable(el('p-sl').value);
-  const tp = numberNullable(el('p-tp').value);
+  const tpOverride = numberNullable(el('p-tp').value);
+  const sizeUsdOverride = numberNullable(el('p-size-override').value);
   const lev = Math.max(1, numberOr(el('p-lev').value, 1));
   const riskPctRaw = numberNullable(el('p-riskpct').value);
   const riskPct = riskPctRaw !== null ? riskPctRaw : settings.maxRiskPct;
@@ -623,57 +624,132 @@ function updatePlanner() {
   const capital = settings.capital; // equity-based? use capital for planner simplicity
   const riskUSD = capital * (riskPct / 100);
 
-  let riskPerUnit = null, rewardPerUnit = null;
-  if (entry !== null && sl !== null) riskPerUnit = Math.abs(entry - sl);
-  if (entry !== null && tp !== null) rewardPerUnit = Math.abs(tp - entry);
+  const riskPerUnit = (entry !== null && sl !== null) ? Math.abs(entry - sl) : null;
 
-  // Direction sanity
+  // Suggested TP from minRR setting
+  const suggestedTP = (entry !== null && sl !== null && riskPerUnit !== null && riskPerUnit > 0)
+    ? (planDir === 'long' ? entry + riskPerUnit * settings.minRR : entry - riskPerUnit * settings.minRR)
+    : null;
+
+  // Effective TP = override or suggested
+  const effectiveTP = tpOverride !== null ? tpOverride : suggestedTP;
+  const rewardPerUnit = (entry !== null && effectiveTP !== null) ? Math.abs(effectiveTP - entry) : null;
+
+  // Direction sanity (uses override TP if provided, otherwise don't flag the suggestion)
   const dirValid = (() => {
     if (entry === null || sl === null) return { ok: true };
     if (planDir === 'long' && sl >= entry) return { ok: false, msg: 'Dla LONG, SL musi być poniżej entry' };
     if (planDir === 'short' && sl <= entry) return { ok: false, msg: 'Dla SHORT, SL musi być powyżej entry' };
-    if (tp !== null) {
-      if (planDir === 'long' && tp <= entry) return { ok: false, msg: 'Dla LONG, TP musi być powyżej entry' };
-      if (planDir === 'short' && tp >= entry) return { ok: false, msg: 'Dla SHORT, TP musi być poniżej entry' };
+    if (tpOverride !== null) {
+      if (planDir === 'long' && tpOverride <= entry) return { ok: false, msg: 'Dla LONG, TP musi być powyżej entry' };
+      if (planDir === 'short' && tpOverride >= entry) return { ok: false, msg: 'Dla SHORT, TP musi być poniżej entry' };
     }
     return { ok: true };
   })();
 
-  const size = (riskPerUnit && riskPerUnit > 0) ? riskUSD / riskPerUnit : null;
-  const rr = (riskPerUnit && rewardPerUnit && riskPerUnit > 0) ? rewardPerUnit / riskPerUnit : null;
-  const notional = (size !== null && entry !== null) ? size * entry : null;
-  const margin = (notional !== null) ? notional / lev : null;
-  const rewardUSD = (size !== null && rewardPerUnit !== null) ? size * rewardPerUnit : null;
-  const actualRiskUSD = (size !== null && riskPerUnit !== null) ? size * riskPerUnit : null;
+  // Calculated (auto) position sizing from risk% + SL distance
+  const calcSize = (riskPerUnit && riskPerUnit > 0) ? riskUSD / riskPerUnit : null;
+  const calcNotional = (calcSize !== null && entry !== null) ? calcSize * entry : null;
 
+  // Effective size / notional: use USD override if provided, else computed
+  let effSize = calcSize;
+  let effNotional = calcNotional;
+  if (sizeUsdOverride !== null && sizeUsdOverride > 0 && entry !== null) {
+    effNotional = sizeUsdOverride;
+    effSize = sizeUsdOverride / entry;
+  }
+
+  const rr = (riskPerUnit && rewardPerUnit && riskPerUnit > 0) ? rewardPerUnit / riskPerUnit : null;
+  const margin = (effNotional !== null) ? effNotional / lev : null;
+  const rewardUSD = (effSize !== null && rewardPerUnit !== null) ? effSize * rewardPerUnit : null;
+  const actualRiskUSD = (effSize !== null && riskPerUnit !== null) ? effSize * riskPerUnit : null;
+  const actualRiskPct = (actualRiskUSD !== null && capital > 0) ? (actualRiskUSD / capital) * 100 : null;
+
+  // Suggested TP pill
+  const suggestPill = el('p-suggest-tp');
+  if (suggestedTP !== null && dirValid.ok) {
+    suggestPill.className = 'plan-pill good';
+    suggestPill.innerHTML = `Sugerowany TP (min ${settings.minRR}R): <strong>${fmtNum(suggestedTP, suggestedTP < 1 ? 6 : 2)}</strong>`;
+  } else if (!dirValid.ok) {
+    suggestPill.className = 'plan-pill bad';
+    suggestPill.textContent = dirValid.msg;
+  } else {
+    suggestPill.className = 'plan-pill neutral';
+    suggestPill.textContent = 'Sugerowany TP pojawi się po ustawieniu Entry + SL';
+  }
+
+  // Summary cells
   el('p-rpu').textContent = riskPerUnit !== null ? fmtNum(riskPerUnit, riskPerUnit < 1 ? 6 : 2) : '—';
   el('p-wpu').textContent = rewardPerUnit !== null ? fmtNum(rewardPerUnit, rewardPerUnit < 1 ? 6 : 2) : '—';
   el('p-rr').textContent = rr !== null ? rr.toFixed(2) : '—';
-  el('p-size').textContent = size !== null ? fmtQty(size) : '—';
-  el('p-notional').textContent = notional !== null ? fmtUSD(notional) : '—';
+  el('p-size').textContent = effSize !== null ? fmtQty(effSize) : '—';
+  el('p-notional').textContent = effNotional !== null ? fmtUSD(effNotional) : '—';
   el('p-margin').textContent = margin !== null ? fmtUSD(margin) : '—';
   el('p-riskusd').textContent = actualRiskUSD !== null ? fmtUSD(-actualRiskUSD) : '—';
   el('p-rewardusd').textContent = rewardUSD !== null ? fmtUSD(rewardUSD, true) : '—';
   el('p-be').textContent = entry !== null ? fmtNum(entry, entry < 1 ? 6 : 2) : '—';
 
+  // Final values that will go to the trade log
+  el('p-final-tp').textContent = effectiveTP !== null ? fmtNum(effectiveTP, effectiveTP < 1 ? 6 : 2) : '—';
+  el('p-final-size').textContent = effSize !== null ? fmtQty(effSize) : '—';
+  el('p-final-notional').textContent = effNotional !== null ? fmtUSD(effNotional) : '—';
+
+  // Hint text under override inputs
+  el('p-size-hint').innerHTML = calcNotional !== null
+    ? `Auto: <strong>${fmtUSD(calcNotional)}</strong> notional · <strong>${fmtQty(calcSize)}</strong> szt. (z ${riskPct.toFixed(2)}% kapitału w SL, dźwignia ${lev}×)`
+    : 'Zostaw puste, aby użyć wartości obliczonej przez aplikację.';
+  el('p-tp-hint').innerHTML = suggestedTP !== null
+    ? `Auto: <strong>${fmtNum(suggestedTP, suggestedTP < 1 ? 6 : 2)}</strong> (min ${settings.minRR}R)`
+    : 'Puste = TP jak sugerowany (min RR z ustawień).';
+
+  // Override impact messages
+  const impact = [];
+  if (tpOverride !== null && rr !== null) {
+    if (rr + 1e-9 < settings.minRR) {
+      impact.push({ k: 'bad', m: `Nadpisany TP daje RR ${rr.toFixed(2)} — poniżej celu ${settings.minRR}R` });
+    } else {
+      impact.push({ k: 'good', m: `Nadpisany TP daje RR ${rr.toFixed(2)} — spełnia min. ${settings.minRR}R` });
+    }
+  }
+  if (sizeUsdOverride !== null && actualRiskPct !== null) {
+    const deltaPct = actualRiskPct - riskPct;
+    if (actualRiskPct > settings.maxRiskPct + 1e-9) {
+      impact.push({ k: 'bad', m: `Nadpisany size = ryzyko ${actualRiskPct.toFixed(2)}% kapitału — łamie limit ${settings.maxRiskPct}%` });
+    } else if (Math.abs(deltaPct) > 0.001) {
+      impact.push({ k: 'warn', m: `Nadpisany size = ryzyko ${actualRiskPct.toFixed(2)}% kapitału (cel: ${riskPct.toFixed(2)}%)` });
+    } else {
+      impact.push({ k: 'good', m: `Nadpisany size zgadza się z celem ryzyka (${actualRiskPct.toFixed(2)}%)` });
+    }
+    if (margin !== null && capital > 0) {
+      impact.push({ k: margin > capital ? 'bad' : 'warn', m: `Wymagana margin: ${fmtUSD(margin)} (${((margin / capital) * 100).toFixed(1)}% kapitału) przy dźwigni ${lev}×` });
+    }
+  }
+  const impactEl = el('p-override-impact');
+  if (impact.length) {
+    impactEl.innerHTML = impact.map(i => `<div class="plan-impact-item ${i.k}">${esc(i.m)}</div>`).join('');
+  } else {
+    impactEl.innerHTML = '<div class="plan-impact-item neutral">Brak nadpisań — używane będą wartości z auto-kalkulacji.</div>';
+  }
+
   // Price track
   const ptWrap = el('p-price-track');
+  const tpForTrack = effectiveTP;
   if (entry !== null && sl !== null) {
     const vals = [entry, sl];
-    if (tp !== null) vals.push(tp);
+    if (tpForTrack !== null) vals.push(tpForTrack);
     const lo = Math.min(...vals), hi = Math.max(...vals);
     const pad = (hi - lo) * 0.25 || entry * 0.01;
     const a = lo - pad, b = hi + pad, span = b - a || 1;
     const pos = x => ((x - a) / span) * 100;
-    const entryPos = pos(entry), slPos = pos(sl), tpPos = tp !== null ? pos(tp) : null;
-    const slIsBelow = sl < entry;
+    const entryPos = pos(entry), slPos = pos(sl), tpPos = tpForTrack !== null ? pos(tpForTrack) : null;
     const slLeft = Math.min(slPos, entryPos), slWidth = Math.abs(entryPos - slPos);
     let tpHtml = '';
-    if (tp !== null) {
+    if (tpForTrack !== null) {
       const tpLeft = Math.min(tpPos, entryPos);
       const tpWidth = Math.abs(entryPos - tpPos);
       tpHtml = `<div class="tp" style="left:${tpLeft}%; width:${tpWidth}%;"></div>`;
     }
+    const tpKind = tpOverride !== null ? 'override' : 'sugerowany';
     ptWrap.innerHTML = `
       <div class="price-track">
         <div class="axis">
@@ -682,29 +758,30 @@ function updatePlanner() {
         </div>
         <div class="marker sl" style="left:${slPos}%;"></div>
         <div class="marker entry" style="left:${entryPos}%;"></div>
-        ${tp !== null ? `<div class="marker tp" style="left:${tpPos}%;"></div>` : ''}
+        ${tpForTrack !== null ? `<div class="marker tp" style="left:${tpPos}%;"></div>` : ''}
         <div class="label lt sl" style="left:${slPos}%;">SL ${fmtNum(sl, sl < 1 ? 4 : 2)}</div>
         <div class="label lt entry" style="left:${entryPos}%;">ENTRY ${fmtNum(entry, entry < 1 ? 4 : 2)}</div>
-        ${tp !== null ? `<div class="label lt tp" style="left:${tpPos}%;">TP ${fmtNum(tp, tp < 1 ? 4 : 2)}</div>` : ''}
+        ${tpForTrack !== null ? `<div class="label lt tp" style="left:${tpPos}%;">TP ${fmtNum(tpForTrack, tpForTrack < 1 ? 4 : 2)} (${tpKind})</div>` : ''}
         <div class="label" style="left:${slPos}%;">-${fmtNum(Math.abs(entry - sl) / entry * 100)}%</div>
         <div class="label" style="left:${entryPos}%;">0%</div>
-        ${tp !== null ? `<div class="label" style="left:${tpPos}%;">+${fmtNum(Math.abs(tp - entry) / entry * 100)}%</div>` : ''}
+        ${tpForTrack !== null ? `<div class="label" style="left:${tpPos}%;">+${fmtNum(Math.abs(tpForTrack - entry) / entry * 100)}%</div>` : ''}
       </div>`;
   } else {
     ptWrap.innerHTML = `<div style="height:56px; background:var(--tc-surface); border-radius:8px; display:flex; align-items:center; justify-content:center; color:var(--tc-muted-2); font-size:12px;">Uzupełnij Entry + SL aby zobaczyć wizualizację</div>`;
   }
 
-  // Score
+  // Score + issues
   const issues = [];
   if (!dirValid.ok) issues.push({ k: 'bad', m: dirValid.msg });
   let score = 50;
   if (rr !== null) {
-    if (rr >= settings.minRR) { score += 25; issues.push({ k: 'good', m: `RR ${rr.toFixed(2)} spełnia minimum ${settings.minRR}` }); }
+    if (rr + 1e-9 >= settings.minRR) { score += 25; issues.push({ k: 'good', m: `RR ${rr.toFixed(2)} spełnia minimum ${settings.minRR}` }); }
     else if (rr >= settings.minRR * 0.7) { score += 10; issues.push({ k: 'warn', m: `RR ${rr.toFixed(2)} poniżej minimum (${settings.minRR})` }); }
     else { score -= 15; issues.push({ k: 'bad', m: `RR ${rr.toFixed(2)} znacznie poniżej min. ${settings.minRR}` }); }
   }
-  if (riskPct > settings.maxRiskPct) { score -= 20; issues.push({ k: 'bad', m: `Ryzyko ${riskPct.toFixed(2)}% przekracza limit ${settings.maxRiskPct}%` }); }
-  else if (riskPct <= settings.maxRiskPct) { score += 10; }
+  const effRiskPctForScore = actualRiskPct !== null ? actualRiskPct : riskPct;
+  if (effRiskPctForScore > settings.maxRiskPct + 1e-9) { score -= 20; issues.push({ k: 'bad', m: `Ryzyko ${effRiskPctForScore.toFixed(2)}% przekracza limit ${settings.maxRiskPct}%` }); }
+  else { score += 10; }
   if (margin !== null && margin > capital * 0.5) { score -= 10; issues.push({ k: 'warn', m: 'Margin > 50% kapitału – wysoka ekspozycja' }); }
   if (lev > 10) { score -= 10; issues.push({ k: 'warn', m: `Dźwignia ${lev}× – uważaj na liquidation` }); }
   score = clamp(Math.round(score), 0, 100);
@@ -722,14 +799,15 @@ function updatePlanner() {
     notesEl.textContent = 'Uzupełnij entry, stop i TP aby zobaczyć kalkulację i walidację setupu.';
   }
 
-  // Add button
-  const canAdd = dirValid.ok && entry !== null && sl !== null && size !== null && size > 0 && el('p-ticker').value.trim();
+  // Add button — store final size and final TP for submission
+  const canAdd = dirValid.ok && entry !== null && sl !== null && effSize !== null && effSize > 0 && el('p-ticker').value.trim();
   el('p-add-btn').disabled = !canAdd;
-  el('p-add-btn').dataset.size = size !== null ? size : '';
+  el('p-add-btn').dataset.size = effSize !== null ? effSize : '';
+  el('p-add-btn').dataset.tp = effectiveTP !== null ? effectiveTP : '';
 }
 
 function clearPlanner() {
-  ['p-ticker', 'p-entry', 'p-sl', 'p-tp', 'p-riskpct', 'p-note'].forEach(id => document.getElementById(id).value = '');
+  ['p-ticker', 'p-entry', 'p-sl', 'p-tp', 'p-riskpct', 'p-note', 'p-size-override'].forEach(id => document.getElementById(id).value = '');
   document.getElementById('p-lev').value = 1;
   document.getElementById('p-date').value = today();
   setPlanDir('long');
@@ -740,13 +818,15 @@ function addTradeFromPlanner() {
   const entry = numberNullable(el('p-entry').value);
   const sl = numberNullable(el('p-sl').value);
   const size = Number(el('p-add-btn').dataset.size);
+  const tpDs = el('p-add-btn').dataset.tp;
+  const tp = tpDs ? Number(tpDs) : null;
   if (!entry || !sl || !size) return;
   const t = normalizeTrade({
     ticker: el('p-ticker').value.trim(),
     direction: planDir,
     leverage: numberOr(el('p-lev').value, 1),
     entry, sl,
-    tp: numberNullable(el('p-tp').value),
+    tp: Number.isFinite(tp) ? tp : null,
     size,
     date: el('p-date').value || today(),
     note: el('p-note').value.trim()
@@ -1251,7 +1331,7 @@ function init() {
   document.getElementById('filter-search').addEventListener('input', e => { tradeFilters.q = e.target.value; renderTradesTable(); });
 
   // Planner listeners
-  ['p-ticker', 'p-entry', 'p-sl', 'p-tp', 'p-riskpct', 'p-lev', 'p-date', 'p-note'].forEach(id => {
+  ['p-ticker', 'p-entry', 'p-sl', 'p-tp', 'p-riskpct', 'p-lev', 'p-date', 'p-note', 'p-size-override'].forEach(id => {
     document.getElementById(id).addEventListener('input', updatePlanner);
   });
   document.getElementById('p-date').value = today();


### PR DESCRIPTION
## Summary
Enhanced the trade planner with optional position size and take-profit overrides, along with real-time impact analysis. The planner now distinguishes between auto-calculated values and user-provided overrides, displaying suggested TP based on minimum risk-reward settings and warning when overrides violate risk constraints.

## Key Changes

- **Position Size Override**: Added `p-size-override` input to allow manual USD notional entry, with auto-calculated fallback based on risk% and SL distance
- **TP Override System**: Renamed `tp` to `tpOverride` and introduced `suggestedTP` calculated from minRR setting; effective TP uses override if provided, otherwise suggested value
- **Impact Analysis**: New `p-override-impact` section displays warnings/confirmations when overrides are used:
  - TP override RR validation against minRR setting
  - Size override risk% vs. maxRiskPct limit checking
  - Margin requirement display relative to capital
- **Suggested TP Pill**: Visual indicator (`p-suggest-tp`) showing auto-calculated TP or validation errors
- **Hint Text**: Dynamic hints under override inputs showing auto-calculated values and rationale
- **Final Values Section**: New summary row displaying final TP, size, and notional that will be logged to trade history
- **Enhanced Scoring**: Risk% calculation now uses actual risk from size override if provided, with epsilon tolerance for floating-point comparisons
- **Price Track Labels**: TP visualization now indicates whether it's "override" or "sugerowany" (suggested)

## Implementation Details

- Refactored size/notional calculation into `calcSize`/`calcNotional` (auto) vs. `effSize`/`effNotional` (effective with override)
- Added `actualRiskPct` calculation to reflect real risk when size is overridden
- Impact messages use severity levels (good/warn/bad) with conditional display logic
- Button dataset now stores both final size and final TP for trade submission
- Cleared planner now includes `p-size-override` field reset
- Added `p-size-override` to input listeners for real-time recalculation
- New CSS classes: `.plan-pill`, `.plan-hint`, `.plan-impact`, `.plan-impact-item`, `.plan-final` for styling overrides and impact feedback

https://claude.ai/code/session_01FEex1UZy9r2fjNJKfxHZgr