### PR TITLE
Add monthly investment plan to budget module

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -4892,9 +4892,53 @@
         <div class="stat-card"><div class="muted">Stałe zapłacone</div><div class="big-number ok" id="ov-fixed-paid">0</div></div>
         <div class="stat-card"><div class="muted">Stałe do zapłacenia</div><div class="big-number warn" id="ov-fixed-unpaid">0</div></div>
         <div class="stat-card"><div class="muted">Wydatki zmienne</div><div class="big-number bad" id="ov-var-spent">0</div></div>
-        <div class="stat-card"><div class="muted">Oszczędności</div><div class="big-number" style="color:var(--blue)" id="ov-savings">0</div></div>
+        <div class="stat-card"><div class="muted">Oszczędności (bez inwestycji)</div><div class="big-number" style="color:var(--blue)" id="ov-savings">0</div></div>
+        <div class="stat-card">
+          <div class="muted">Inwestycje (plan / postęp)</div>
+          <div class="big-number" style="color:var(--blue)"><span id="ov-inv-actual">0</span> <span class="muted" style="font-size:14px;font-weight:500">/ <span id="ov-inv-planned">0</span></span></div>
+          <div class="inv-progress-track" id="ov-inv-progress" style="margin-top:6px"><div class="inv-progress-fill" id="ov-inv-progress-fill"></div></div>
+          <div class="tiny muted" id="ov-inv-delta" style="margin-top:4px">Brak planu na ten miesiąc</div>
+        </div>
         <div class="stat-card"><div class="muted">Budżet zmienny do dyspozycji</div><div class="big-number" id="ov-remaining">0</div></div>
         <div class="stat-card"><div class="muted">Prognozowana stopa oszczędności</div><div class="big-number" id="stat-savings-rate">0%</div></div>
+      </div>
+
+      <!-- Plan inwestycyjny — edytor -->
+      <div class="inv-plan-card" id="inv-plan-card">
+        <div class="inv-plan-header">
+          <div>
+            <div class="title" style="margin:0">📈 Plan inwestycyjny — <span id="inv-plan-month">YYYY-MM</span></div>
+            <div class="tiny muted">Zarezerwuj kwotę na inwestycje. Zmniejsza budżet zmienny do dyspozycji od razu (jak wydatki stałe). Faktyczne wpłaty w kategorii „Inwestycje” są liczone osobno; tylko nadwyżka ponad plan dodatkowo obniża budżet i prognozę.</div>
+          </div>
+          <div class="row" style="gap:6px">
+            <button class="btn ghost" type="button" id="inv-plan-copy-prev" title="Skopiuj plan z poprzedniego miesiąca">Kopiuj z poprzedniego</button>
+            <button class="btn danger" type="button" id="inv-plan-clear" title="Usuń plan na ten miesiąc">Wyczyść</button>
+          </div>
+        </div>
+        <div class="inv-plan-stats">
+          <div class="inv-plan-stat"><div class="lbl">Plan miesięczny</div><div class="val" id="inv-plan-stat-planned">0</div></div>
+          <div class="inv-plan-stat"><div class="lbl">Zainwestowane</div><div class="val" id="inv-plan-stat-actual">0</div></div>
+          <div class="inv-plan-stat"><div class="lbl">Pozostało do planu</div><div class="val" id="inv-plan-stat-remaining">0</div></div>
+          <div class="inv-plan-stat" id="inv-plan-stat-overage-card"><div class="lbl">Powyżej planu</div><div class="val" id="inv-plan-stat-overage">0</div></div>
+        </div>
+        <form id="inv-plan-form" class="grid g-4" style="gap:8px">
+          <label class="tiny" style="display:flex;flex-direction:column;gap:4px">
+            Kwota miesięczna (zł)
+            <input name="amount" inputmode="decimal" placeholder="np. 2000" />
+          </label>
+          <label class="tiny" style="display:flex;flex-direction:column;gap:4px">
+            albo Kwota tygodniowa (zł)
+            <input name="weekly" inputmode="decimal" placeholder="np. 500" />
+          </label>
+          <label class="tiny" style="display:flex;flex-direction:column;gap:4px">
+            Notatka
+            <input name="note" placeholder="np. ETF + krypto, DCA" />
+          </label>
+          <div style="display:flex;align-items:flex-end">
+            <button class="btn" type="submit" style="width:100%">Zapisz plan</button>
+          </div>
+        </form>
+        <div class="tiny muted" id="inv-plan-hint" style="margin-top:6px">Wskazówka: jeśli wpiszesz tylko kwotę tygodniową, plan miesięczny zostanie wyliczony jako tygodniowa × liczba pełnych tygodni w miesiącu (~4,3).</div>
       </div>
     </section>
 
@@ -6012,6 +6056,15 @@
               <span class="tiny muted" id="dash-mom-note">Porównanie dostępne dla bieżącego miesiąca</span>
             </div>
           </div>
+          <div class="kpi-compact" id="inv-plan-kpi">
+            <span class="kpi-emoji material-symbols-outlined">trending_up</span>
+            <div class="kpi-body">
+              <span class="kpi-label">Plan inwestycyjny</span>
+              <span class="kpi-value" id="dash-inv-progress">— / —</span>
+              <div class="inv-progress-track" id="dash-inv-progress-track" title=""><div class="inv-progress-fill" id="dash-inv-progress-fill"></div></div>
+              <span class="tiny muted" id="dash-inv-note">Brak planu na ten miesiąc</span>
+            </div>
+          </div>
           <div class="kpi-compact">
             <span class="kpi-emoji material-symbols-outlined">payments</span>
             <div class="kpi-body">
@@ -6157,6 +6210,21 @@
     if(!Array.isArray(bud.investments.trades)) bud.investments.trades=[];
     if(!Array.isArray(bud.investments.groups)) bud.investments.groups=[];
     if(!Array.isArray(bud.eomInvestmentBridge)) bud.eomInvestmentBridge=[];
+    // Per-month investment plan – planowana kwota inwestycji w danym miesiącu.
+    // Działa jak planowane wydatki stałe: zmniejsza budżet zmienny do dyspozycji
+    // od razu po ustaleniu, a nie dopiero przy zaksięgowaniu transakcji.
+    if(bud.monthly && typeof bud.monthly === 'object'){
+      for(const ym of Object.keys(bud.monthly)){
+        const m = bud.monthly[ym]; if(!m || typeof m !== 'object') continue;
+        if(!m.investmentPlan || typeof m.investmentPlan !== 'object'){
+          m.investmentPlan = {amount:0, weekly:0, note:''};
+        } else {
+          m.investmentPlan.amount = num(m.investmentPlan.amount);
+          m.investmentPlan.weekly = num(m.investmentPlan.weekly);
+          m.investmentPlan.note = String(m.investmentPlan.note||'');
+        }
+      }
+    }
     for(const t of bud.investments.trades){
       if(!t.side) t.side='buy';
       if(t.side==='buy' && !t.fundSource) t.fundSource='budget';
@@ -6201,7 +6269,10 @@
   const b=()=>state.modules.budget;
 
   // --- Core Helpers ----------------------------------------------------------------
-  function ensureMonth(ym){if(!b().monthly[ym]) b().monthly[ym]={ incomes:[], fixed:[] }}
+  function ensureMonth(ym){
+    if(!b().monthly[ym]) b().monthly[ym]={ incomes:[], fixed:[], investmentPlan:{amount:0, weekly:0, note:''} };
+    if(!b().monthly[ym].investmentPlan) b().monthly[ym].investmentPlan={amount:0, weekly:0, note:''};
+  }
   function setDefaultDate(){const i=document.querySelector('#var-form input[name="date"]'); if(i && !i.value){i.value=new Date().toISOString().slice(0,10)}}
   const catsById=()=>Object.fromEntries((b().categories||[]).map(c=>[c.id,c]));
   function catType(id){const c=catsById()[id];return c?c.type:undefined}
@@ -6358,6 +6429,117 @@
     bindMoneyInputs(document.getElementById('qa-editor'));
   }
   
+  // --- Investment Plan helpers --------------------------------------------------
+  // Plan inwestycyjny działa jak planowane wydatki stałe: kwota planu od razu
+  // pomniejsza budżet zmienny do dyspozycji. Faktyczne wpłaty w kategorii
+  // inwestycyjnej są śledzone osobno (postęp). Dopiero gdy faktyczne > plan,
+  // nadwyżka dodatkowo obniża budżet i prognozę.
+  function isInvestmentCategory(c){
+    return !!c && (c.id === 'c_invest' || c.name === 'Inwestycje');
+  }
+  function getInvestmentPlanned(ym){
+    ensureMonth(ym);
+    const p = b().monthly[ym].investmentPlan || {amount:0};
+    return num(p.amount);
+  }
+  function getInvestmentActual(ym){
+    const cb = catsById();
+    return entriesForMonth(ym).reduce((s,e)=>{
+      const c = cb[e.categoryId];
+      return isInvestmentCategory(c) ? s + Math.abs(e.amount) : s;
+    }, 0);
+  }
+  function getInvestmentSummary(ym){
+    const planned = getInvestmentPlanned(ym);
+    const actual  = getInvestmentActual(ym);
+    const overage = Math.max(0, actual - planned);
+    const reserved = Math.max(0, planned - actual); // nieskonsumowana rezerwa planu
+    const effective = Math.max(planned, actual);    // ile faktycznie obciąża budżet
+    return {planned, actual, overage, reserved, effective};
+  }
+
+  // --- Investment Plan UI -----------------------------------------------------
+  function weeksInMonth(ym){
+    // Liczba pełnych "tygodni płatności" – używamy 4 tyg dla 28-30 dni i 5 dla 31?
+    // Prościej: dni / 7 ≈ 4.29..4.43. Wybieramy zaokrąglenie do 1 miejsca dziesiętnego.
+    return daysInYm(ym) / 7;
+  }
+  function renderInvestmentPlan(){
+    const ym = b().workingMonth; ensureMonth(ym);
+    const plan = b().monthly[ym].investmentPlan || {amount:0, weekly:0, note:''};
+    const inv = getInvestmentSummary(ym);
+    const monthLabel = document.getElementById('inv-plan-month');
+    if(monthLabel) monthLabel.textContent = ym;
+
+    const cur = state.currency;
+    const set = (id, val) => { const el = document.getElementById(id); if(el) el.textContent = val; };
+    set('inv-plan-stat-planned', fmt(inv.planned, cur));
+    set('inv-plan-stat-actual', fmt(inv.actual, cur));
+    set('inv-plan-stat-remaining', fmt(inv.reserved, cur));
+    set('inv-plan-stat-overage', fmt(inv.overage, cur));
+
+    const overageCard = document.getElementById('inv-plan-stat-overage-card');
+    if(overageCard){
+      overageCard.classList.toggle('warn', inv.overage > 0);
+      overageCard.classList.toggle('ok', inv.overage === 0 && inv.planned > 0);
+    }
+
+    const form = document.getElementById('inv-plan-form');
+    if(form){
+      const amountInp = form.elements.namedItem('amount');
+      const weeklyInp = form.elements.namedItem('weekly');
+      const noteInp = form.elements.namedItem('note');
+      if(amountInp) amountInp.value = plan.amount ? String(plan.amount) : '';
+      if(weeklyInp) weeklyInp.value = plan.weekly ? String(plan.weekly) : '';
+      if(noteInp) noteInp.value = plan.note || '';
+      bindMoneyInputs(form);
+    }
+  }
+
+  (function bindInvestmentPlanForm(){
+    const form = document.getElementById('inv-plan-form');
+    if(!form || form.dataset.bound) return;
+    form.dataset.bound = '1';
+    form.onsubmit = (e) => {
+      e.preventDefault();
+      const ym = b().workingMonth; ensureMonth(ym);
+      const f = new FormData(form);
+      const amount = num(f.get('amount'));
+      const weekly = num(f.get('weekly'));
+      // Jeśli użytkownik podał tygodniówkę bez kwoty miesięcznej — wylicz miesięczną.
+      const computedAmount = amount > 0 ? amount : (weekly > 0 ? Math.round(weekly * weeksInMonth(ym)) : 0);
+      b().monthly[ym].investmentPlan = {
+        amount: computedAmount,
+        weekly: weekly,
+        note: String(f.get('note')||'')
+      };
+      save(state); renderAll();
+    };
+    const clearBtn = document.getElementById('inv-plan-clear');
+    if(clearBtn) clearBtn.onclick = () => {
+      const ym = b().workingMonth; ensureMonth(ym);
+      if(!confirm(`Wyczyścić plan inwestycyjny na ${ym}?`)) return;
+      b().monthly[ym].investmentPlan = {amount:0, weekly:0, note:''};
+      save(state); renderAll();
+    };
+    const copyPrevBtn = document.getElementById('inv-plan-copy-prev');
+    if(copyPrevBtn) copyPrevBtn.onclick = () => {
+      const ym = b().workingMonth; ensureMonth(ym);
+      const prev = ymAdd(ym, -1);
+      const prevPlan = b().monthly[prev]?.investmentPlan;
+      if(!prevPlan || (!prevPlan.amount && !prevPlan.weekly)){
+        alert(`Brak planu inwestycyjnego w ${prev}.`);
+        return;
+      }
+      b().monthly[ym].investmentPlan = {
+        amount: num(prevPlan.amount),
+        weekly: num(prevPlan.weekly),
+        note: String(prevPlan.note||'')
+      };
+      save(state); renderAll();
+    };
+  })();
+
   // --- NEW: Fixed Expenses Templates & Suggestions ---------------------------------
   function fixedExistsForTpl(ym, tplId){ensureMonth(ym); return b().monthly[ym].fixed.some(f=>f.tplId===tplId)}
 
@@ -6438,12 +6620,17 @@
   }
 
   // --- Daily calculations (spending + savings) --------------------------------
+  // Inwestycje są pomijane, ponieważ traktowane są jako osobny,
+  // planowany wydatek (patrz getInvestmentSummary). Dzięki temu prognoza
+  // oszczędności bez stałych i bez inwestycji jest spójna z deklaracją planu.
   function getDailySpending(ym){
     const daily={};
     const entries=entriesForMonth(ym);
     for(const e of entries){
       const c=catsById()[e.categoryId];
-      if(!c || !((c.type==='expense' && c.id!=='c_fixed') || c.type==='saving')) continue;
+      if(!c) continue;
+      if(isInvestmentCategory(c)) continue;
+      if(!((c.type==='expense' && c.id!=='c_fixed') || c.type==='saving')) continue;
       const day=parseInt(e.date.slice(-2));
       daily[day]=(daily[day]||0)+Math.abs(e.amount);
     }
@@ -6463,24 +6650,55 @@
     const ym=b().workingMonth; ensureMonth(ym);
     const incSum=b().monthly[ym].incomes.reduce((s,x)=>s+num(x.amount),0);
     const fixSum=b().monthly[ym].fixed.reduce((s,x)=>s+num(x.amount),0);
+    const inv=getInvestmentSummary(ym);
     const days=daysInYm(ym);
-    const dailyBudget=Math.max(0,(incSum-fixSum)/days);
+    // Limit dzienny liczy się z budżetu po odjęciu stałych ORAZ zarezerwowanego
+    // planu inwestycyjnego — żeby nie zachęcał do wydania pieniędzy "obiecanych" inwestycjom.
+    const dailyBudget=Math.max(0,(incSum-fixSum-inv.effective)/days);
 
       const entries=entriesForMonth(ym);
       const cb=catsById();
-    
+
     const variableSpent = entries.reduce((s, e) => {
         const c = cb[e.categoryId];
         return (c?.type === 'expense' && c.id !== 'c_fixed') ? s + Math.abs(e.amount) : s;
     }, 0);
     const savingsTransfers = entries.reduce((s, e) => {
         const c = cb[e.categoryId];
-        return c?.type === 'saving' ? s + Math.abs(e.amount) : s;
+        if(!c || c.type !== 'saving') return s;
+        if(isInvestmentCategory(c)) return s;
+        return s + Math.abs(e.amount);
     }, 0);
-    const remain = incSum - fixSum - variableSpent - savingsTransfers;
+    const remain = incSum - fixSum - variableSpent - savingsTransfers - inv.effective;
 
     document.getElementById('dash-remaining').textContent=fmt(remain, state.currency);
     document.getElementById('dash-daily-budget').textContent=fmt(dailyBudget, state.currency);
+
+    const dashInvProgress = document.getElementById('dash-inv-progress');
+    const dashInvFill = document.getElementById('dash-inv-progress-fill');
+    const dashInvTrack = document.getElementById('dash-inv-progress-track');
+    const dashInvNote = document.getElementById('dash-inv-note');
+    if(dashInvProgress){
+      dashInvProgress.textContent = `${fmt(inv.actual, state.currency)} / ${fmt(inv.planned, state.currency)}`;
+    }
+    if(dashInvFill && dashInvTrack){
+      const pct = inv.planned > 0 ? (inv.actual / inv.planned) * 100 : 0;
+      dashInvFill.style.width = `${Math.min(100, pct)}%`;
+      dashInvFill.style.background = inv.overage > 0 ? 'var(--red, #dc2626)' : 'var(--blue, #2563eb)';
+      dashInvTrack.title = inv.planned > 0 ? `${pct.toFixed(0)}% planu` : 'Brak planu';
+    }
+    if(dashInvNote){
+      if(inv.planned <= 0){
+        dashInvNote.textContent = inv.actual > 0 ? `Zainwestowano ${fmt(inv.actual, state.currency)} bez planu` : 'Brak planu na ten miesiąc';
+        dashInvNote.className = 'tiny muted';
+      } else if(inv.overage > 0){
+        dashInvNote.textContent = `Powyżej planu o ${fmt(inv.overage, state.currency)} — obniża budżet`;
+        dashInvNote.className = 'tiny warn';
+      } else {
+        dashInvNote.textContent = `Pozostało: ${fmt(inv.reserved, state.currency)}`;
+        dashInvNote.className = 'tiny muted';
+      }
+    }
 
     const todayKey=new Date().toISOString().slice(0,10);
     const todaySpent=entries.filter(e=>e.date===todayKey).reduce((s,e)=>{
@@ -6517,7 +6735,8 @@
 
     // --- Forecast & Buffer Section (NEW) ---
     const daysLeft = getDaysRemaining(ym);
-    const totalVariableBudget = incSum - fixSum;
+    // Budżet zmienny do prognozy nie zawiera ani stałych, ani zarezerwowanego planu inwestycji.
+    const totalVariableBudget = incSum - fixSum - inv.effective;
     const projectedTotalVariableOutflow = spentSoFar + (daysLeft * avgDaily);
     const forecastedSavings = totalVariableBudget - projectedTotalVariableOutflow;
     
@@ -6943,12 +7162,18 @@
         const c = cb[e.categoryId];
         return (c?.type === 'expense' && c.id !== 'c_fixed') ? s + Math.abs(e.amount) : s;
     }, 0);
+    // Oszczędności BEZ inwestycji – inwestycje obsługiwane są przez plan inwestycyjny.
     const savingsTransfers = entries.reduce((s, e) => {
         const c = cb[e.categoryId];
-        return c?.type === 'saving' ? s + Math.abs(e.amount) : s;
+        if(!c || c.type !== 'saving') return s;
+        if(isInvestmentCategory(c)) return s;
+        return s + Math.abs(e.amount);
     }, 0);
+    const inv = getInvestmentSummary(ym);
 
-    const remainingVariableBudget = incomes - fixedPlanned - varSpent - savingsTransfers;
+    // Plan inwestycyjny rezerwuje kwotę z budżetu od razu (jak wydatki stałe).
+    // Dopiero faktyczne wpłaty powyżej planu (overage) dodatkowo obniżają budżet.
+    const remainingVariableBudget = incomes - fixedPlanned - varSpent - savingsTransfers - inv.effective;
 
     const days = daysInYm(ym);
     const daysElapsed = (ym === monthKey()) ? new Date().getDate() : (monthKey() > ym ? days : 0);
@@ -6957,9 +7182,10 @@
     const avgDaily = (daysElapsed > 0 ? (spentSoFar / daysElapsed) : 0);
     const daysLeft = getDaysRemaining(ym);
     const projectedTotalVariableOutflow = spentSoFar + (daysLeft * avgDaily);
-    const forecastedSavings = (incomes - fixedPlanned) - projectedTotalVariableOutflow;
+    // Prognoza: budżet pomniejszony o stałe oraz zarezerwowany plan inwestycyjny.
+    const forecastedSavings = (incomes - fixedPlanned - inv.effective) - projectedTotalVariableOutflow;
     const savingsRate = incomes > 0 ? (forecastedSavings / incomes) * 100 : 0;
-    
+
     document.getElementById('ov-inc').textContent = fmt(incomes, state.currency);
     document.getElementById('ov-fixed-planned').textContent = fmt(fixedPlanned, state.currency);
     document.getElementById('ov-fixed-paid').textContent = fmt(fixedPaid, state.currency);
@@ -6968,6 +7194,31 @@
     document.getElementById('ov-savings').textContent = fmt(savingsTransfers, state.currency);
     document.getElementById('ov-remaining').textContent = fmt(remainingVariableBudget, state.currency);
     document.getElementById('stat-savings-rate').textContent = savingsRate.toFixed(0)+'%';
+    const ovInvPlan = document.getElementById('ov-inv-planned');
+    const ovInvActual = document.getElementById('ov-inv-actual');
+    const ovInvProgress = document.getElementById('ov-inv-progress');
+    const ovInvProgressFill = document.getElementById('ov-inv-progress-fill');
+    const ovInvDelta = document.getElementById('ov-inv-delta');
+    if(ovInvPlan) ovInvPlan.textContent = fmt(inv.planned, state.currency);
+    if(ovInvActual) ovInvActual.textContent = fmt(inv.actual, state.currency);
+    if(ovInvDelta){
+      if(inv.planned <= 0){
+        ovInvDelta.textContent = inv.actual > 0 ? `Brak planu — zainwestowano ${fmt(inv.actual, state.currency)}` : 'Brak planu na ten miesiąc';
+        ovInvDelta.className = 'tiny muted';
+      } else if(inv.overage > 0){
+        ovInvDelta.textContent = `Powyżej planu o ${fmt(inv.overage, state.currency)}`;
+        ovInvDelta.className = 'tiny warn';
+      } else {
+        ovInvDelta.textContent = `Pozostało do planu: ${fmt(inv.reserved, state.currency)}`;
+        ovInvDelta.className = 'tiny muted';
+      }
+    }
+    if(ovInvProgress && ovInvProgressFill){
+      const pct = inv.planned > 0 ? Math.min(150, (inv.actual / inv.planned) * 100) : 0;
+      ovInvProgressFill.style.width = `${Math.min(100, pct)}%`;
+      ovInvProgressFill.style.background = inv.overage > 0 ? 'var(--red, #dc2626)' : 'var(--blue, #2563eb)';
+      ovInvProgress.title = inv.planned > 0 ? `${pct.toFixed(0)}% planu` : 'Brak planu';
+    }
   }
 
   // --- Forms ------------------------------------------------------------------
@@ -19063,6 +19314,7 @@
     document.getElementById('workingMonth').textContent=ym;
     safeRender(renderDashboard,'Dashboard');
     safeRender(renderOverview,'Overview');
+    safeRender(renderInvestmentPlan,'InvestmentPlan');
     safeRender(renderIncomes,'Incomes');
     safeRender(renderFixed,'Fixed');
     safeRender(renderVariable,'Variable');

--- a/index.html
+++ b/index.html
@@ -712,22 +712,41 @@ function renderKPIData(){
       const daysInMonth = new Date(ym.split('-')[0], ym.split('-')[1], 0).getDate();
       const currentDay = new Date().getDate();
 
-      const dailyBudget = Math.max(0, (incSum - fixSum)/daysInMonth);
+      const catsById = Object.fromEntries((Array.isArray(bState?.categories)?bState.categories:[]).map(c=>[c.id,c]));
+      const isInvCat = (cat) => !!cat && (cat.id === 'c_invest' || cat.name === 'Inwestycje');
+      const txs = Array.isArray(bState?.transactions) ? bState.transactions : [];
+
+      // Plan inwestycyjny (z budget.html: monthly[ym].investmentPlan)
+      const invPlan = (m && typeof m.investmentPlan === 'object') ? m.investmentPlan : null;
+      const investmentPlanned = num(invPlan?.amount) || 0;
+      const investmentActual = txs
+        .filter(t => String(t.date||'').startsWith(ym))
+        .reduce((sum,t)=>{
+          if(t.splits?.length){
+            return sum + t.splits.reduce((ss,sp)=> isInvCat(catsById[sp.categoryId]) ? ss+Math.abs(num(sp.amount)) : ss, 0);
+          }
+          return isInvCat(catsById[t.categoryId]) ? sum+Math.abs(num(t.amount)) : sum;
+        }, 0);
+      const investmentEffective = Math.max(investmentPlanned, investmentActual);
+      const investmentOverage = Math.max(0, investmentActual - investmentPlanned);
+      const investmentReserved = Math.max(0, investmentPlanned - investmentActual);
+
+      // Limit dzienny i bufor: budżet po odjęciu stałych ORAZ zarezerwowanego planu inwestycyjnego.
+      // Inwestycje nie liczą się do "spentUntilToday" — są obsługiwane przez plan.
+      const dailyBudget = Math.max(0, (incSum - fixSum - investmentEffective)/daysInMonth);
       const budgetForToday = dailyBudget * currentDay;
 
-      const catsById = Object.fromEntries((Array.isArray(bState?.categories)?bState.categories:[]).map(c=>[c.id,c]));
-      const txs = Array.isArray(bState?.transactions) ? bState.transactions : [];
       const spentUntilToday = txs.filter(t=> String(t.date||'').startsWith(ym) && new Date(t.date).getDate()<=currentDay).reduce((sum,t)=>{
-        if(t.splits?.length){ return sum + t.splits.reduce((ss,sp)=>{ const cat=catsById[sp.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving') && cat.id!=='c_fixed') ? ss+Math.abs(num(sp.amount)) : ss },0) }
-        const cat=catsById[t.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving') && cat.id!=='c_fixed') ? sum+Math.abs(num(t.amount)) : sum
+        if(t.splits?.length){ return sum + t.splits.reduce((ss,sp)=>{ const cat=catsById[sp.categoryId]; if(!cat || isInvCat(cat)) return ss; return ((cat.type==='expense'||cat.type==='saving') && cat.id!=='c_fixed') ? ss+Math.abs(num(sp.amount)) : ss },0) }
+        const cat=catsById[t.categoryId]; if(!cat || isInvCat(cat)) return sum; return ((cat.type==='expense'||cat.type==='saving') && cat.id!=='c_fixed') ? sum+Math.abs(num(t.amount)) : sum
       },0);
 
       const buffer = budgetForToday - spentUntilToday;
       const bufferClass = buffer > budgetForToday * 0.2 ? 'value-ok' : buffer >= 0 ? 'value-warn' : 'value-bad';
 
       const totalSpentMonth = txs.filter(t=> String(t.date||'').startsWith(ym)).reduce((sum,t)=>{
-        if(t.splits?.length){ return sum + t.splits.reduce((ss,sp)=>{ const cat=catsById[sp.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving')) ? ss+Math.abs(num(sp.amount)) : ss },0) }
-        const cat=catsById[t.categoryId]; return (cat && (cat.type==='expense'||cat.type==='saving')) ? sum+Math.abs(num(t.amount)) : sum
+        if(t.splits?.length){ return sum + t.splits.reduce((ss,sp)=>{ const cat=catsById[sp.categoryId]; if(!cat || isInvCat(cat)) return ss; return (cat.type==='expense'||cat.type==='saving') ? ss+Math.abs(num(sp.amount)) : ss },0) }
+        const cat=catsById[t.categoryId]; if(!cat || isInvCat(cat)) return sum; return (cat.type==='expense'||cat.type==='saving') ? sum+Math.abs(num(t.amount)) : sum
       },0);
       const monthlyBudget = incSum;
       const spentPct = monthlyBudget > 0 ? (totalSpentMonth / monthlyBudget) * 100 : 0;
@@ -737,15 +756,17 @@ function renderKPIData(){
         `Plan miesięczny: ${fmt(monthlyBudget)} (wykorzystano ${Math.round(spentPct)}%).`
       ];
 
-      // Month-end savings forecast: extrapolate variable-only spend rate (matches budget.html logic)
+      // Prognoza oszczędności na koniec miesiąca: spójna z budget.html.
+      // Bazuje na ekstrapolacji wydatków zmiennych (BEZ inwestycji) i odejmuje
+      // zarezerwowany plan inwestycyjny od budżetu.
       const dailySpendRate = currentDay > 0 ? spentUntilToday / currentDay : 0;
       const projectedTotalSpend = dailySpendRate * daysInMonth;
-      const projectedSavings = (incSum - fixSum) - projectedTotalSpend;
+      const projectedSavings = (incSum - fixSum - investmentEffective) - projectedTotalSpend;
 
-      // Already saved this month: find saving-type categories by name pattern
+      // Already saved this month: find saving-type categories by name pattern (BEZ inwestycji – te są osobno jako plan)
       const monthTxs = txs.filter(t => String(t.date||'').startsWith(ym));
       const allCategories = Array.isArray(bState?.categories) ? bState.categories : [];
-      const savingCats = allCategories.filter(c => c.type === 'saving');
+      const savingCats = allCategories.filter(c => c.type === 'saving' && !isInvCat(c));
 
       function savingIdsByName(namePart) {
         return new Set(savingCats.filter(c => (c.name||'').toLowerCase().includes(namePart)).map(c => c.id));
@@ -757,23 +778,38 @@ function renderKPIData(){
         }, 0);
       }
 
-      const investIds = savingIdsByName('inwestycj');
       const sharedIds = savingIdsByName('oszczędnoś');
-      // fallback: any saving not matched above
-      const otherSavingIds = new Set(savingCats.filter(c => !investIds.has(c.id) && !sharedIds.has(c.id)).map(c => c.id));
+      const otherSavingIds = new Set(savingCats.filter(c => !sharedIds.has(c.id)).map(c => c.id));
 
-      const investSaved  = sumByIds(investIds);
       const sharedSaved  = sumByIds(sharedIds);
       const otherSaved   = sumByIds(otherSavingIds);
-      const totalAlreadySaved = investSaved + sharedSaved + otherSaved;
+      const totalAlreadySaved = sharedSaved + otherSaved;
+      // Prognoza ŁĄCZNYCH oszczędności: prognoza zmiennych + już odłożone (bez inwestycji).
+      // Inwestycje są pokazane osobno jako plan/postęp (nie wliczają się ponownie do prognozy,
+      // bo plan został już odjęty od budżetu).
       const totalForecast = projectedSavings + totalAlreadySaved;
       const forecastSign  = totalForecast >= 0 ? '+' : '';
       const forecastClass = totalForecast >= 0 ? 'value-ok' : 'value-bad';
       const projSign = projectedSavings >= 0 ? '+' : '';
 
-      // Build invest/shared category name labels from actual categories
-      const investLabel = investIds.size ? [...savingCats].filter(c=>investIds.has(c.id)).map(c=>c.name).join(', ') : 'Inwestycje';
       const sharedLabel = sharedIds.size ? [...savingCats].filter(c=>sharedIds.has(c.id)).map(c=>c.name).join(', ') : 'Oszczędności wspólne';
+
+      // Sekcja inwestycji – plan vs postęp z budget.html
+      const invHasData = investmentPlanned > 0 || investmentActual > 0;
+      let invLine = '';
+      if(invHasData){
+        const invValClass = investmentOverage > 0 ? 'value-bad' : 'value-ok';
+        const invHint = investmentPlanned > 0
+          ? (investmentOverage > 0
+              ? `nadwyżka ${fmt(investmentOverage,'')}`
+              : `pozostało ${fmt(investmentReserved,'')}`)
+          : 'brak planu';
+        invLine = `
+              <div class="budget-saving-row">
+                <span class="budget-saving-label">Inwestycje (plan)</span>
+                <span class="budget-saving-val ${invValClass}">${fmt(investmentActual,'')} / ${fmt(investmentPlanned,'')}<span class="tiny muted" style="margin-left:6px;">${invHint}</span></span>
+              </div>`;
+      }
 
       const bufferSign = buffer >= 0 ? '+' : '';
       kpiElements.budget.innerHTML = `
@@ -785,6 +821,7 @@ function renderKPIData(){
             <div class="budget-mini-stats">
               <span>${fmt(incSum)} <span class="budget-mini-label">dochód</span></span>
               <span>${fmt(fixSum)} <span class="budget-mini-label">stałe</span></span>
+              <span>${fmt(investmentEffective)} <span class="budget-mini-label">inwestycje</span></span>
               <span>${fmt(totalSpentMonth)} <span class="budget-mini-label">wydano</span></span>
             </div>
           </div>
@@ -795,11 +832,7 @@ function renderKPIData(){
               <div class="budget-saving-row">
                 <span class="budget-saving-label">Prognoza zmiennych</span>
                 <span class="budget-saving-val ${projectedSavings>=0?'value-ok':'value-bad'}">${projSign}${fmt(projectedSavings,'')}</span>
-              </div>
-              <div class="budget-saving-row">
-                <span class="budget-saving-label">${investLabel}</span>
-                <span class="budget-saving-val">${investSaved > 0 ? fmt(investSaved,'') : '—'}</span>
-              </div>
+              </div>${invLine}
               <div class="budget-saving-row">
                 <span class="budget-saving-label">${sharedLabel}</span>
                 <span class="budget-saving-val">${sharedSaved > 0 ? fmt(sharedSaved,'') : '—'}</span>
@@ -1150,9 +1183,13 @@ function getInvestmentStats(){
     .filter(t => t.date && t.date.startsWith(ym) && (t.side||'').toLowerCase()==='buy' && t.fundSource!=='reinvest')
     .reduce((s,t) => s + num(t.amount), 0);
 
-  /* ---- Monthly goal from settings ---- */
+  /* ---- Monthly goal: priorytet ma plan z budget.html (monthly[ym].investmentPlan),
+         fallback do globalnego celu z ustawień. ---- */
+  const monthlyPlan = num(bm?.monthly?.[ym]?.investmentPlan?.amount) || 0;
   const settings = safeParse(localStorage.getItem(SETTINGS_STORAGE_KEY), {}) || {};
-  const monthlyGoal = num(settings.invMonthlyGoal) || 0;
+  const settingsGoal = num(settings.invMonthlyGoal) || 0;
+  const monthlyGoal = monthlyPlan > 0 ? monthlyPlan : settingsGoal;
+  const monthlyGoalSource = monthlyPlan > 0 ? 'plan' : (settingsGoal > 0 ? 'settings' : null);
 
   /* ---- Reinvestment pool (sell proceeds not returned to budget, minus already reinvested) ---- */
   let reinvestPool = 0;
@@ -1217,7 +1254,7 @@ function getInvestmentStats(){
   const savingsMv = savingsEntry ? savingsEntry[1].mv : 0;
   const availableCapital = savingsMv + reinvestPool;
 
-  return { portfolioValue, totalPnl, roi, costBasis, monthlyContrib, monthlyGoal, groupBreakdown, availableCapital };
+  return { portfolioValue, totalPnl, roi, costBasis, monthlyContrib, monthlyGoal, monthlyGoalSource, groupBreakdown, availableCapital };
 }
 
 function renderInvestmentKPI(){
@@ -1242,10 +1279,13 @@ function renderInvestmentKPI(){
   const contribPct   = s.monthlyGoal > 0 ? Math.min(100,(s.monthlyContrib/s.monthlyGoal)*100) : 0;
   const goalBarColor = contribPct >= 100 ? 'var(--green)' : '#0057c0';
 
+  const goalSourceLabel = s.monthlyGoalSource === 'plan'
+    ? 'plan miesięczny'
+    : (s.monthlyGoalSource === 'settings' ? 'cel z ustawień' : '');
   const goalSection = s.monthlyGoal > 0 ? `
     <div class="inv-goal-section">
       <div class="inv-goal-header">
-        <span class="tiny muted">Wpłaty w tym miesiącu</span>
+        <span class="tiny muted">Wpłaty w tym miesiącu${goalSourceLabel ? ` <span style="opacity:.7">(${goalSourceLabel})</span>` : ''}</span>
         <span class="tiny muted">${fmt(s.monthlyContrib)} / ${fmt(s.monthlyGoal)}</span>
       </div>
       <div class="progress" style="height:6px;margin-top:4px;">
@@ -1565,9 +1605,9 @@ function openSettingsModal(){
             <p class="tiny muted" style="margin-top: 6px;">Wpisz miasto, dla którego chcesz widzieć prognozę pogody.</p>
           </div>
           <div>
-            <label for="inv-monthly-goal" style="font-weight:600; margin-bottom: 6px; display:block;">Cel miesięcznych wpłat na inwestycje (PLN)</label>
+            <label for="inv-monthly-goal" style="font-weight:600; margin-bottom: 6px; display:block;">Cel miesięcznych wpłat na inwestycje (PLN) – fallback</label>
             <input type="number" id="inv-monthly-goal" value="${invMonthlyGoal}" placeholder="np. 2000" min="0" step="100">
-            <p class="tiny muted" style="margin-top: 6px;">Ustaw miesięczny cel wpłat, który będzie śledzony na dashboardzie.</p>
+            <p class="tiny muted" style="margin-top: 6px;">Wartość zastępcza: jeśli w module Budżet (zakładka „Przegląd miesiąca") ustawisz Plan inwestycyjny na bieżący miesiąc, on ma pierwszeństwo.</p>
           </div>
         </div>
     `, buttons);

--- a/styles.css
+++ b/styles.css
@@ -920,6 +920,72 @@ textarea:focus {
   color: var(--danger);
 }
 
+.inv-progress-track {
+  width: 100%;
+  height: 6px;
+  background: var(--line, #e5e7eb);
+  border-radius: 999px;
+  overflow: hidden;
+  margin-top: 4px;
+}
+
+.inv-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--blue, #2563eb);
+  border-radius: 999px;
+  transition: width 0.25s ease, background-color 0.25s ease;
+}
+
+.inv-plan-card {
+  border: 1px solid var(--line, #e5e7eb);
+  border-radius: 14px;
+  padding: 14px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.04), rgba(124, 58, 237, 0.04));
+  margin-top: 12px;
+}
+
+.inv-plan-card .inv-plan-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.inv-plan-card .inv-plan-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.inv-plan-card .inv-plan-stat {
+  background: #fff;
+  border: 1px solid var(--line, #e5e7eb);
+  border-radius: 10px;
+  padding: 8px 10px;
+}
+
+.inv-plan-card .inv-plan-stat .lbl {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted, #64748b);
+  font-weight: 600;
+}
+
+.inv-plan-card .inv-plan-stat .val {
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.inv-plan-card .inv-plan-stat.warn .val { color: var(--danger, #dc2626); }
+.inv-plan-card .inv-plan-stat.ok .val { color: var(--success, #16a34a); }
+
+.tiny.warn { color: var(--danger, #dc2626); }
+
 .insight-bubble {
   font-size: 12px;
   padding: 8px 10px;


### PR DESCRIPTION
Wprowadza planowanie miesięcznych inwestycji analogiczne do planowanych
wydatków stałych. Plan rezerwuje kwotę z budżetu zmiennego od razu po
ustaleniu, faktyczne wpłaty na kategorię „Inwestycje" są liczone osobno
jako postęp, a budżet i prognoza dodatkowo obniżają się tylko o nadwyżkę
ponad plan. Dzięki temu prognoza oszczędności jest stabilna pomimo
księgowania regularnych wpłat inwestycyjnych w ciągu miesiąca.

- Nowa struktura danych monthly[ym].investmentPlan {amount, weekly, note}
- Helpery getInvestmentSummary / isInvestmentCategory
- Karta „Plan inwestycyjny" w przeglądzie miesiąca z formularzem
  (kwota miesięczna lub tygodniowa), kopiowaniem z poprzedniego miesiąca
  oraz statystykami plan/postęp/pozostało/nadwyżka
- KPI „Plan inwestycyjny" w prawym pasku dashboardu z paskiem postępu
- renderOverview / renderDashboard pomniejszają budżet i prognozę o
  max(plan, faktyczne); inwestycje wyłączone z licznika oszczędności
  i z getDailySpending używanego do prognozy