### PR TITLE
Add ROI vs Last Month metric to calendar view

### DIFF
--- a/trading.css
+++ b/trading.css
@@ -1011,6 +1011,36 @@ body[data-page="trading"] .site-header__title {
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
+.cal-lm-info {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 14px;
+  background: var(--tc-bg2, #f8fafc);
+  border-bottom: 1px solid var(--tc-line);
+  font-size: 12px;
+  flex-wrap: wrap;
+}
+.cal-lm-info .lm-label {
+  color: var(--tc-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+}
+.cal-lm-info .lm-value {
+  font-family: var(--mono);
+  font-weight: 700;
+  color: var(--tc-text);
+}
+.cal-lm-info .lm-target {
+  font-family: var(--mono);
+  font-weight: 600;
+  color: #16a34a;
+  background: #effaf3;
+  border: 1px solid #bfe8ce;
+  border-radius: 6px;
+  padding: 2px 8px;
+}
 .cal-buckets {
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));

--- a/trading.html
+++ b/trading.html
@@ -395,12 +395,14 @@
               <div class="filter-chip-grp" id="cal-metric-toggle">
                 <button class="filter-chip active" data-m="pnl">PnL</button>
                 <button class="filter-chip" data-m="roi">ROI</button>
+                <button class="filter-chip" data-m="roi-lm">ROI vs LM</button>
                 <button class="filter-chip" data-m="rr">RR</button>
                 <button class="filter-chip" data-m="depo">Depo</button>
                 <button class="filter-chip" data-m="trades">Trades</button>
                 <button class="filter-chip" data-m="wr">WR</button>
               </div>
             </div>
+            <div class="cal-lm-info" id="cal-lm-info" style="display:none"></div>
             <div class="cal-buckets" id="cal-buckets"></div>
             <div class="cal-grid-wrap">
               <div class="cal-weekdays">

--- a/trading.js
+++ b/trading.js
@@ -1277,6 +1277,7 @@ function fmtMetricValue(metric, stat) {
   if (!stat) return '—';
   if (metric === 'pnl') return fmtUSD(stat.pnl, true);
   if (metric === 'roi') return fmtPct(stat.roi, true, 2);
+  if (metric === 'roi-lm') return stat.roiLm !== null && Number.isFinite(stat.roiLm) ? fmtPct(stat.roiLm, true, 2) : '—';
   if (metric === 'rr') return fmtR(stat.rr, true, 2);
   if (metric === 'depo') return fmtUSD(stat.depo);
   if (metric === 'trades') return String(stat.trades);
@@ -1305,16 +1306,22 @@ function getMetricClass(metric, stat) {
     ? stat.pnl
     : metric === 'roi'
       ? stat.roi
-      : metric === 'rr'
-        ? (stat.rr ?? 0)
-        : 0;
+      : metric === 'roi-lm'
+        ? (stat.roiLm ?? 0)
+        : metric === 'rr'
+          ? (stat.rr ?? 0)
+          : 0;
   return v > 0 ? 'pos' : v < 0 ? 'neg' : '';
 }
 
-function calcBucketMetric(metric, stats) {
+function calcBucketMetric(metric, stats, lastMonthClosingDepo) {
   if (!stats.length) return '—';
   if (metric === 'pnl') return fmtUSD(stats.reduce((a, s) => a + s.pnl, 0), true);
   if (metric === 'roi') return fmtPct(stats.reduce((a, s) => a + s.pnl, 0) / Math.max(settings.capital, 0.01) * 100, true, 2);
+  if (metric === 'roi-lm') {
+    const base = lastMonthClosingDepo && lastMonthClosingDepo > 0 ? lastMonthClosingDepo : settings.capital;
+    return fmtPct(stats.reduce((a, s) => a + s.pnl, 0) / base * 100, true, 2);
+  }
   if (metric === 'rr') {
     const vals = stats.map(s => s.rr).filter(v => v !== null && Number.isFinite(v));
     return vals.length ? fmtR(vals.reduce((a, b) => a + b, 0) / vals.length, true, 2) : '—';
@@ -1333,7 +1340,7 @@ function calcBucketMetric(metric, stats) {
   return '—';
 }
 
-function renderCalendarBuckets(days, monthStats, metric) {
+function renderCalendarBuckets(days, monthStats, metric, lastMonthClosingDepo) {
   const wrap = document.getElementById('cal-buckets');
   const ranges = [[1,7],[8,14],[15,21],[22,28],[29,days],['all','all']];
   wrap.innerHTML = ranges.map(r => {
@@ -1346,9 +1353,12 @@ function renderCalendarBuckets(days, monthStats, metric) {
           })
           .map(k => monthStats[k]);
     const stats = statsRaw.filter(s => !s.isFuture);
+    const bucketPnl = stats.reduce((a, s) => a + s.pnl, 0);
+    const lmBase = lastMonthClosingDepo > 0 ? lastMonthClosingDepo : settings.capital;
     const aggStat = {
-      pnl: stats.reduce((a, s) => a + s.pnl, 0),
-      roi: settings.capital > 0 ? (stats.reduce((a, s) => a + s.pnl, 0) / settings.capital) * 100 : 0,
+      pnl: bucketPnl,
+      roi: settings.capital > 0 ? (bucketPnl / settings.capital) * 100 : 0,
+      roiLm: lmBase > 0 ? (bucketPnl / lmBase) * 100 : null,
       depo: stats.length ? stats[stats.length - 1].depo : null,
       rr: (() => {
         const vals = stats.map(s => s.rr).filter(v => v !== null && Number.isFinite(v));
@@ -1361,7 +1371,7 @@ function renderCalendarBuckets(days, monthStats, metric) {
       })()
     };
     const label = r[0] === 'all' ? 'Full Month' : `${r[0]}-${r[1]} dzień`;
-    return `<div class="cal-bucket"><div class="k">${label}</div><div class="v ${getMetricClass(metric, aggStat)}">${calcBucketMetric(metric, stats)}</div></div>`;
+    return `<div class="cal-bucket"><div class="k">${label}</div><div class="v ${getMetricClass(metric, aggStat)}">${calcBucketMetric(metric, stats, lastMonthClosingDepo)}</div></div>`;
   }).join('');
 }
 
@@ -1384,17 +1394,29 @@ function renderCalendarView() {
   const pnlBeforeMonth = Object.entries(agg.byDay)
     .filter(([k]) => k < monthStartKey)
     .reduce((a, [, v]) => a + v, 0);
-  let runningDepo = settings.capital + pnlBeforeMonth;
+  const lastMonthClosingDepo = settings.capital + pnlBeforeMonth;
+  let runningDepo = lastMonthClosingDepo;
+
+  // info bar — last month closing deposit (baza dla ROI vs LM)
+  const lmInfoEl = document.getElementById('cal-lm-info');
+  if (lmInfoEl) {
+    const prevMonthDate = new Date(year, mon - 2, 1);
+    const prevMonthName = prevMonthDate.toLocaleDateString('pl-PL', { month: 'long', year: 'numeric' });
+    lmInfoEl.style.display = '';
+    lmInfoEl.innerHTML = `<span class="lm-label">Zamknięcie ${prevMonthName}:</span><span class="lm-value">${fmtUSD(lastMonthClosingDepo)}</span><span class="lm-target">cel +10%: ${fmtUSD(lastMonthClosingDepo * 1.1)}</span>`;
+  }
+
   for (let d = 1; d <= daysInMonth; d++) {
     const key = `${year}-${String(mon).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
     const day = daily[key] || { pnl: 0, roi: 0, rr: null, trades: 0, wins: 0, losses: 0, wr: null };
     const isFuture = key > todayKey;
     if (!isFuture) runningDepo += day.pnl;
+    const roiLm = !isFuture && lastMonthClosingDepo > 0 ? (day.pnl / lastMonthClosingDepo) * 100 : null;
     monthStats[key] = isFuture
-      ? { pnl: null, roi: null, rr: null, depo: null, trades: 0, wins: 0, losses: 0, wr: null, isFuture: true }
-      : { ...day, depo: runningDepo, isFuture: false };
+      ? { pnl: null, roi: null, roiLm: null, rr: null, depo: null, trades: 0, wins: 0, losses: 0, wr: null, isFuture: true }
+      : { ...day, depo: runningDepo, roiLm, isFuture: false };
   }
-  renderCalendarBuckets(daysInMonth, monthStats, metric);
+  renderCalendarBuckets(daysInMonth, monthStats, metric, lastMonthClosingDepo);
 
   const cells = [];
   for (let i = 0; i < firstDay; i++) cells.push(`<div class="cal-cell empty"></div>`);


### PR DESCRIPTION
## Summary
Added a new "ROI vs LM" (Return on Investment vs Last Month) metric to the trading calendar view, allowing traders to track performance relative to the previous month's closing deposit instead of just the initial capital.

## Key Changes

- **New metric `roi-lm`**: Calculates ROI based on the previous month's closing deposit as the base instead of the initial capital
  - Added formatting logic in `fmtMetricValue()` to display the metric with proper null/NaN handling
  - Updated `getMetricClass()` to support color-coding (positive/negative) for the new metric
  
- **Last Month Info Bar**: Added a new information section displaying:
  - Previous month's closing deposit (the base for ROI vs LM calculation)
  - A visual target indicator showing +10% goal
  - Styled with dedicated CSS classes for clarity

- **Bucket Metric Calculation**: Extended `calcBucketMetric()` to compute ROI vs LM for weekly/monthly buckets using the last month's closing deposit as the denominator

- **Calendar Data Structure**: Updated month statistics to include `roiLm` field for each day, calculated as `(daily_pnl / lastMonthClosingDepo) * 100`

- **UI Updates**:
  - Added "ROI vs LM" filter chip button to metric toggle group
  - Added `cal-lm-info` element to display last month closing deposit and target
  - Styled the info bar with proper typography and color scheme

## Implementation Details

- The `lastMonthClosingDepo` is calculated as `settings.capital + pnlBeforeMonth` (initial capital plus cumulative PnL before the current month)
- Future dates (not yet occurred) have `roiLm` set to `null` to avoid misleading projections
- The metric gracefully falls back to initial capital if last month's closing deposit is invalid or zero

https://claude.ai/code/session_01BSXqLh1iZ9oQ4pao1em1WF