### PR TITLE
Add investment asset deep-dive modal with P&L and history

### DIFF
--- a/budget.html
+++ b/budget.html
@@ -368,6 +368,10 @@
     .inv-deep-list table{width:100%;border-collapse:collapse}
     .inv-deep-list th,.inv-deep-list td{padding:7px 4px;border-bottom:1px solid #eef2f7;font-size:12px;text-align:left}
     .inv-deep-list tr:last-child td{border-bottom:none}
+    .inv-deep-lots{display:grid;gap:8px;margin-top:8px}
+    .inv-deep-lot{border:1px solid #e2e8f0;border-radius:10px;padding:8px;background:#f8fafc}
+    .inv-deep-lot-top{display:flex;justify-content:space-between;gap:8px;flex-wrap:wrap;font-size:12px}
+    .inv-deep-lot-meta{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:4px 10px;margin-top:6px;font-size:12px}
     @media(max-width:780px){.inv-deep-grid{grid-template-columns:1fr}}
 
     /* --- Investment Analytics Hub ------------------------------------------- */
@@ -5378,6 +5382,8 @@
                 <div class="inv-deep-list">
                   <strong>Metryki pozycji</strong>
                   <table><tbody id="inv-deep-metrics"></tbody></table>
+                  <div class="row" style="justify-content:space-between;margin-top:8px"><strong>DCA — zakupy i wynik</strong><span class="tiny muted" id="inv-deep-lots-count"></span></div>
+                  <div id="inv-deep-lots" class="inv-deep-lots"></div>
                 </div>
               </div>
             </div>
@@ -8986,7 +8992,11 @@
     const roi=(buyAmount>0)?(totalPnl/buyAmount)*100:null;
     const firstDate=[...assetTrades].sort((a,b)=>String(a.date||'').localeCompare(String(b.date||'')))[0]?.date||'—';
     const lastDate=assetTrades[0]?.date||'—';
+    const now=new Date();
+    const firstDateObj=firstDate!=='—'?new Date(firstDate):null;
+    const holdingDays=firstDateObj?Math.max(0,Math.floor((now-firstDateObj)/(1000*60*60*24))):null;
     const cur=state.currency;
+    const avgBuyPrice=buys.length?buys.reduce((s,t)=>s+(num(t.amount)/Math.max(num(t.quantity),0.000001)),0)/buys.length:null;
 
     document.getElementById('inv-deep-title').textContent=`${asset.name}`;
     document.getElementById('inv-deep-sub').textContent=`${asset.group||'Inne'} • ${asset.symbol||'brak tickera'}`;
@@ -8997,7 +9007,8 @@
       <div class="inv-deep-kpi"><div class="lbl">Niezrealizowane P&L</div><div class="val ${unrealized>=0?'inv-pnl-pos':'inv-pnl-neg'}">${unrealized===null?'—':`${unrealized>=0?'+':''}${fmt(unrealized,cur)}`}</div></div>
       <div class="inv-deep-kpi"><div class="lbl">Zrealizowane P&L</div><div class="val ${realized>=0?'inv-pnl-pos':'inv-pnl-neg'}">${realized>=0?'+':''}${fmt(realized,cur)}</div></div>
       <div class="inv-deep-kpi"><div class="lbl">Łączne P&L</div><div class="val ${totalPnl>=0?'inv-pnl-pos':'inv-pnl-neg'}">${totalPnl>=0?'+':''}${fmt(totalPnl,cur)}</div></div>
-      <div class="inv-deep-kpi"><div class="lbl">ROI od wpłat</div><div class="val">${roi===null?'—':`${roi>=0?'+':''}${roi.toFixed(1)}%`}</div></div>`;
+      <div class="inv-deep-kpi"><div class="lbl">ROI od wpłat</div><div class="val">${roi===null?'—':`${roi>=0?'+':''}${roi.toFixed(1)}%`}</div></div>
+      <div class="inv-deep-kpi"><div class="lbl">Dni w pozycji</div><div class="val">${holdingDays===null?'—':holdingDays}</div></div>`;
 
     document.getElementById('inv-deep-metrics').innerHTML=`
       <tr><td>Pierwsza transakcja</td><td><strong>${firstDate}</strong></td></tr>
@@ -9016,6 +9027,43 @@
     }).join(''):'<tr><td colspan="6" class="muted">Brak transakcji</td></tr>';
 
     const backdrop=document.getElementById('inv-deep-backdrop');
+    const lotsWrap=document.getElementById('inv-deep-lots');
+    const lotsCount=document.getElementById('inv-deep-lots-count');
+    const buyLots=buys.slice().sort((a,b)=>String(a.date||'').localeCompare(String(b.date||'')));
+    const sellQueue=sells.slice().sort((a,b)=>String(a.date||'').localeCompare(String(b.date||''))).map(t=>({qty:num(t.quantity)}));
+    const lots=buyLots.map(t=>({date:t.date,qty:num(t.quantity),amount:num(t.amount),ppu:num(t.amount)/Math.max(num(t.quantity),0.000001),remaining:num(t.quantity)}));
+    for(const lot of lots){
+      let remainingToMatch=lot.remaining;
+      for(const sq of sellQueue){
+        if(remainingToMatch<=0) break;
+        if(sq.qty<=0) continue;
+        const take=Math.min(remainingToMatch,sq.qty);
+        remainingToMatch-=take;
+        sq.qty-=take;
+      }
+      lot.remaining=remainingToMatch;
+      const days=Math.max(0,Math.floor((now-new Date(lot.date||now))/(1000*60*60*24)));
+      const refPrice=num(asset.currentPrice)||lot.ppu;
+      lot.unrealized=(refPrice-lot.ppu)*lot.remaining;
+      lot.realizedPart=(lot.qty-lot.remaining)*lot.ppu;
+      lot.days=days;
+      lot.lateFlag=avgBuyPrice!==null&&lot.ppu>avgBuyPrice*1.1;
+    }
+    lotsCount.textContent=`${lots.length} zakupów`;
+    lotsWrap.innerHTML=lots.length?lots.map((lot,idx)=>{
+      const cls=lot.unrealized>=0?'inv-pnl-pos':'inv-pnl-neg';
+      return `<div class="inv-deep-lot">
+        <div class="inv-deep-lot-top"><strong>#${idx+1} ${lot.date||'—'}</strong><span>${lot.days} dni</span></div>
+        <div class="inv-deep-lot-meta">
+          <span>Ilość: <strong>${lot.qty.toFixed(4)}</strong></span>
+          <span>Pozostało: <strong>${lot.remaining.toFixed(4)}</strong></span>
+          <span>Cena zakupu: <strong>${fmt(lot.ppu,cur)}</strong></span>
+          <span>Kwota: <strong>${fmt(lot.amount,cur)}</strong></span>
+          <span>P&L na pozostałej części: <strong class="${cls}">${lot.unrealized>=0?'+':''}${fmt(lot.unrealized,cur)}</strong></span>
+          <span>${lot.lateFlag?'<strong style="color:#b45309">Możliwy zakup na szczycie</strong>':'Timing OK'}</span>
+        </div>
+      </div>`;
+    }).join(''):'<div class="tiny muted">Brak zakupów do analizy DCA.</div>';
     backdrop.classList.add('open');
     backdrop.setAttribute('aria-hidden','false');
   }

--- a/budget.html
+++ b/budget.html
@@ -353,6 +353,22 @@
     .inv-holdings-group-toggle { border:none; background:transparent; cursor:pointer; font:inherit; color:inherit; display:flex; align-items:center; gap:8px; padding:0; }
     .inv-holdings-group-chevron { color:var(--muted); width:12px; display:inline-block; }
     .inv-holdings-group-metrics { display:flex; flex-wrap:wrap; justify-content:flex-end; gap:10px; font-size:12px; font-weight:600; color:var(--muted); }
+    .inv-asset-name-btn{background:none;border:none;padding:0;color:var(--ink);font:inherit;font-weight:700;cursor:pointer;text-align:left}
+    .inv-asset-name-btn:hover{color:var(--accent);text-decoration:underline}
+    .inv-deep-backdrop{position:fixed;inset:0;background:rgba(15,23,42,.55);display:none;align-items:center;justify-content:center;padding:20px;z-index:1400}
+    .inv-deep-backdrop.open{display:flex}
+    .inv-deep-modal{width:min(980px,100%);max-height:90vh;overflow:auto;background:var(--surface);border:1px solid var(--line);border-radius:18px;padding:18px;box-shadow:0 30px 60px rgba(15,23,42,.35);display:grid;gap:14px}
+    .inv-deep-head{display:flex;justify-content:space-between;gap:12px;align-items:flex-start}
+    .inv-deep-kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px}
+    .inv-deep-kpi{border:1px solid var(--line);background:#f8fafc;border-radius:12px;padding:10px 12px}
+    .inv-deep-kpi .lbl{font-size:11px;color:var(--muted);font-weight:700;text-transform:uppercase}
+    .inv-deep-kpi .val{margin-top:4px;font-size:18px;font-weight:800}
+    .inv-deep-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:12px}
+    .inv-deep-list{border:1px solid var(--line);border-radius:12px;padding:10px;background:#fff}
+    .inv-deep-list table{width:100%;border-collapse:collapse}
+    .inv-deep-list th,.inv-deep-list td{padding:7px 4px;border-bottom:1px solid #eef2f7;font-size:12px;text-align:left}
+    .inv-deep-list tr:last-child td{border-bottom:none}
+    @media(max-width:780px){.inv-deep-grid{grid-template-columns:1fr}}
 
     /* --- Investment Analytics Hub ------------------------------------------- */
     .inv-hub-snapshot-bar { display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:8px; }
@@ -5341,6 +5357,32 @@
             </div>
           </div>
 
+          <div class="inv-deep-backdrop" id="inv-deep-backdrop" aria-hidden="true">
+            <div class="inv-deep-modal" role="dialog" aria-modal="true" aria-labelledby="inv-deep-title">
+              <div class="inv-deep-head">
+                <div>
+                  <h3 id="inv-deep-title" style="margin:0">Szczegóły aktywa</h3>
+                  <div class="tiny muted" id="inv-deep-sub">—</div>
+                </div>
+                <button class="btn ghost" type="button" id="inv-deep-close">Zamknij</button>
+              </div>
+              <div class="inv-deep-kpis" id="inv-deep-kpis"></div>
+              <div class="inv-deep-grid">
+                <div class="inv-deep-list">
+                  <div class="row" style="justify-content:space-between"><strong>Historia transakcji</strong><span class="tiny muted" id="inv-deep-count"></span></div>
+                  <table>
+                    <thead><tr><th>Data</th><th>Typ</th><th>Ilość</th><th>Kwota</th><th>Cena/szt</th><th>P&amp;L</th></tr></thead>
+                    <tbody id="inv-deep-trades"></tbody>
+                  </table>
+                </div>
+                <div class="inv-deep-list">
+                  <strong>Metryki pozycji</strong>
+                  <table><tbody id="inv-deep-metrics"></tbody></table>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <!-- Group Summary -->
           <div class="card stack">
             <div class="row" style="justify-content:space-between;align-items:center">
@@ -8864,6 +8906,11 @@
         }
       };
     };
+    const bindDeepDive=tr=>{
+      tr.querySelector('.inv-asset-name-btn')?.addEventListener('click',()=>{
+        openInvestmentAssetDetail(tr.dataset.assetId, holdings, stats);
+      });
+    };
 
     for(const g of groups){
       const isCollapsed=invCollapsedGroups.has(g.name);
@@ -8890,9 +8937,11 @@
           roiHtml=`<span class="${cls}">${sign}${pct.toFixed(1)}%</span>`;
         }
         const priceDisplay=h.currentPrice?fmt(h.currentPrice,state.currency):'<span class="muted">ustaw</span>';
-        tr.innerHTML=`<td><strong>${escapeHtml(h.name)}</strong></td><td>${h.qty.toFixed(4)}</td><td>${fmt(h.avgCost,state.currency)}</td><td class="inv-price-cell" data-asset-id="${h.id}" style="cursor:pointer" title="Kliknij, aby zmienić cenę">${priceDisplay}</td><td>${fmt(val,state.currency)}</td><td>${pnlHtml}</td><td>${roiHtml}</td><td>${weight}%</td><td><button class="btn ghost inv-sell-quick" data-sell-asset="${h.id}" data-sell-qty="${h.qty}" style="font-size:11px;padding:4px 8px">Sprzedaj</button></td>`;
+        tr.dataset.assetId=h.id;
+        tr.innerHTML=`<td><button type="button" class="inv-asset-name-btn" title="Kliknij, aby zobaczyć szczegóły">${escapeHtml(h.name)}</button></td><td>${h.qty.toFixed(4)}</td><td>${fmt(h.avgCost,state.currency)}</td><td class="inv-price-cell" data-asset-id="${h.id}" style="cursor:pointer" title="Kliknij, aby zmienić cenę">${priceDisplay}</td><td>${fmt(val,state.currency)}</td><td>${pnlHtml}</td><td>${roiHtml}</td><td>${weight}%</td><td><button class="btn ghost inv-sell-quick" data-sell-asset="${h.id}" data-sell-qty="${h.qty}" style="font-size:11px;padding:4px 8px">Sprzedaj</button></td>`;
         bindPriceEditor(tr);
         bindQuickSell(tr);
+        bindDeepDive(tr);
         tbody.appendChild(tr);
       }
     }
@@ -8919,6 +8968,56 @@
       }
       tfoot.innerHTML=`<tr style="font-weight:700;border-top:2px solid rgba(148,163,184,.3)"><td colspan="2">Razem</td><td>${fmt(totalCost,state.currency)}</td><td></td><td>${fmt(totalMV,state.currency)}</td><td>${pnlFoot}</td><td>${roiFoot}</td><td>100%</td><td></td></tr>`;
     }
+  }
+
+  function openInvestmentAssetDetail(assetId, holdingsFromRender, stats){
+    const data=investments();
+    const asset=data.assets.find(a=>a.id===assetId);
+    if(!asset) return;
+    const holding=(holdingsFromRender||[]).find(h=>h.id===assetId) || computeHoldingsFIFO().find(h=>h.id===assetId);
+    const assetTrades=[...data.trades].filter(t=>t.assetId===assetId).sort((a,b)=>String(b.date||'').localeCompare(String(a.date||'')));
+    const buys=assetTrades.filter(t=>t.side!=='sell');
+    const sells=assetTrades.filter(t=>t.side==='sell');
+    const buyAmount=buys.reduce((s,t)=>s+num(t.amount),0);
+    const sellAmount=sells.reduce((s,t)=>s+num(t.amount),0);
+    const realized=sells.reduce((s,t)=>s+num(t.realizedPnl),0);
+    const unrealized=holding?.unrealizedPnl??null;
+    const totalPnl=(unrealized===null?0:unrealized)+realized;
+    const roi=(buyAmount>0)?(totalPnl/buyAmount)*100:null;
+    const firstDate=[...assetTrades].sort((a,b)=>String(a.date||'').localeCompare(String(b.date||'')))[0]?.date||'—';
+    const lastDate=assetTrades[0]?.date||'—';
+    const cur=state.currency;
+
+    document.getElementById('inv-deep-title').textContent=`${asset.name}`;
+    document.getElementById('inv-deep-sub').textContent=`${asset.group||'Inne'} • ${asset.symbol||'brak tickera'}`;
+    document.getElementById('inv-deep-count').textContent=`${assetTrades.length} transakcji`;
+    document.getElementById('inv-deep-kpis').innerHTML=`
+      <div class="inv-deep-kpi"><div class="lbl">Ilość otwarta</div><div class="val">${holding?holding.qty.toFixed(4):'0'}</div></div>
+      <div class="inv-deep-kpi"><div class="lbl">Wartość rynkowa</div><div class="val">${holding?fmt(holding.marketValue!==null?holding.marketValue:holding.costBasis,cur):'—'}</div></div>
+      <div class="inv-deep-kpi"><div class="lbl">Niezrealizowane P&L</div><div class="val ${unrealized>=0?'inv-pnl-pos':'inv-pnl-neg'}">${unrealized===null?'—':`${unrealized>=0?'+':''}${fmt(unrealized,cur)}`}</div></div>
+      <div class="inv-deep-kpi"><div class="lbl">Zrealizowane P&L</div><div class="val ${realized>=0?'inv-pnl-pos':'inv-pnl-neg'}">${realized>=0?'+':''}${fmt(realized,cur)}</div></div>
+      <div class="inv-deep-kpi"><div class="lbl">Łączne P&L</div><div class="val ${totalPnl>=0?'inv-pnl-pos':'inv-pnl-neg'}">${totalPnl>=0?'+':''}${fmt(totalPnl,cur)}</div></div>
+      <div class="inv-deep-kpi"><div class="lbl">ROI od wpłat</div><div class="val">${roi===null?'—':`${roi>=0?'+':''}${roi.toFixed(1)}%`}</div></div>`;
+
+    document.getElementById('inv-deep-metrics').innerHTML=`
+      <tr><td>Pierwsza transakcja</td><td><strong>${firstDate}</strong></td></tr>
+      <tr><td>Ostatnia transakcja</td><td><strong>${lastDate}</strong></td></tr>
+      <tr><td>Suma zakupów</td><td><strong>${fmt(buyAmount,cur)}</strong></td></tr>
+      <tr><td>Suma sprzedaży</td><td><strong>${fmt(sellAmount,cur)}</strong></td></tr>
+      <tr><td>Średni koszt/szt</td><td><strong>${holding?fmt(holding.avgCost,cur):'—'}</strong></td></tr>
+      <tr><td>Aktualna cena</td><td><strong>${asset.currentPrice?fmt(asset.currentPrice,cur):'—'}</strong></td></tr>
+      <tr><td>Data aktualizacji ceny</td><td><strong>${asset.priceDate||'—'}</strong></td></tr>
+      <tr><td>Udział w portfelu</td><td><strong>${holding&&stats?.totalMarketValue?(((holding.marketValue!==null?holding.marketValue:holding.costBasis)/stats.totalMarketValue)*100).toFixed(1)+'%':'—'}</strong></td></tr>`;
+
+    const tbody=document.getElementById('inv-deep-trades');
+    tbody.innerHTML=assetTrades.length?assetTrades.map(t=>{
+      const qty=num(t.quantity), amt=num(t.amount), ppu=qty>0?amt/qty:0, isSell=t.side==='sell', rp=num(t.realizedPnl);
+      return `<tr><td>${t.date||'—'}</td><td>${isSell?'SELL':'BUY'}</td><td>${qty.toFixed(4)}</td><td>${fmt(amt,cur)}</td><td>${fmt(ppu,cur)}</td><td>${isSell?`<span class="${rp>=0?'inv-pnl-pos':'inv-pnl-neg'}">${rp>=0?'+':''}${fmt(rp,cur)}</span>`:'—'}</td></tr>`;
+    }).join(''):'<tr><td colspan="6" class="muted">Brak transakcji</td></tr>';
+
+    const backdrop=document.getElementById('inv-deep-backdrop');
+    backdrop.classList.add('open');
+    backdrop.setAttribute('aria-hidden','false');
   }
 
 
@@ -11527,6 +11626,24 @@
     if(exportJsonBtn&&!exportJsonBtn._bound){exportJsonBtn._bound=true;exportJsonBtn.onclick=exportInvestmentsJson;}
     const exportCsvBtn=document.getElementById('inv-export-csv');
     if(exportCsvBtn&&!exportCsvBtn._bound){exportCsvBtn._bound=true;exportCsvBtn.onclick=exportInvestmentsCsv;}
+    const deepBackdrop=document.getElementById('inv-deep-backdrop');
+    const deepClose=document.getElementById('inv-deep-close');
+    if(deepBackdrop&&!deepBackdrop._bound){
+      deepBackdrop._bound=true;
+      deepBackdrop.addEventListener('click',e=>{
+        if(e.target===deepBackdrop){
+          deepBackdrop.classList.remove('open');
+          deepBackdrop.setAttribute('aria-hidden','true');
+        }
+      });
+    }
+    if(deepClose&&!deepClose._bound){
+      deepClose._bound=true;
+      deepClose.onclick=()=>{
+        deepBackdrop?.classList.remove('open');
+        deepBackdrop?.setAttribute('aria-hidden','true');
+      };
+    }
     renderAssetManagerList(data.assets,data.trades);
 
     // Buy form

--- a/budget.html
+++ b/budget.html
@@ -368,10 +368,6 @@
     .inv-deep-list table{width:100%;border-collapse:collapse}
     .inv-deep-list th,.inv-deep-list td{padding:7px 4px;border-bottom:1px solid #eef2f7;font-size:12px;text-align:left}
     .inv-deep-list tr:last-child td{border-bottom:none}
-    .inv-deep-lots{display:grid;gap:8px;margin-top:8px}
-    .inv-deep-lot{border:1px solid #e2e8f0;border-radius:10px;padding:8px;background:#f8fafc}
-    .inv-deep-lot-top{display:flex;justify-content:space-between;gap:8px;flex-wrap:wrap;font-size:12px}
-    .inv-deep-lot-meta{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:4px 10px;margin-top:6px;font-size:12px}
     @media(max-width:780px){.inv-deep-grid{grid-template-columns:1fr}}
 
     /* --- Investment Analytics Hub ------------------------------------------- */
@@ -5375,15 +5371,13 @@
                 <div class="inv-deep-list">
                   <div class="row" style="justify-content:space-between"><strong>Historia transakcji</strong><span class="tiny muted" id="inv-deep-count"></span></div>
                   <table>
-                    <thead><tr><th>Data</th><th>Typ</th><th>Ilość</th><th>Kwota</th><th>Cena/szt</th><th>P&amp;L</th></tr></thead>
+                    <thead><tr><th>Data</th><th>Typ</th><th>Ilość</th><th>Kwota</th><th>Cena/szt</th><th>Dni</th><th>P&amp;L transakcji</th></tr></thead>
                     <tbody id="inv-deep-trades"></tbody>
                   </table>
                 </div>
                 <div class="inv-deep-list">
                   <strong>Metryki pozycji</strong>
                   <table><tbody id="inv-deep-metrics"></tbody></table>
-                  <div class="row" style="justify-content:space-between;margin-top:8px"><strong>DCA — zakupy i wynik</strong><span class="tiny muted" id="inv-deep-lots-count"></span></div>
-                  <div id="inv-deep-lots" class="inv-deep-lots"></div>
                 </div>
               </div>
             </div>
@@ -9020,15 +9014,7 @@
       <tr><td>Data aktualizacji ceny</td><td><strong>${asset.priceDate||'—'}</strong></td></tr>
       <tr><td>Udział w portfelu</td><td><strong>${holding&&stats?.totalMarketValue?(((holding.marketValue!==null?holding.marketValue:holding.costBasis)/stats.totalMarketValue)*100).toFixed(1)+'%':'—'}</strong></td></tr>`;
 
-    const tbody=document.getElementById('inv-deep-trades');
-    tbody.innerHTML=assetTrades.length?assetTrades.map(t=>{
-      const qty=num(t.quantity), amt=num(t.amount), ppu=qty>0?amt/qty:0, isSell=t.side==='sell', rp=num(t.realizedPnl);
-      return `<tr><td>${t.date||'—'}</td><td>${isSell?'SELL':'BUY'}</td><td>${qty.toFixed(4)}</td><td>${fmt(amt,cur)}</td><td>${fmt(ppu,cur)}</td><td>${isSell?`<span class="${rp>=0?'inv-pnl-pos':'inv-pnl-neg'}">${rp>=0?'+':''}${fmt(rp,cur)}</span>`:'—'}</td></tr>`;
-    }).join(''):'<tr><td colspan="6" class="muted">Brak transakcji</td></tr>';
-
     const backdrop=document.getElementById('inv-deep-backdrop');
-    const lotsWrap=document.getElementById('inv-deep-lots');
-    const lotsCount=document.getElementById('inv-deep-lots-count');
     const buyLots=buys.slice().sort((a,b)=>String(a.date||'').localeCompare(String(b.date||'')));
     const sellQueue=sells.slice().sort((a,b)=>String(a.date||'').localeCompare(String(b.date||''))).map(t=>({qty:num(t.quantity)}));
     const lots=buyLots.map(t=>({date:t.date,qty:num(t.quantity),amount:num(t.amount),ppu:num(t.amount)/Math.max(num(t.quantity),0.000001),remaining:num(t.quantity)}));
@@ -9045,25 +9031,25 @@
       const days=Math.max(0,Math.floor((now-new Date(lot.date||now))/(1000*60*60*24)));
       const refPrice=num(asset.currentPrice)||lot.ppu;
       lot.unrealized=(refPrice-lot.ppu)*lot.remaining;
-      lot.realizedPart=(lot.qty-lot.remaining)*lot.ppu;
       lot.days=days;
       lot.lateFlag=avgBuyPrice!==null&&lot.ppu>avgBuyPrice*1.1;
     }
-    lotsCount.textContent=`${lots.length} zakupów`;
-    lotsWrap.innerHTML=lots.length?lots.map((lot,idx)=>{
-      const cls=lot.unrealized>=0?'inv-pnl-pos':'inv-pnl-neg';
-      return `<div class="inv-deep-lot">
-        <div class="inv-deep-lot-top"><strong>#${idx+1} ${lot.date||'—'}</strong><span>${lot.days} dni</span></div>
-        <div class="inv-deep-lot-meta">
-          <span>Ilość: <strong>${lot.qty.toFixed(4)}</strong></span>
-          <span>Pozostało: <strong>${lot.remaining.toFixed(4)}</strong></span>
-          <span>Cena zakupu: <strong>${fmt(lot.ppu,cur)}</strong></span>
-          <span>Kwota: <strong>${fmt(lot.amount,cur)}</strong></span>
-          <span>P&L na pozostałej części: <strong class="${cls}">${lot.unrealized>=0?'+':''}${fmt(lot.unrealized,cur)}</strong></span>
-          <span>${lot.lateFlag?'<strong style="color:#b45309">Możliwy zakup na szczycie</strong>':'Timing OK'}</span>
-        </div>
-      </div>`;
-    }).join(''):'<div class="tiny muted">Brak zakupów do analizy DCA.</div>';
+    const lotByDateAndPpu=new Map(lots.map(l=>[`${l.date}|${l.ppu.toFixed(8)}|${l.qty.toFixed(8)}`,l]));
+    const tbody=document.getElementById('inv-deep-trades');
+    tbody.innerHTML=assetTrades.length?assetTrades.map(t=>{
+      const qty=num(t.quantity), amt=num(t.amount), ppu=qty>0?amt/qty:0, isSell=t.side==='sell', rp=num(t.realizedPnl);
+      const days=t.date?Math.max(0,Math.floor((now-new Date(t.date))/(1000*60*60*24))):0;
+      let txPnlHtml='—';
+      if(isSell){
+        txPnlHtml=`<span class="${rp>=0?'inv-pnl-pos':'inv-pnl-neg'}">${rp>=0?'+':''}${fmt(rp,cur)}</span>`;
+      } else {
+        const key=`${t.date}|${ppu.toFixed(8)}|${qty.toFixed(8)}`;
+        const lot=lotByDateAndPpu.get(key);
+        const lotPnl=lot?lot.unrealized:(num(asset.currentPrice)-ppu)*qty;
+        txPnlHtml=`<span class="${lotPnl>=0?'inv-pnl-pos':'inv-pnl-neg'}">${lotPnl>=0?'+':''}${fmt(lotPnl,cur)}</span>${lot?.lateFlag?' <span class="tiny" style="color:#b45309">(szczyt?)</span>':''}`;
+      }
+      return `<tr><td>${t.date||'—'}</td><td>${isSell?'SELL':'BUY'}</td><td>${qty.toFixed(4)}</td><td>${fmt(amt,cur)}</td><td>${fmt(ppu,cur)}</td><td>${days}</td><td>${txPnlHtml}</td></tr>`;
+    }).join(''):'<tr><td colspan="7" class="muted">Brak transakcji</td></tr>';
     backdrop.classList.add('open');
     backdrop.setAttribute('aria-hidden','false');
   }

--- a/trading.css
+++ b/trading.css
@@ -1219,6 +1219,8 @@ body[data-page="trading"] .site-header__title {
 /* -------------------- Tab panels -------------------- */
 .tab-panel { display: none; }
 .tab-panel.active { display: block; }
+.exec-hit{color:#0b8a4a;font-weight:700}
+.exec-miss{color:#c0362c;font-weight:700}
 
 /* Small helpers */
 .mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }

--- a/trading.html
+++ b/trading.html
@@ -65,6 +65,7 @@
         <div class="trade-tabs">
           <button class="trade-tab active" data-tab="dashboard"><span class="material-symbols-outlined">dashboard</span>Dashboard</button>
           <button class="trade-tab" data-tab="planner"><span class="material-symbols-outlined">calculate</span>Planer pozycji</button>
+          <button class="trade-tab" data-tab="execution"><span class="material-symbols-outlined">target</span>Realizacja planu</button>
           <button class="trade-tab" data-tab="trades"><span class="material-symbols-outlined">receipt_long</span>Transakcje</button>
           <button class="trade-tab" data-tab="analytics"><span class="material-symbols-outlined">bar_chart</span>Analityka</button>
           <button class="trade-tab" data-tab="calendar"><span class="material-symbols-outlined">calendar_month</span>Kalendarz</button>
@@ -175,6 +176,24 @@
               </section>
             </div>
 
+          </div>
+        </div>
+
+        <!-- ========== EXECUTION PLAN ========== -->
+        <div class="tab-panel" id="tab-execution">
+          <div class="tc-card stack">
+            <div class="tc-card-head">
+              <h3>Plan wzrostu +10% MoM (procent składany ×1.1)</h3>
+              <span class="sub">Symulacja celu i egzekucji miesiąc po miesiącu</span>
+            </div>
+            <div class="ff-grid cols-3">
+              <div class="ff"><label>Horyzont (miesiące)</label><input id="exec-horizon" type="number" min="1" max="120" value="24"></div>
+              <div class="ff"><label>Cel MoM (%)</label><input id="exec-target" type="number" min="1" max="100" step="0.1" value="10"></div>
+              <div class="ff"><label>Zał. liczba trade/mies.</label><input id="exec-trades-month" type="number" min="1" max="200" value="12"></div>
+            </div>
+            <div class="row" style="justify-content:flex-end"><button class="btn-small primary" id="exec-recalc-btn">Przelicz plan</button></div>
+            <div class="tc-grid-kpi" id="exec-kpis"></div>
+            <div class="tc-tbl-wrap"><table class="tc-table" id="exec-table"></table></div>
           </div>
         </div>
 

--- a/trading.js
+++ b/trading.js
@@ -1215,6 +1215,7 @@ function switchTab(name) {
   if (name === 'analytics') setTimeout(renderAnalytics, 30);
   if (name === 'calendar') setTimeout(renderCalendarView, 30);
   if (name === 'planner') setTimeout(updatePlanner, 30);
+  if (name === 'execution') setTimeout(renderExecutionPlan, 30);
 }
 
 function toast(msg, kind = '') {
@@ -1635,6 +1636,80 @@ function drawHeatmap(agg) {
   `;
 }
 
+function monthShift(ym, add) {
+  const [y,m]=ym.split('-').map(Number);
+  const d=new Date(y,m-1+add,1);
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}`;
+}
+
+function renderExecutionPlan() {
+  const agg = aggregate();
+  const horizon = clamp(numberOr(document.getElementById('exec-horizon')?.value,24),1,120);
+  const targetPct = clamp(numberOr(document.getElementById('exec-target')?.value,10),0.1,100);
+  const tradesPerMonthInput = clamp(numberOr(document.getElementById('exec-trades-month')?.value,12),1,200);
+  const targetFactor = 1 + targetPct / 100;
+
+  const firstTradeDate = [...state.trades].map(t=>t.date).filter(Boolean).sort()[0] || today();
+  const startMonth = firstTradeDate.slice(0,7);
+  const pnlByMonth = {};
+  for (const e of agg.events) {
+    const m = e.date.slice(0,7);
+    pnlByMonth[m] = (pnlByMonth[m] || 0) + e.pnl;
+  }
+
+  const rrVals = agg.events.map(e=>e.realizedR).filter(v=>v!==null && Number.isFinite(v));
+  const avgR = rrVals.length ? rrVals.reduce((a,b)=>a+b,0)/rrVals.length : 0.4;
+  const monthsWithData = Object.keys(pnlByMonth).length || 1;
+  const avgTradesPerMonthReal = Math.max(1, agg.events.length / monthsWithData);
+  const tradesPerMonth = tradesPerMonthInput || avgTradesPerMonthReal;
+
+  let depoStart = settings.capital;
+  let targetCum = 0;
+  let actualCum = 0;
+  const rows = [];
+  for (let i=0;i<horizon;i++) {
+    const ym = monthShift(startMonth, i);
+    const targetPnl = depoStart * (targetFactor - 1);
+    const targetEnd = depoStart * targetFactor;
+    targetCum += targetPnl;
+    const actualPnl = pnlByMonth[ym] || 0;
+    actualCum += actualPnl;
+    const actualEnd = depoStart + actualPnl;
+    const monthRealPct = targetPnl !== 0 ? (actualPnl / targetPnl) * 100 : 0;
+    const gap = actualPnl - targetPnl;
+    const requiredRiskPct = (depoStart > 0 && avgR !== 0 && tradesPerMonth > 0) ? (targetPnl / (depoStart * avgR * tradesPerMonth)) * 100 : null;
+    rows.push({ym,depoStart,targetPnl,targetEnd,targetCum,actualPnl,actualEnd,actualCum,monthRealPct,gap,requiredRiskPct});
+    depoStart = targetEnd;
+  }
+
+  const kpis = document.getElementById('exec-kpis');
+  const table = document.getElementById('exec-table');
+  if (!kpis || !table) return;
+  const realizedAll = rows.reduce((a,r)=>a+r.actualPnl,0);
+  const targetAll = rows.reduce((a,r)=>a+r.targetPnl,0);
+  const realization = targetAll>0?(realizedAll/targetAll)*100:0;
+  const last = rows[rows.length-1];
+  kpis.innerHTML = `
+    <div class="tc-kpi"><span class="k">Start miesiąca</span><span class="v mono">${startMonth}</span><span class="n">Pierwsza transakcja</span></div>
+    <div class="tc-kpi"><span class="k">Cel końcowy</span><span class="v mono">${fmtUSD(last.targetEnd)}</span><span class="n">po ${horizon} mies.</span></div>
+    <div class="tc-kpi"><span class="k">Realizacja planu</span><span class="v mono ${realization>=100?'pos':'neg'}">${fmtPct(realization, false, 1)}</span><span class="n">vs target sum</span></div>
+    <div class="tc-kpi"><span class="k">Śr. R z historii</span><span class="v mono">${fmtR(avgR, true, 2)}</span><span class="n">do estymacji SL%</span></div>`;
+
+  table.innerHTML = `<thead><tr>
+    <th>Miesiąc</th><th>Depo start</th><th>Plan +${targetPct}%</th><th>Depo cel</th><th>PnL real</th><th>Depo real</th>
+    <th>Plan skum.</th><th>Real skum.</th><th>Realizacja %</th><th>Gap</th><th>Sug. SL %/trade</th>
+  </tr></thead><tbody>${
+    rows.map(r=>`<tr>
+      <td>${r.ym}</td><td>${fmtUSD(r.depoStart)}</td><td>${fmtUSD(r.targetPnl,true)}</td><td>${fmtUSD(r.targetEnd)}</td>
+      <td class="${posClass(r.actualPnl)}">${fmtUSD(r.actualPnl,true)}</td><td>${fmtUSD(r.actualEnd)}</td>
+      <td>${fmtUSD(r.targetCum,true)}</td><td>${fmtUSD(r.actualCum,true)}</td>
+      <td class="${r.monthRealPct>=100?'exec-hit':'exec-miss'}">${fmtPct(r.monthRealPct,false,1)}</td>
+      <td class="${posClass(r.gap)}">${fmtUSD(r.gap,true)}</td>
+      <td>${r.requiredRiskPct===null?'—':fmtPct(r.requiredRiskPct,false,2)}</td>
+    </tr>`).join('')
+  }</tbody>`;
+}
+
 // ============================================================
 // Render all
 // ============================================================
@@ -1651,6 +1726,7 @@ function renderAll() {
   // Only redraw analytics if tab visible
   if (document.getElementById('tab-analytics').classList.contains('active')) renderAnalytics();
   if (document.getElementById('tab-calendar').classList.contains('active')) renderCalendarView();
+  if (document.getElementById('tab-execution').classList.contains('active')) renderExecutionPlan();
 }
 
 // ============================================================
@@ -1672,6 +1748,7 @@ function init() {
   document.getElementById('settings-btn').addEventListener('click', openSettings);
   document.getElementById('export-btn').addEventListener('click', exportCSV);
   document.getElementById('new-trade-btn').addEventListener('click', openNewTradeModal);
+  document.getElementById('exec-recalc-btn')?.addEventListener('click', renderExecutionPlan);
 
   // Filters
   document.querySelectorAll('#filter-status .filter-chip').forEach(b => b.addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Provide a quick, focused per-asset deep-dive view from the holdings table so users can inspect an asset's history, P&L and key metrics without leaving the Investments area.
- Reuse existing persisted structures (`assets`, `trades`, FIFO holdings) so the feature works with current data and requires no backend changes.

### Description
- Added modal styles and markup (`.inv-deep-backdrop`, `.inv-deep-modal`, KPI grid, trades table) directly in `budget.html` to match existing UI language.  
- Made asset names in the holdings table clickable by replacing the name cell with a `button.inv-asset-name-btn` and attaching `bindDeepDive` to each row.  
- Implemented `openInvestmentAssetDetail(assetId, ...)` which builds modal content from `assets`, `trades`, and computed holdings and shows KPIs (open qty, market value, unrealized/realized/total P&L, ROI), metadata (first/last trade, sums, avg cost, current price/date, portfolio weight) and per-asset transaction history with per-SELL realized P&L.  
- Added backdrop click and close-button handlers in `renderInvestments` to dismiss the modal; kept all logic inside `budget.html` and did not change persisted schemas or APIs.

### Testing
- Verified presence of new identifiers and styles with `rg -n "inv-deep" budget.html`, which returned the inserted CSS/HTML/JS hooks successfully. (success)
- Committed the change with `git commit -m "Add per-asset deep-dive modal in investments holdings"`, which completed successfully. (success)
- Created the PR metadata via the repository helper (`make_pr`) to summarize the change. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f987a2785483318ad6bfb55a4a83a5)