### PR TITLE
Integrate Day Trading group and import P&L from Trading module

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -119,11 +119,12 @@
     #inv-kpi-roi-card { position:relative; padding-right:128px; align-items:flex-start; gap:4px; }
     #inv-kpi-roi-card .inv-kpi-label { white-space:nowrap; }
     #inv-kpi-roi-card .inv-kpi-value { margin-top:0; }
-    #inv-kpi-roi-foot { font-size:11px; color:var(--muted); }
     #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split { position:absolute; right:16px; top:14px; margin:0; display:flex; flex-direction:column; align-items:flex-end; gap:2px; line-height:1.1; font-size:10px; }
+    .inv-kpi-roi-note { margin-top:4px; font-size:10px; color:var(--muted); max-width:104px; text-align:right; line-height:1.15; white-space:normal; }
     @media(max-width:560px){
       #inv-kpi-roi-card{padding-right:16px;}
       #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split{position:static;align-items:flex-start;}
+      .inv-kpi-roi-note{text-align:left;}
     }
     .inv-kpi-card.positive .inv-kpi-value { color:#16a34a; }
     .inv-kpi-card.negative .inv-kpi-value { color:#dc2626; }
@@ -5062,7 +5063,6 @@
             <div class="inv-kpi-card" id="inv-kpi-roi-card">
               <span class="inv-kpi-label">ROI %</span>
               <span class="inv-kpi-value" id="inv-kpi-roi">—</span>
-              <span class="inv-kpi-sub" id="inv-kpi-roi-foot">Zwrot na kapitale z budżetu</span>
               <span class="inv-kpi-sub inv-kpi-sub-split" id="inv-kpi-roi-sub">Zwrot na kapitale z budżetu</span>
             </div>
           </div>
@@ -8244,7 +8244,7 @@
         <div class="inv-kpi-roi-row"><span class="inv-kpi-roi-label">ETF</span><span class="inv-kpi-roi-val-wrap"><span class="inv-kpi-roi-value">${etfTxt}</span>${placeholder}</span></div>
         <div class="inv-kpi-roi-row"><span class="inv-kpi-roi-label">Rest</span><span class="inv-kpi-roi-val-wrap"><span class="inv-kpi-roi-value">${otherTxt}</span>${cmpDelta(restVal)||placeholder}</span></div>
         <div class="inv-kpi-roi-row"><span class="inv-kpi-roi-label">Trading</span><span class="inv-kpi-roi-val-wrap"><span class="inv-kpi-roi-value">${tradingTxt}</span>${cmpDelta(tradingVal)||placeholder}</span></div>
-      </div>`;
+      </div><div class="inv-kpi-roi-note">Zwrot na kapitale z budżetu</div>`;
     }
     roiCard.className='inv-kpi-card '+(stats.roi>0?'positive':stats.roi<0?'negative':'');
   }

--- a/budget.html
+++ b/budget.html
@@ -5356,7 +5356,7 @@
                   </div>
                   <div class="table-wrapper">
                     <table class="inv-hub-table" id="inv-hub-snap-table">
-                      <thead><tr><th>Data</th><th>Wartość portfela</th><th>Zainwestowano</th><th>P&amp;L</th><th>ROI Total</th><th>ROI ETF</th><th>ROI Rest</th><th></th></tr></thead>
+                      <thead><tr><th>Data</th><th>Wartość portfela</th><th>Zainwestowano</th><th>P&amp;L</th><th>ROI Total</th><th>ROI ETF</th><th>ROI Rest</th><th>ROI Trading</th><th></th></tr></thead>
                       <tbody></tbody>
                     </table>
                   </div>
@@ -7434,7 +7434,8 @@
 
   // --- Investments v2 ----------------------------------------------------------
   const invPalette=['#2563eb','#22c55e','#f59e0b','#0ea5e9','#8b5cf6','#ef4444','#ec4899','#14b8a6'];
-  const invGroupOptions=['Akcje','Dywidenda','Krypto','Metal','Waluta','Inne'];
+  const invGroupOptions=['Akcje','Dywidenda','Krypto','Metal','Waluta','Day Trading','Inne'];
+  const INV_TRADING_KEY='lifeos_trading_v2';
   let invCapitalChart=null, invCumulativeChart=null, invAllocationChart=null, invAllocationDetailChart=null, invPnlChart=null;
   let invSelectedAllocationGroup=null;
   let invModalBound=false;
@@ -7472,6 +7473,42 @@
     return gc!==0?gc:(a.name||'').localeCompare(bb.name||'');
   });
 
+  function isDayTradingGroup(groupName){
+    return String(groupName||'').trim().toUpperCase()==='DAY TRADING';
+  }
+
+  function normalizeTradingTrade(t){
+    return {
+      entry:num(t?.entry),
+      size:Math.max(num(t?.size),0),
+      direction:t?.direction==='short'?'short':'long',
+      closings:Array.isArray(t?.closings)?t.closings:[]
+    };
+  }
+
+  function getTradingModulePnlRaw(){
+    try{
+      const parsed=JSON.parse(localStorage.getItem(INV_TRADING_KEY)||'{}');
+      const trades=Array.isArray(parsed?.trades)?parsed.trades:[];
+      let total=0;
+      for(const rawTrade of trades){
+        const trade=normalizeTradingTrade(rawTrade);
+        for(const c of trade.closings){
+          const pct=Math.max(0,Math.min(100,num(c?.pct)));
+          const closingSize=trade.size*(pct/100);
+          if(closingSize<=0) continue;
+          const closePrice=num(c?.price);
+          const commission=num(c?.commission);
+          const gross=trade.direction==='short'?(trade.entry-closePrice)*closingSize:(closePrice-trade.entry)*closingSize;
+          total+=(gross-commission);
+        }
+      }
+      return total;
+    }catch(_err){
+      return 0;
+    }
+  }
+
   function populateAssetGroupSelect(select,current){
     if(!select) return;
     const cv=current||select.value||'';
@@ -7493,6 +7530,23 @@
     const id='c_invest';
     b().categories.push({id,name:'Inwestycje',type:'saving',emoji:'📈',budget:0});
     return id;
+  }
+
+  function ensureDayTradingAsset(){
+    const data=investments();
+    const exists=(data.assets||[]).some(a=>isDayTradingGroup(a.group));
+    if(exists) return;
+    data.assets.push({
+      id:'inv_asset_day_trading',
+      name:'Day Trading',
+      group:'Day Trading',
+      currentPrice:null,
+      priceDate:null,
+      priceProvider:'nbp',
+      priceSymbol:'USD',
+      priceCurrency:'USD'
+    });
+    save(state);
   }
 
   // --- FIFO Holdings Engine --------------------------------------------------
@@ -7540,10 +7594,13 @@
     const holdings=computeHoldingsFIFO();
     const assetGroupById={};
     for(const asset of data.assets||[]) assetGroupById[asset.id]=String(asset.group||'Inne').trim().toUpperCase();
+    const dayTradingAssets=(data.assets||[]).filter(a=>isDayTradingGroup(a.group));
+    const dayTradingAssetIds=new Set(dayTradingAssets.map(a=>a.id));
     let capitalFromBudget=0, capitalReturned=0, reinvestPool=0;
-    let etfCapitalFromBudget=0, otherCapitalFromBudget=0;
+    let etfCapitalFromBudget=0, otherCapitalFromBudget=0, tradingCapitalFromBudget=0;
     for(const t of data.trades){
       const isEtf=assetGroupById[t.assetId]==='ETF';
+      const isTrading=dayTradingAssetIds.has(t.assetId);
       if(t.side==='sell'){
         if(t.sellDestination==='budget') capitalReturned+=num(t.amount);
         else reinvestPool+=num(t.amount);
@@ -7552,38 +7609,65 @@
         else {
           const amount=num(t.amount);
           capitalFromBudget+=amount;
-          if(isEtf) etfCapitalFromBudget+=amount;
+          if(isTrading) tradingCapitalFromBudget+=amount;
+          else if(isEtf) etfCapitalFromBudget+=amount;
           else otherCapitalFromBudget+=amount;
         }
       }
     }
+    const primaryTradingAsset=dayTradingAssets[0]||null;
+    const tradingCurrency=String(primaryTradingAsset?.priceCurrency||'USD').trim().toUpperCase()||'USD';
+    const tradingFxRate=tradingCurrency==='PLN'?1:Math.max(num(primaryTradingAsset?.currentPrice),0);
+    const tradingPnlSourceRaw=getTradingModulePnlRaw();
+    const tradingPnlConverted=(tradingCurrency==='PLN'?tradingPnlSourceRaw:tradingPnlSourceRaw*tradingFxRate);
+    const tradingConfigReady=tradingCurrency==='PLN'||tradingFxRate>0;
+
+    const dayTradingCostBasis=holdings
+      .filter(h=>dayTradingAssetIds.has(h.id))
+      .reduce((s,h)=>s+h.costBasis,0);
+    if(dayTradingCostBasis>0){
+      for(const h of holdings){
+        if(!dayTradingAssetIds.has(h.id)) continue;
+        const share=h.costBasis/dayTradingCostBasis;
+        const ownPnl=tradingConfigReady?(tradingPnlConverted*share):0;
+        h.marketValue=h.costBasis+ownPnl;
+        h.unrealizedPnl=ownPnl;
+      }
+    }
+
     const totalCostBasis=holdings.reduce((s,h)=>s+h.costBasis,0);
-    const hasAnyPrice=holdings.some(h=>h.currentPrice&&h.qty>0);
+    const hasAnyPrice=holdings.some(h=>(h.marketValue!==null||h.currentPrice)&&h.qty>0);
     const totalMarketValue=holdings.reduce((s,h)=>s+(h.marketValue!==null?h.marketValue:h.costBasis),0);
     const totalRealizedPnl=holdings.reduce((s,h)=>s+h.realizedPnl,0);
     const totalUnrealizedPnl=hasAnyPrice?(totalMarketValue-totalCostBasis):null;
     const totalPnl=totalRealizedPnl+(totalUnrealizedPnl||0);
     const roi=capitalFromBudget>0?((totalPnl/capitalFromBudget)*100):0;
     const etfHoldings=holdings.filter(h=>String(h.group||'').trim().toUpperCase()==='ETF');
-    const otherHoldings=holdings.filter(h=>String(h.group||'').trim().toUpperCase()!=='ETF');
+    const tradingHoldings=holdings.filter(h=>dayTradingAssetIds.has(h.id));
+    const otherHoldings=holdings.filter(h=>String(h.group||'').trim().toUpperCase()!=='ETF'&&!dayTradingAssetIds.has(h.id));
     const etfMarketValue=etfHoldings.reduce((s,h)=>s+(h.marketValue!==null?h.marketValue:h.costBasis),0);
     const otherMarketValue=otherHoldings.reduce((s,h)=>s+(h.marketValue!==null?h.marketValue:h.costBasis),0);
     const etfCostBasis=etfHoldings.reduce((s,h)=>s+h.costBasis,0);
     const otherCostBasis=otherHoldings.reduce((s,h)=>s+h.costBasis,0);
     const etfRealizedPnl=etfHoldings.reduce((s,h)=>s+h.realizedPnl,0);
     const otherRealizedPnl=otherHoldings.reduce((s,h)=>s+h.realizedPnl,0);
+    const tradingRealizedPnl=tradingHoldings.reduce((s,h)=>s+h.realizedPnl,0);
     const etfUnrealizedPnl=etfHoldings.some(h=>h.currentPrice&&h.qty>0)?(etfMarketValue-etfCostBasis):null;
     const otherUnrealizedPnl=otherHoldings.some(h=>h.currentPrice&&h.qty>0)?(otherMarketValue-otherCostBasis):null;
+    const tradingUnrealizedPnl=tradingHoldings.length?(tradingHoldings.reduce((s,h)=>s+((h.marketValue!==null?h.marketValue:h.costBasis)-h.costBasis),0)):null;
     const etfTotalPnl=etfRealizedPnl+(etfUnrealizedPnl||0);
     const otherTotalPnl=otherRealizedPnl+(otherUnrealizedPnl||0);
+    const tradingTotalPnl=tradingRealizedPnl+(tradingUnrealizedPnl||0);
     const etfRoi=etfCapitalFromBudget>0?(etfTotalPnl/etfCapitalFromBudget)*100:null;
     const otherRoi=otherCapitalFromBudget>0?(otherTotalPnl/otherCapitalFromBudget)*100:null;
+    const tradingRoi=tradingCapitalFromBudget>0?(tradingTotalPnl/tradingCapitalFromBudget)*100:null;
     return {holdings,capitalFromBudget,capitalReturned,netFromBudget:capitalFromBudget-capitalReturned,
       reinvestPool:Math.max(0,reinvestPool),totalCostBasis,totalMarketValue,hasAnyPrice,
       totalRealizedPnl,totalUnrealizedPnl,totalPnl,roi,
       roiBreakdown:{
-        etfRoi,otherRoi,etfCapitalFromBudget,otherCapitalFromBudget,
-        etfTotalPnl,otherTotalPnl,etfRealizedPnl,otherRealizedPnl
+        etfRoi,otherRoi,tradingRoi,etfCapitalFromBudget,otherCapitalFromBudget,tradingCapitalFromBudget,
+        etfTotalPnl,otherTotalPnl,tradingTotalPnl,etfRealizedPnl,otherRealizedPnl,tradingRealizedPnl,
+        tradingPnlSourceRaw,tradingCurrency,tradingFxRate:tradingCurrency==='PLN'?1:(tradingConfigReady?tradingFxRate:null)
       }};
   }
 
@@ -7979,7 +8063,12 @@
     const provider=String(asset.priceProvider||'manual');
     const symbol=String(asset.priceSymbol||'').trim();
     const currency=String(asset.priceCurrency||state.currency||'PLN').trim().toLowerCase();
+    const dayTradingAsset=isDayTradingGroup(asset.group);
     if(provider==='manual') return {price:null,skipped:true};
+    if(dayTradingAsset&&provider==='nbp'){
+      const srcCode=String(asset.priceCurrency||symbol||'USD').trim().toUpperCase();
+      return {price:await fetchNbpFxPrice(srcCode),currency:'PLN'};
+    }
     if(!symbol) return {price:null,error:'Brak symbolu API'};
     try{
       if(provider==='stooq'){
@@ -8125,12 +8214,8 @@
     if(roiSub){
       const etfTxt=stats.roiBreakdown?.etfRoi===null?'—':`${stats.roiBreakdown.etfRoi.toFixed(1)}%`;
       const otherTxt=stats.roiBreakdown?.otherRoi===null?'—':`${stats.roiBreakdown.otherRoi.toFixed(1)}%`;
-      let deltaHtml='';
-      if(stats.roiBreakdown?.etfRoi!==null&&stats.roiBreakdown?.otherRoi!==null){
-        if(stats.roiBreakdown.otherRoi>stats.roiBreakdown.etfRoi) deltaHtml='<span class="inv-kpi-roi-delta up" title="Rest lepszy od ETF">▲</span>';
-        else if(stats.roiBreakdown.otherRoi<stats.roiBreakdown.etfRoi) deltaHtml='<span class="inv-kpi-roi-delta down" title="Rest słabszy od ETF">▼</span>';
-      }
-      roiSub.innerHTML=`<span class="inv-kpi-roi-mini">ETF <b>${etfTxt}</b></span><span class="inv-kpi-roi-mini">Rest <b>${otherTxt}</b></span>${deltaHtml}`;
+      const tradingTxt=stats.roiBreakdown?.tradingRoi===null?'—':`${stats.roiBreakdown.tradingRoi.toFixed(1)}%`;
+      roiSub.innerHTML=`<span class="inv-kpi-roi-mini">ETF <b>${etfTxt}</b></span><span class="inv-kpi-roi-mini">Rest <b>${otherTxt}</b></span><span class="inv-kpi-roi-mini">Trading <b>${tradingTxt}</b></span>`;
     }
     roiCard.className='inv-kpi-card '+(stats.roi>0?'positive':stats.roi<0?'negative':'');
   }
@@ -8416,6 +8501,41 @@
     preview.innerHTML=html;
   }
 
+  function updateInvBuyFormForAsset(){
+    const form=document.getElementById('inv-buy-form');
+    if(!form) return;
+    const assetId=form.querySelector('select[name="assetId"]')?.value;
+    const asset=investments().assets.find(a=>a.id===assetId);
+    const qtyInput=form.querySelector('input[name="quantity"]');
+    const qtyLabel=qtyInput?.closest('label');
+    const amountInput=form.querySelector('input[name="amount"]');
+    const footnote=document.getElementById('inv-buy-footnote');
+    const isDayTrading=!!asset&&isDayTradingGroup(asset.group);
+    if(qtyInput){
+      qtyInput.required=!isDayTrading;
+      qtyInput.readOnly=isDayTrading;
+      qtyInput.placeholder=isDayTrading?'auto':'0';
+      if(isDayTrading&&amountInput){
+        const amount=Math.abs(num(amountInput.value));
+        qtyInput.value=amount>0?String(amount):'';
+      }
+    }
+    if(qtyLabel){
+      qtyLabel.childNodes[0].nodeValue=isDayTrading?'Jednostki kapitału':'Ilość';
+      qtyLabel.title=isDayTrading?'Dla Day Trading ilość jest liczona automatycznie = kwota kapitału.':'';
+    }
+    if(footnote){
+      if(isDayTrading){
+        footnote.textContent='Day Trading: wpłata księgowana jak zwykły zakup, a P&L pobierany z modułu trading.html (waluta i kurs z konfiguracji aktywa).';
+      } else {
+        const srcSel=form.querySelector('select[name="fundSource"]');
+        footnote.textContent=srcSel?.value==='reinvest'
+          ?'Źródło: pula reinwestycyjna — jeśli kwota przekroczy pulę, reszta zostanie pobrana z budżetu.'
+          :'Źródło: budżet — kwota zostanie zaksięgowana jako inwestycja.';
+      }
+    }
+  }
+
   // --- Charts ----------------------------------------------------------------
   function invMonthKey(dateStr){
     const d=new Date(dateStr||new Date());
@@ -8593,10 +8713,13 @@
       costBasis:stats.totalCostBasis,
       etfRoi:stats.roiBreakdown?.etfRoi??null,
       restRoi:stats.roiBreakdown?.otherRoi??null,
+      tradingRoi:stats.roiBreakdown?.tradingRoi??null,
       etfCapitalFromBudget:stats.roiBreakdown?.etfCapitalFromBudget??0,
       restCapitalFromBudget:stats.roiBreakdown?.otherCapitalFromBudget??0,
+      tradingCapitalFromBudget:stats.roiBreakdown?.tradingCapitalFromBudget??0,
       etfTotalPnl:stats.roiBreakdown?.etfTotalPnl??0,
-      restTotalPnl:stats.roiBreakdown?.otherTotalPnl??0
+      restTotalPnl:stats.roiBreakdown?.otherTotalPnl??0,
+      tradingTotalPnl:stats.roiBreakdown?.tradingTotalPnl??0
     };
     if(existing>=0) snaps[existing]=snap;
     else snaps.push(snap);
@@ -8968,12 +9091,15 @@
           const roiCls=s.roi>=0?'inv-pnl-pos':'inv-pnl-neg';
           const etfRoiNum=Number(s.etfRoi);
           const restRoiNum=Number(s.restRoi);
+          const tradingRoiNum=Number(s.tradingRoi);
           const hasEtfRoi=Number.isFinite(etfRoiNum);
           const hasRestRoi=Number.isFinite(restRoiNum);
+          const hasTradingRoi=Number.isFinite(tradingRoiNum);
           const etfRoiCls=hasEtfRoi?(etfRoiNum>=0?'inv-pnl-pos':'inv-pnl-neg'):'';
           const restRoiCls=hasRestRoi?(restRoiNum>=0?'inv-pnl-pos':'inv-pnl-neg'):'';
+          const tradingRoiCls=hasTradingRoi?(tradingRoiNum>=0?'inv-pnl-pos':'inv-pnl-neg'):'';
           const tr=document.createElement('tr');
-          tr.innerHTML=`<td>${s.date}</td><td>${fmt(s.portfolioValue,cur)}</td><td>${fmt(s.capitalFromBudget,cur)}</td><td class="${pnlCls}">${s.totalPnl>=0?'+':''}${fmt(s.totalPnl,cur)}</td><td class="${roiCls}">${s.roi.toFixed(2)}%</td><td class="${etfRoiCls}">${hasEtfRoi?`${etfRoiNum.toFixed(2)}%`:'—'}</td><td class="${restRoiCls}">${hasRestRoi?`${restRoiNum.toFixed(2)}%`:'—'}</td><td><button class="btn ghost" style="font-size:10px;padding:2px 6px" data-snap-del="${s.date}">Usuń</button></td>`;
+          tr.innerHTML=`<td>${s.date}</td><td>${fmt(s.portfolioValue,cur)}</td><td>${fmt(s.capitalFromBudget,cur)}</td><td class="${pnlCls}">${s.totalPnl>=0?'+':''}${fmt(s.totalPnl,cur)}</td><td class="${roiCls}">${s.roi.toFixed(2)}%</td><td class="${etfRoiCls}">${hasEtfRoi?`${etfRoiNum.toFixed(2)}%`:'—'}</td><td class="${restRoiCls}">${hasRestRoi?`${restRoiNum.toFixed(2)}%`:'—'}</td><td class="${tradingRoiCls}">${hasTradingRoi?`${tradingRoiNum.toFixed(2)}%`:'—'}</td><td><button class="btn ghost" style="font-size:10px;padding:2px 6px" data-snap-del="${s.date}">Usuń</button></td>`;
           tr.querySelector('[data-snap-del]').onclick=()=>invHubDeleteSnapshot(s.date);
           snapTbody.appendChild(tr);
         }
@@ -10707,13 +10833,15 @@
     lines.push(`  ROI: ${stats.capitalFromBudget>0?stats.roi.toFixed(2)+'%':'—'}`);
     const etfRoi=stats.roiBreakdown?.etfRoi;
     const restRoi=stats.roiBreakdown?.otherRoi;
+    const tradingRoi=stats.roiBreakdown?.tradingRoi;
     const etfRoiTxt=etfRoi===null||etfRoi===undefined?'—':`${etfRoi.toFixed(2)}%`;
     const restRoiTxt=restRoi===null||restRoi===undefined?'—':`${restRoi.toFixed(2)}%`;
+    const tradingRoiTxt=tradingRoi===null||tradingRoi===undefined?'—':`${tradingRoi.toFixed(2)}%`;
     let roiCmp='';
     if(etfRoi!==null&&etfRoi!==undefined&&restRoi!==null&&restRoi!==undefined){
       roiCmp=restRoi>etfRoi?' ▲':restRoi<etfRoi?' ▼':'';
     }
-    lines.push(`  ROI ETF / Rest: ${etfRoiTxt} / ${restRoiTxt}${roiCmp}`);
+    lines.push(`  ROI ETF / Rest / Trading: ${etfRoiTxt} / ${restRoiTxt} / ${tradingRoiTxt}${roiCmp}`);
     lines.push(`  Pula reinwestycyjna: ${fmt(stats.reinvestPool,cur)}`);
 
     // --- Holdings ---
@@ -10827,6 +10955,7 @@
   // --- Main Render -----------------------------------------------------------
   function renderInvestments(){
     ensureInvestmentCategory();
+    ensureDayTradingAsset();
     const data=investments();
     bindInvestmentModal();
     bindInvestmentAnalyticsNav();
@@ -10878,11 +11007,15 @@
       buyForm._bound=true;
       const srcSel=buyForm.querySelector('select[name="fundSource"]');
       const footnote=document.getElementById('inv-buy-footnote');
+      const assetSel=buyForm.querySelector('select[name="assetId"]');
+      const amountInput=buyForm.querySelector('input[name="amount"]');
       if(srcSel){
         srcSel.onchange=()=>{
           if(footnote) footnote.textContent=srcSel.value==='reinvest'?'Źródło: pula reinwestycyjna — jeśli kwota przekroczy pulę, reszta zostanie pobrana z budżetu.':'Źródło: budżet — kwota zostanie zaksięgowana jako inwestycja.';
         };
       }
+      if(assetSel) assetSel.addEventListener('change',updateInvBuyFormForAsset);
+      if(amountInput) amountInput.addEventListener('input',updateInvBuyFormForAsset);
       buyForm.onsubmit=e=>{
         e.preventDefault();
         const f=new FormData(buyForm);
@@ -10891,7 +11024,8 @@
         if(!asset){alert('Dodaj najpierw aktywo.');return;}
         const date=f.get('date')||new Date().toISOString().slice(0,10);
         const amount=Math.abs(num(f.get('amount')));
-        const quantity=num(f.get('quantity'));
+        const isDayTrading=isDayTradingGroup(asset.group);
+        const quantity=isDayTrading?amount:num(f.get('quantity'));
         const note=String(f.get('note')||'');
         const fundSource=f.get('fundSource')||'budget';
         if(amount<=0||quantity<=0){alert('Kwota i ilość muszą być > 0.');return;}
@@ -10929,9 +11063,11 @@
         }
         save(state);buyForm.reset();
         const di=buyForm.querySelector('input[name="date"]');if(di) di.value=new Date().toISOString().slice(0,10);
+        updateInvBuyFormForAsset();
         renderAll();
       };
     }
+    updateInvBuyFormForAsset();
 
     // Sell form
     const sellForm=document.getElementById('inv-sell-form');

--- a/budget.html
+++ b/budget.html
@@ -116,13 +116,13 @@
     .inv-kpi-roi-delta.down { color:#dc2626; background:rgba(220,38,38,.12); }
     .inv-kpi-roi-delta.flat { color:var(--muted); background:rgba(148,163,184,.14); }
     .inv-kpi-roi-delta.placeholder { visibility:hidden; }
-    #inv-kpi-roi-card { display:grid; grid-template-columns:minmax(0,1fr) auto; grid-template-areas:'label split' 'value split'; align-items:start; column-gap:12px; row-gap:2px; }
-    #inv-kpi-roi-card .inv-kpi-label { grid-area:label; white-space:nowrap; }
-    #inv-kpi-roi-card .inv-kpi-value { grid-area:value; margin-top:0; }
-    #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split { grid-area:split; align-self:center; justify-self:end; display:flex; flex-direction:column; align-items:flex-end; gap:2px; line-height:1.1; font-size:10px; }
+    #inv-kpi-roi-card { position:relative; padding-right:128px; align-items:flex-start; gap:4px; }
+    #inv-kpi-roi-card .inv-kpi-label { white-space:nowrap; }
+    #inv-kpi-roi-card .inv-kpi-value { margin-top:0; }
+    #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split { position:absolute; right:16px; top:14px; margin:0; display:flex; flex-direction:column; align-items:flex-end; gap:2px; line-height:1.1; font-size:10px; }
     @media(max-width:560px){
-      #inv-kpi-roi-card{grid-template-columns:1fr;grid-template-areas:'label' 'value' 'split';}
-      #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split{justify-self:start;align-items:flex-start;}
+      #inv-kpi-roi-card{padding-right:16px;}
+      #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split{position:static;align-items:flex-start;}
     }
     .inv-kpi-card.positive .inv-kpi-value { color:#16a34a; }
     .inv-kpi-card.negative .inv-kpi-value { color:#dc2626; }

--- a/budget.html
+++ b/budget.html
@@ -119,6 +119,7 @@
     #inv-kpi-roi-card { position:relative; padding-right:128px; align-items:flex-start; gap:4px; }
     #inv-kpi-roi-card .inv-kpi-label { white-space:nowrap; }
     #inv-kpi-roi-card .inv-kpi-value { margin-top:0; }
+    #inv-kpi-roi-foot { font-size:11px; color:var(--muted); }
     #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split { position:absolute; right:16px; top:14px; margin:0; display:flex; flex-direction:column; align-items:flex-end; gap:2px; line-height:1.1; font-size:10px; }
     @media(max-width:560px){
       #inv-kpi-roi-card{padding-right:16px;}
@@ -5061,6 +5062,7 @@
             <div class="inv-kpi-card" id="inv-kpi-roi-card">
               <span class="inv-kpi-label">ROI %</span>
               <span class="inv-kpi-value" id="inv-kpi-roi">—</span>
+              <span class="inv-kpi-sub" id="inv-kpi-roi-foot">Zwrot na kapitale z budżetu</span>
               <span class="inv-kpi-sub inv-kpi-sub-split" id="inv-kpi-roi-sub">Zwrot na kapitale z budżetu</span>
             </div>
           </div>

--- a/budget.html
+++ b/budget.html
@@ -105,18 +105,21 @@
     .inv-kpi-card .inv-kpi-label { font-size:11px; font-weight:700; color:var(--muted); text-transform:uppercase; letter-spacing:.03em; }
     .inv-kpi-card .inv-kpi-value { font-size:20px; font-weight:700; color:var(--ink); line-height:1.2; }
     .inv-kpi-card .inv-kpi-sub { font-size:11px; color:var(--muted); }
-    .inv-kpi-card .inv-kpi-sub.inv-kpi-sub-split { font-size:10px; line-height:1.2; display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
-    .inv-kpi-roi-mini { display:inline-flex; align-items:baseline; gap:4px; white-space:nowrap; }
-    .inv-kpi-roi-mini b { font-size:11px; color:var(--ink); font-weight:700; }
+    .inv-kpi-card .inv-kpi-sub.inv-kpi-sub-split { font-size:10px; line-height:1.1; display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+    .inv-kpi-roi-list { display:flex; flex-direction:column; gap:2px; min-width:102px; }
+    .inv-kpi-roi-row { display:grid; grid-template-columns:52px auto; align-items:center; column-gap:6px; white-space:nowrap; font-variant-numeric:tabular-nums; }
+    .inv-kpi-roi-label { font-size:10px; color:var(--muted); text-align:right; }
+    .inv-kpi-roi-val-wrap { display:inline-flex; align-items:center; justify-content:flex-end; gap:4px; }
+    .inv-kpi-roi-value { font-size:11px; color:var(--ink); font-weight:700; min-width:46px; text-align:right; }
     .inv-kpi-roi-delta { display:inline-flex; align-items:center; justify-content:center; width:14px; height:14px; border-radius:999px; font-size:9px; font-weight:700; line-height:1; }
     .inv-kpi-roi-delta.up { color:#16a34a; background:rgba(22,163,74,.12); }
     .inv-kpi-roi-delta.down { color:#dc2626; background:rgba(220,38,38,.12); }
     .inv-kpi-roi-delta.flat { color:var(--muted); background:rgba(148,163,184,.14); }
+    .inv-kpi-roi-delta.placeholder { visibility:hidden; }
     #inv-kpi-roi-card { display:grid; grid-template-columns:minmax(0,1fr) auto; grid-template-areas:'label split' 'value split'; align-items:center; column-gap:12px; row-gap:3px; }
     #inv-kpi-roi-card .inv-kpi-label { grid-area:label; }
     #inv-kpi-roi-card .inv-kpi-value { grid-area:value; }
-    #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split { grid-area:split; align-self:center; justify-self:end; display:flex; flex-direction:column; align-items:flex-end; gap:3px; line-height:1.1; font-size:10px; }
-    #inv-kpi-roi-card .inv-kpi-roi-mini { gap:5px; }
+    #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split { grid-area:split; align-self:center; justify-self:end; display:flex; flex-direction:column; align-items:flex-end; gap:2px; line-height:1.1; font-size:10px; }
     @media(max-width:560px){
       #inv-kpi-roi-card{grid-template-columns:1fr;grid-template-areas:'label' 'value' 'split';}
       #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split{justify-self:start;align-items:flex-start;}
@@ -8234,7 +8237,12 @@
         if(val<etfVal) return '<span class="inv-kpi-roi-delta down" title="Poniżej ETF">▼</span>';
         return '<span class="inv-kpi-roi-delta flat" title="Równo ETF">•</span>';
       };
-      roiSub.innerHTML=`<span class="inv-kpi-roi-mini">ETF <b>${etfTxt}</b></span><span class="inv-kpi-roi-mini">Rest <b>${otherTxt}</b>${cmpDelta(restVal)}</span><span class="inv-kpi-roi-mini">Trading <b>${tradingTxt}</b>${cmpDelta(tradingVal)}</span>`;
+      const placeholder='<span class="inv-kpi-roi-delta placeholder">•</span>';
+      roiSub.innerHTML=`<div class="inv-kpi-roi-list">
+        <div class="inv-kpi-roi-row"><span class="inv-kpi-roi-label">ETF</span><span class="inv-kpi-roi-val-wrap"><span class="inv-kpi-roi-value">${etfTxt}</span>${placeholder}</span></div>
+        <div class="inv-kpi-roi-row"><span class="inv-kpi-roi-label">Rest</span><span class="inv-kpi-roi-val-wrap"><span class="inv-kpi-roi-value">${otherTxt}</span>${cmpDelta(restVal)||placeholder}</span></div>
+        <div class="inv-kpi-roi-row"><span class="inv-kpi-roi-label">Trading</span><span class="inv-kpi-roi-val-wrap"><span class="inv-kpi-roi-value">${tradingTxt}</span>${cmpDelta(tradingVal)||placeholder}</span></div>
+      </div>`;
     }
     roiCard.className='inv-kpi-card '+(stats.roi>0?'positive':stats.roi<0?'negative':'');
   }

--- a/budget.html
+++ b/budget.html
@@ -116,9 +116,9 @@
     .inv-kpi-roi-delta.down { color:#dc2626; background:rgba(220,38,38,.12); }
     .inv-kpi-roi-delta.flat { color:var(--muted); background:rgba(148,163,184,.14); }
     .inv-kpi-roi-delta.placeholder { visibility:hidden; }
-    #inv-kpi-roi-card { display:grid; grid-template-columns:minmax(0,1fr) auto; grid-template-areas:'label split' 'value split'; align-items:center; column-gap:12px; row-gap:3px; }
-    #inv-kpi-roi-card .inv-kpi-label { grid-area:label; }
-    #inv-kpi-roi-card .inv-kpi-value { grid-area:value; }
+    #inv-kpi-roi-card { display:grid; grid-template-columns:minmax(0,1fr) auto; grid-template-areas:'label split' 'value split'; align-items:start; column-gap:12px; row-gap:2px; }
+    #inv-kpi-roi-card .inv-kpi-label { grid-area:label; white-space:nowrap; }
+    #inv-kpi-roi-card .inv-kpi-value { grid-area:value; margin-top:0; }
     #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split { grid-area:split; align-self:center; justify-self:end; display:flex; flex-direction:column; align-items:flex-end; gap:2px; line-height:1.1; font-size:10px; }
     @media(max-width:560px){
       #inv-kpi-roi-card{grid-template-columns:1fr;grid-template-areas:'label' 'value' 'split';}
@@ -5059,7 +5059,7 @@
               <span class="inv-kpi-sub">Gotówka do reinwestycji</span>
             </div>
             <div class="inv-kpi-card" id="inv-kpi-roi-card">
-              <span class="inv-kpi-label">Całkowity ROI</span>
+              <span class="inv-kpi-label">ROI %</span>
               <span class="inv-kpi-value" id="inv-kpi-roi">—</span>
               <span class="inv-kpi-sub inv-kpi-sub-split" id="inv-kpi-roi-sub">Zwrot na kapitale z budżetu</span>
             </div>

--- a/budget.html
+++ b/budget.html
@@ -111,6 +111,16 @@
     .inv-kpi-roi-delta { display:inline-flex; align-items:center; justify-content:center; width:14px; height:14px; border-radius:999px; font-size:9px; font-weight:700; line-height:1; }
     .inv-kpi-roi-delta.up { color:#16a34a; background:rgba(22,163,74,.12); }
     .inv-kpi-roi-delta.down { color:#dc2626; background:rgba(220,38,38,.12); }
+    .inv-kpi-roi-delta.flat { color:var(--muted); background:rgba(148,163,184,.14); }
+    #inv-kpi-roi-card { display:grid; grid-template-columns:minmax(0,1fr) auto; grid-template-areas:'label split' 'value split'; align-items:center; column-gap:12px; row-gap:3px; }
+    #inv-kpi-roi-card .inv-kpi-label { grid-area:label; }
+    #inv-kpi-roi-card .inv-kpi-value { grid-area:value; }
+    #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split { grid-area:split; align-self:center; justify-self:end; display:flex; flex-direction:column; align-items:flex-end; gap:3px; line-height:1.1; font-size:10px; }
+    #inv-kpi-roi-card .inv-kpi-roi-mini { gap:5px; }
+    @media(max-width:560px){
+      #inv-kpi-roi-card{grid-template-columns:1fr;grid-template-areas:'label' 'value' 'split';}
+      #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split{justify-self:start;align-items:flex-start;}
+    }
     .inv-kpi-card.positive .inv-kpi-value { color:#16a34a; }
     .inv-kpi-card.negative .inv-kpi-value { color:#dc2626; }
     .inv-kpi-card.accent { background:linear-gradient(135deg,#2563eb 0%,#1d4ed8 100%); border-color:transparent; }
@@ -8215,7 +8225,16 @@
       const etfTxt=stats.roiBreakdown?.etfRoi===null?'—':`${stats.roiBreakdown.etfRoi.toFixed(1)}%`;
       const otherTxt=stats.roiBreakdown?.otherRoi===null?'—':`${stats.roiBreakdown.otherRoi.toFixed(1)}%`;
       const tradingTxt=stats.roiBreakdown?.tradingRoi===null?'—':`${stats.roiBreakdown.tradingRoi.toFixed(1)}%`;
-      roiSub.innerHTML=`<span class="inv-kpi-roi-mini">ETF <b>${etfTxt}</b></span><span class="inv-kpi-roi-mini">Rest <b>${otherTxt}</b></span><span class="inv-kpi-roi-mini">Trading <b>${tradingTxt}</b></span>`;
+      const etfVal=Number(stats.roiBreakdown?.etfRoi);
+      const restVal=Number(stats.roiBreakdown?.otherRoi);
+      const tradingVal=Number(stats.roiBreakdown?.tradingRoi);
+      const cmpDelta=(val)=>{
+        if(!Number.isFinite(etfVal)||!Number.isFinite(val)) return '';
+        if(val>etfVal) return '<span class="inv-kpi-roi-delta up" title="Powyżej ETF">▲</span>';
+        if(val<etfVal) return '<span class="inv-kpi-roi-delta down" title="Poniżej ETF">▼</span>';
+        return '<span class="inv-kpi-roi-delta flat" title="Równo ETF">•</span>';
+      };
+      roiSub.innerHTML=`<span class="inv-kpi-roi-mini">ETF <b>${etfTxt}</b></span><span class="inv-kpi-roi-mini">Rest <b>${otherTxt}</b>${cmpDelta(restVal)}</span><span class="inv-kpi-roi-mini">Trading <b>${tradingTxt}</b>${cmpDelta(tradingVal)}</span>`;
     }
     roiCard.className='inv-kpi-card '+(stats.roi>0?'positive':stats.roi<0?'negative':'');
   }

--- a/budget.html
+++ b/budget.html
@@ -116,15 +116,15 @@
     .inv-kpi-roi-delta.down { color:#dc2626; background:rgba(220,38,38,.12); }
     .inv-kpi-roi-delta.flat { color:var(--muted); background:rgba(148,163,184,.14); }
     .inv-kpi-roi-delta.placeholder { visibility:hidden; }
-    #inv-kpi-roi-card { position:relative; padding-right:128px; align-items:flex-start; gap:4px; }
+    #inv-kpi-roi-card { position:relative; padding-right:128px; padding-bottom:30px; align-items:flex-start; gap:4px; }
     #inv-kpi-roi-card .inv-kpi-label { white-space:nowrap; }
     #inv-kpi-roi-card .inv-kpi-value { margin-top:0; }
     #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split { position:absolute; right:16px; top:14px; margin:0; display:flex; flex-direction:column; align-items:flex-end; gap:2px; line-height:1.1; font-size:10px; }
-    .inv-kpi-roi-note { margin-top:4px; font-size:10px; color:var(--muted); max-width:104px; text-align:right; line-height:1.15; white-space:normal; }
+    #inv-kpi-roi-foot { position:absolute; left:16px; right:16px; bottom:10px; font-size:11px; color:var(--muted); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
     @media(max-width:560px){
-      #inv-kpi-roi-card{padding-right:16px;}
+      #inv-kpi-roi-card{padding-right:16px;padding-bottom:14px;}
       #inv-kpi-roi-card .inv-kpi-sub.inv-kpi-sub-split{position:static;align-items:flex-start;}
-      .inv-kpi-roi-note{text-align:left;}
+      #inv-kpi-roi-foot{position:static;left:auto;right:auto;bottom:auto;}
     }
     .inv-kpi-card.positive .inv-kpi-value { color:#16a34a; }
     .inv-kpi-card.negative .inv-kpi-value { color:#dc2626; }
@@ -5064,6 +5064,7 @@
               <span class="inv-kpi-label">ROI %</span>
               <span class="inv-kpi-value" id="inv-kpi-roi">—</span>
               <span class="inv-kpi-sub inv-kpi-sub-split" id="inv-kpi-roi-sub">Zwrot na kapitale z budżetu</span>
+              <span class="inv-kpi-sub" id="inv-kpi-roi-foot">Zwrot na kapitale z budżetu</span>
             </div>
           </div>
 
@@ -8244,7 +8245,7 @@
         <div class="inv-kpi-roi-row"><span class="inv-kpi-roi-label">ETF</span><span class="inv-kpi-roi-val-wrap"><span class="inv-kpi-roi-value">${etfTxt}</span>${placeholder}</span></div>
         <div class="inv-kpi-roi-row"><span class="inv-kpi-roi-label">Rest</span><span class="inv-kpi-roi-val-wrap"><span class="inv-kpi-roi-value">${otherTxt}</span>${cmpDelta(restVal)||placeholder}</span></div>
         <div class="inv-kpi-roi-row"><span class="inv-kpi-roi-label">Trading</span><span class="inv-kpi-roi-val-wrap"><span class="inv-kpi-roi-value">${tradingTxt}</span>${cmpDelta(tradingVal)||placeholder}</span></div>
-      </div><div class="inv-kpi-roi-note">Zwrot na kapitale z budżetu</div>`;
+      </div>`;
     }
     roiCard.className='inv-kpi-card '+(stats.roi>0?'positive':stats.roi<0?'negative':'');
   }

--- a/index.html
+++ b/index.html
@@ -324,6 +324,8 @@ const INV_CORS_PROXY_KEY = 'invCorsProxyTemplate';
 const INV_FMP_API_KEY_STORE = 'invFmpApiKey';
 const INV_CAL_GOAL_KEY = 'invCalGoal';
 const TRAININGS_MIGRATION_KEY = 'lifeos_trainings_migrated_to_month_v1';
+const TRADING_STORAGE_KEY = 'lifeos_trading_v2';
+const TRADING_SETTINGS_KEY = 'lifeos_trading_settings_v1';
 const DEF_WORKHUB_MEMBERS = [
   { id:'m1', name:'Pracownik 1', role:'', color:'#6366f1', profileNote:'', specialties:[] },
   { id:'m2', name:'Pracownik 2', role:'', color:'#f59e0b', profileNote:'', specialties:[] },
@@ -1568,6 +1570,8 @@ exportBtn.onclick = ()=>{
     invest_sheet: JSON.parse(localStorage.getItem(INVEST_SHEET_KEY) || 'null'),
     budget_filters: JSON.parse(localStorage.getItem(BUDGET_FILTERS_KEY) || 'null'),
     budget_eom_ui: JSON.parse(localStorage.getItem(BUDGET_EOM_UI_KEY) || 'null'),
+    trading_state: JSON.parse(localStorage.getItem(TRADING_STORAGE_KEY) || 'null'),
+    trading_settings: JSON.parse(localStorage.getItem(TRADING_SETTINGS_KEY) || 'null'),
     inv_cors_proxy: localStorage.getItem(INV_CORS_PROXY_KEY) || null,
     inv_fmp_api_key: localStorage.getItem(INV_FMP_API_KEY_STORE) || null,
     inv_cal_goal: localStorage.getItem(INV_CAL_GOAL_KEY) || null,
@@ -1628,6 +1632,14 @@ importInput.onchange = (e)=>{
       if(data.invest_sheet) localStorage.setItem(INVEST_SHEET_KEY, JSON.stringify(data.invest_sheet));
       if(data.budget_filters) localStorage.setItem(BUDGET_FILTERS_KEY, JSON.stringify(data.budget_filters));
       if(data.budget_eom_ui) localStorage.setItem(BUDGET_EOM_UI_KEY, JSON.stringify(data.budget_eom_ui));
+      if(Object.prototype.hasOwnProperty.call(data,'trading_state')){
+        if(data.trading_state && typeof data.trading_state==='object') localStorage.setItem(TRADING_STORAGE_KEY, JSON.stringify(data.trading_state));
+        else if(data.trading_state===null) localStorage.removeItem(TRADING_STORAGE_KEY);
+      }
+      if(Object.prototype.hasOwnProperty.call(data,'trading_settings')){
+        if(data.trading_settings && typeof data.trading_settings==='object') localStorage.setItem(TRADING_SETTINGS_KEY, JSON.stringify(data.trading_settings));
+        else if(data.trading_settings===null) localStorage.removeItem(TRADING_SETTINGS_KEY);
+      }
       if(data.inv_cors_proxy) localStorage.setItem(INV_CORS_PROXY_KEY, data.inv_cors_proxy);
       if(data.inv_fmp_api_key) localStorage.setItem(INV_FMP_API_KEY_STORE, data.inv_fmp_api_key);
       if(data.inv_cal_goal !== null && data.inv_cal_goal !== undefined) localStorage.setItem(INV_CAL_GOAL_KEY, data.inv_cal_goal);

--- a/index.html
+++ b/index.html
@@ -1060,6 +1060,40 @@ function getInvestmentStats(){
   const assets  = Array.isArray(investments.assets)  ? investments.assets  : [];
   if(!trades.length && !assets.length) return null;
 
+  const isDayTradingGroup = (name)=>String(name||'').trim().toUpperCase()==='DAY TRADING';
+  const dayTradingAssets = assets.filter(a=>isDayTradingGroup(a.group));
+  const dayTradingAssetIds = new Set(dayTradingAssets.map(a=>a.id));
+  const getTradingModulePnlRaw = ()=>{
+    const parsed = safeParse(localStorage.getItem(TRADING_STORAGE_KEY), {}) || {};
+    const tr = Array.isArray(parsed.trades) ? parsed.trades : [];
+    let total = 0;
+    for(const t of tr){
+      const entry = num(t?.entry);
+      const size = Math.max(num(t?.size),0);
+      const dir = t?.direction === 'short' ? 'short' : 'long';
+      const closings = Array.isArray(t?.closings) ? t.closings : [];
+      for(const c of closings){
+        const pct = Math.max(0, Math.min(100, num(c?.pct)));
+        const closingSize = size * (pct/100);
+        if(closingSize <= 0) continue;
+        const closePrice = num(c?.price);
+        const commission = num(c?.commission);
+        const gross = dir === 'short' ? (entry - closePrice) * closingSize : (closePrice - entry) * closingSize;
+        total += gross - commission;
+      }
+    }
+    return total;
+  };
+  const getTradingPnlConverted = ()=>{
+    if(!dayTradingAssets.length) return 0;
+    const primary = dayTradingAssets[0] || {};
+    const sourceCurrency = String(primary.priceCurrency || 'USD').trim().toUpperCase() || 'USD';
+    const fxRate = sourceCurrency === 'PLN' ? 1 : num(primary.currentPrice);
+    if(sourceCurrency !== 'PLN' && !(fxRate > 0)) return 0;
+    return getTradingModulePnlRaw() * fxRate;
+  };
+  const tradingPnlConverted = getTradingPnlConverted();
+
   /* ---- Latest snapshot (has pre-computed stats) ---- */
   const snapshots = safeParse(localStorage.getItem(INV_HUB_SNAP_KEY), []) || [];
   const snap = snapshots.length ? snapshots[snapshots.length-1] : null;
@@ -1088,14 +1122,21 @@ function getInvestmentStats(){
         h.cost += num(t.amount);
       }
     }
-    let mv=0, cb=0, realized=0;
+    let mv=0, cb=0, realized=0, dayTradingCb=0;
     for(const [id, h] of Object.entries(hMap)){
       if(h.qty <= 0){ realized += h.realized; continue; }
       const asset = assets.find(a=>a.id===id);
-      const price = asset && asset.currentPrice ? num(asset.currentPrice) : 0;
-      mv += price > 0 ? h.qty*price : h.cost;
+      if(asset && dayTradingAssetIds.has(id)){
+        dayTradingCb += h.cost;
+      } else {
+        const price = asset && asset.currentPrice ? num(asset.currentPrice) : 0;
+        mv += price > 0 ? h.qty*price : h.cost;
+      }
       cb += h.cost;
       realized += h.realized;
+    }
+    if(dayTradingCb > 0){
+      mv += dayTradingCb + tradingPnlConverted;
     }
     portfolioValue = mv;
     costBasis      = cb;
@@ -1146,16 +1187,29 @@ function getInvestmentStats(){
     }
   }
   const groupBreakdown = {};
+  let dayTradingCbTotal = 0;
+  const dayTradingCbByGroup = {};
   for(const [id, h] of Object.entries(fifoMap)){
     const qty = h.lots.reduce((s,l)=>s+l.qty, 0);
     if(qty <= 0.000001) continue;
     const cb = h.lots.reduce((s,l)=>s+l.qty*l.costPerUnit, 0);
+    const isDt = dayTradingAssetIds.has(id);
     const price = h.currentPrice ? num(h.currentPrice) : 0;
-    const mv = price > 0 ? qty * price : cb;
+    const mv = isDt ? cb : (price > 0 ? qty * price : cb);
     const group = h.group;
     if(!groupBreakdown[group]) groupBreakdown[group] = { mv:0, cb:0 };
     groupBreakdown[group].mv += mv;
     groupBreakdown[group].cb += cb;
+    if(isDt){
+      dayTradingCbTotal += cb;
+      dayTradingCbByGroup[group] = (dayTradingCbByGroup[group]||0) + cb;
+    }
+  }
+  if(dayTradingCbTotal > 0){
+    for(const [group, cbPart] of Object.entries(dayTradingCbByGroup)){
+      if(!groupBreakdown[group]) continue;
+      groupBreakdown[group].mv += tradingPnlConverted * (cbPart / dayTradingCbTotal);
+    }
   }
 
   // Available to invest: savings group + reinvest pool


### PR DESCRIPTION
### Motivation
- Wprowadzić nową grupę inwestycyjną „Day Trading” i móc księgować wpłaty do niej tak jak do innych grup, ale pobierać P&L z modułu `trading.html` (dane w USD).  
- Umożliwić konfigurację waluty/źródła przeliczenia dla Day Trading i uwzględnić Trading w całkowitym rozbiciu ROI oraz w snapshotach.  
- Zliczać całkowity PnL, ROI i snapshoty łącznie z danymi z modułu trading, tak jak dla każdej innej grupy.

### Description
- Dodano nową opcję grupy w `budget.html`: dodałem `Day Trading` do `invGroupOptions` i stałą `INV_TRADING_KEY='lifeos_trading_v2'`.  
- Zaimplementowano funkcje pomocnicze `isDayTradingGroup`, `normalizeTradingTrade` i `getTradingModulePnlRaw`, które czytają `localStorage` z klucza `lifeos_trading_v2` i sumują P&L z zamknięć.  
- W `computePortfolioStats()` zintegrowano importowany PnL: PnL z modułu trading jest konwertowany wg konfiguracji aktywa (waluta `priceCurrency` oraz kurs/`currentPrice` lub pobranie NBP), a wynik rozdzielany proporcjonalnie na aktywa Day Trading (modyfikuje `marketValue` i `unrealizedPnl`).  
- Dodano automatyczne utworzenie domyślnego aktywa `inv_asset_day_trading` (grupa `Day Trading`) oraz zmiany w formularzu kupna `inv-buy-form`, gdzie dla Day Trading `quantity` jest automatycznie wyliczane z `amount` (wpłata księgowana normalnie), a stopka formularza informuje o źródle PnL.  
- Rozszerzono rozbicie ROI i snapshoty: dodano `tradingRoi`, `tradingTotalPnl` i `tradingCapitalFromBudget`, kolumnę `ROI Trading` w tabeli snapshotów oraz uwzględnienie Trading w eksporcie i tekście w schowku.  
- Drobne zmiany w pobieraniu cen, by obsłużyć aktywa Day Trading z providerem `nbp` (pobranie kursu walutowego jako źródła przeliczenia).

### Testing
- Sprawdzono składnię wyciągniętego inline JS przy pomocy `node --check` (przejście zakończone sukcesem).  
- Wykonano przeglądy zmian (`git diff` / `rg` grep) żeby potwierdzić dodane ścieżki `Day Trading` / `tradingRoi` / `INV_TRADING_KEY` i widoczne modyfikacje UI; wyniki zgodne z oczekiwaniami.  
- `git status` oraz commit z wiadomością `Integrate Day Trading group with Trading module PnL` wykonane pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9fbcfff58833190ce5fe7243b7125)