### PR TITLE
Migrate stats module from TheSportsDB to football-data.co.uk

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stats-cache/

--- a/STATS.md
+++ b/STATS.md
@@ -14,9 +14,17 @@ node server.js
 Serwer wymaga Node 18+ i nie ma żadnych zależności. Robi dwie rzeczy:
 serwuje pliki aplikacji i pośredniczy w pobieraniu danych.
 
-Aplikacja działa też bez serwera (otwarta z dowolnego innego hosta lokalnego),
-ale wtedy przechodzi na publiczne proxy CORS — wolniejsze i zawodne. Nagłówek
-strony pokazuje, które proxy jest aktualnie używane.
+`server.js` wysyła `Access-Control-Allow-Origin: *`, więc **wystarczy, że
+działa w tle** — stronę możesz otwierać skąd chcesz (inny port, Live Server).
+Aplikacja wykryje proxy pod `http://localhost:8787` i użyje go.
+
+Bez uruchomionego serwera moduł spada na publiczne proxy CORS, które są
+zawodne: w lipcu 2026 `r.jina.ai` zaczął wymagać logowania (HTTP 401),
+a `allorigins.win` i `codetabs.com` zwracały 522. W przeglądarce takie
+odpowiedzi nie niosą nagłówka CORS, więc `fetch` nie może ich odczytać
+i zgłasza generyczne **„Failed to fetch"** zamiast kodu HTTP — stąd cztery
+identyczne komunikaty w błędzie. Nagłówek strony ostrzega wtedy
+**„Bez lokalnego proxy"**.
 
 ## Dwa źródła i podział obowiązków
 

--- a/STATS.md
+++ b/STATS.md
@@ -1,0 +1,122 @@
+# Moduł Statystyki — macierze pokrycia rynków
+
+Narzędzie do deep-dive'u w statystyki meczowe: wybierasz ligę i mecz, dostajesz
+komplet linii bukmacherskich z pokryciem w oknach **5 / 10 / 20** ostatnich
+spotkań każdej z drużyn — w trafieniach (`8/10`) i w procentach.
+
+## Uruchomienie
+
+```bash
+node server.js
+# http://localhost:8787/stats.html
+```
+
+Serwer wymaga Node 18+ i nie ma żadnych zależności. Robi dwie rzeczy:
+serwuje pliki aplikacji i pośredniczy w pobieraniu danych.
+
+Aplikacja działa też bez serwera (otwarta z dowolnego innego hosta lokalnego),
+ale wtedy przechodzi na publiczne proxy CORS — wolniejsze i zawodne. Nagłówek
+strony pokazuje, które proxy jest aktualnie używane.
+
+## Skąd biorą się dane
+
+[football-data.co.uk](https://www.football-data.co.uk) — darmowe pliki CSV,
+bez klucza API i bez limitów zapytań. Jeden plik to cały sezon ligi z kompletem
+statystyk meczowych:
+
+| Kolumna    | Znaczenie                          |
+|------------|------------------------------------|
+| `FTHG/FTAG`| gole (koniec meczu)                |
+| `HTHG/HTAG`| gole do przerwy                    |
+| `HS/AS`    | strzały                            |
+| `HST/AST`  | strzały celne                      |
+| `HC/AC`    | **rzuty rożne**                    |
+| `HF/AF`    | faule                              |
+| `HY/AY`    | żółte kartki                       |
+| `HR/AR`    | czerwone kartki                    |
+| `PSCH…`    | kursy zamknięcia 1X2, O/U 2.5, AH  |
+
+**22 ligi z pełną statystyką**: Anglia (5 poziomów), Szkocja (4), Niemcy (2),
+Włochy (2), Hiszpania (2), Francja (2), Holandia, Belgia, Portugalia, Turcja,
+Grecja.
+
+**16 lig dodatkowych** (m.in. Ekstraklasa, MLS, Brazylia, Japonia) — tam
+źródło publikuje wyłącznie gole i kursy. Moduł wykrywa to sam i zamiast
+pustych tabel pokazuje informację, których kategorii brakuje.
+
+### Dlaczego nie TheSportsDB
+
+Poprzednia wersja korzystała z TheSportsDB z darmowym kluczem `123`. Ten klucz
+obcina **każdą** odpowiedź do 3 rekordów — `eventsday.php` dla pełnej kolejki
+ligowej zwracał 3 mecze, przez co terminarz był praktycznie pusty. Endpoint
+`lookupeventstats.php` tnie z kolei do 5 pozycji i zwraca same strzały:
+rożnych, kartek ani fauli nie ma tam w ogóle.
+
+## Jak czytać dashboard
+
+**1. Źródło danych** — liga, zakres historii (1–4 sezony), okno główne,
+filtr dom–wyjazd. Pobrane pliki zostają w cache przeglądarki i na dysku
+serwera, więc kolejne analizy w tej samej lidze są natychmiastowe.
+
+**2. Terminarz** — nadchodzące mecze wybranej ligi razem z kursami. Plik
+`fixtures.csv` obejmuje ok. tygodnia naprzód i bywa pusty w przerwie
+międzysezonowej.
+
+**3. Własne zestawienie** — dowolna para drużyn z wczytanej ligi. Działa
+niezależnie od terminarza, więc analiza jest możliwa zawsze.
+
+**4. Macierze pokrycia** — sedno narzędzia. Dla każdej linii:
+
+```
+Rożne w meczu pow. 8,5 │ Arsenal          │ Chelsea          │ Razem  │ Model
+                       │ 5     10    20   │ 5     10    20   │        │
+                       │ 20%   50%   50%  │ 60%   70%   75%  │  60%   │  66%
+                       │ 1/5   5/10  10/20│ 3/5   7/10  15/20│ 12/20  │  1.51
+```
+
+- **kolumny 5/10/20** — pokrycie w ostatnich N meczach każdej z drużyn osobno
+- **Razem** — obie próbki złączone (2 × okno główne)
+- **Model** — rozkład Poissona na projekcji + kurs godziwy pod spodem
+- **kolor** — im ciemniejsza zieleń, tym częściej linia była przekraczana
+
+Rozjazd między oknami jest sygnałem sam w sobie: `20% / 50% / 50%` u Arsenalu
+oznacza, że ostatnie pięć meczów wyraźnie odstaje od dłuższego trendu.
+
+**Pasek formy** pod każdą macierzą pokazuje przebieg mecz po meczu (od
+najstarszego), żeby odróżnić stabilne pokrycie od jednej serii.
+
+**5. Skrót typów** — rynki, które utrzymały poziom **we wszystkich** oknach,
+uszeregowane wg dolnej granicy przedziału Wilsona (kara za małą próbkę).
+Zdarzenia o pokryciu powyżej 93% są odcinane — kurs godziwy poniżej 1,08 nie
+jest zakładem, na który da się zagrać.
+
+**6. Wynik meczu** — model bramkowy zestawiony z kursem bukmachera po zdjęciu
+marży. Kolumna „Przewaga" pokazuje różnicę w punktach procentowych.
+
+**7. Profile, H2H, Historia** — średnie zdobyte/stracone dla każdej metryki,
+bezpośrednie starcia i pełne dane źródłowe stojące za macierzami.
+
+## Metodyka — co warto wiedzieć
+
+- **Projekcja** metryki liczy średnią z tego, co drużyna kreuje, i z tego, na
+  co pozwala rywal, na oknie 10 meczów.
+- **Model Poissona** jest sensowny dla goli, rożnych, strzałów i fauli.
+  Świadomie nie jest liczony dla punktów kartkowych, czerwonych kartek i goli
+  do przerwy — tam rozkład jest zbyt skokowy i model by kłamał.
+- **Filtr dom–wyjazd** zawęża próbkę o połowę. Przy oknie 20 bywa, że
+  realna liczba meczów jest mniejsza — nagłówek komórki zawsze pokazuje
+  faktyczne `trafienia/próbka`.
+- **Drużyny po awansie** mają krótką historię w swojej lidze. Moduł
+  automatycznie dobiera mecze z ligi sąsiedniej (np. Championship dla
+  beniaminka Premier League) i informuje o tym w nagłówku analizy.
+- Pokrycie historyczne **nie jest** prognozą. To rozkład tego, co się wydarzyło.
+
+## Cache
+
+- **Przeglądarka** — `localStorage`, budżet ok. 3,5 MB, najstarsze wpisy
+  usuwane automatycznie.
+- **Serwer** — katalog `.stats-cache/` (poza repozytorium). Terminarz 30 minut,
+  sezony 12 godzin. Gdy źródło nie odpowiada, serwer oddaje ostatnią znaną
+  wersję zamiast błędu.
+
+Przycisk **Cache** w nagłówku czyści oba naraz.

--- a/STATS.md
+++ b/STATS.md
@@ -126,6 +126,20 @@ potrzebna wyłącznie do **własnego zestawienia** — pary drużyn spoza termin
 np. gdy chcesz przejrzeć mecz z przyszłej kolejki albo porównać dwie dowolne
 ekipy. Przy pracy z terminarza możesz ją całkowicie pominąć.
 
+### Panele zwijane i filtr terminarza
+
+Terminarz na jutro potrafi mieć ponad 300 meczów, więc:
+
+- **„Tylko z analizą"** — chip przy filtrze pokazuje, ile meczów ma historię
+  w CSV, i zawęża listę wyłącznie do nich. Na przykładowym dniu: 341 → 16
+  meczów, wysokość strony spada z 7410 do 2371 px.
+- **Ligi bez historii startują zwinięte** — to one robią większość
+  przewijania, a i tak nic z nich nie policzymy.
+- **Każdy panel ma strzałkę zwijania** w nagłówku sekcji. Stan jest
+  zapamiętywany między wizytami.
+- **Terminarz zwija się sam** po wejściu w analizę meczu, żeby powrót do
+  macierzy nie wymagał przewijania przez całą listę.
+
 ### Co się cachuje
 
 | Warstwa | Czas życia | Uwagi |

--- a/STATS.md
+++ b/STATS.md
@@ -18,6 +18,20 @@ serwuje pliki aplikacji i pośredniczy w pobieraniu danych.
 działa w tle** — stronę możesz otwierać skąd chcesz (inny port, Live Server).
 Aplikacja wykryje proxy pod `http://localhost:8787` i użyje go.
 
+### Gdy nic nie działa: import plików z dysku
+
+Przeglądarka blokuje localhost w dwóch układach, **niezależnie od tego, czy
+`server.js` jest uruchomiony**:
+
+- strona otwarta bezpośrednio z dysku (`file://`) — origin jest wtedy „null",
+- strona po `https` sięgająca po `http://localhost` — mieszana treść.
+
+W obu przypadkach fetch kończy się „Failed to fetch". Rozwiązania są dwa:
+otworzyć stronę pod `http://localhost:8787`, albo skorzystać z **importu
+plików** w sekcji *Źródło danych*: klikasz link do pliku (zwykłe pobranie,
+CORS go nie dotyczy), a potem wskazujesz go przyciskiem. Zaimportowane dane
+mają pierwszeństwo przed siecią i przeżywają przeładowanie strony.
+
 Bez uruchomionego serwera moduł spada na publiczne proxy CORS, które są
 zawodne: w lipcu 2026 `r.jina.ai` zaczął wymagać logowania (HTTP 401),
 a `allorigins.win` i `codetabs.com` zwracały 522. W przeglądarce takie

--- a/STATS.md
+++ b/STATS.md
@@ -118,6 +118,27 @@ międzysezonowej.
 **3. Własne zestawienie** — dowolna para drużyn z wczytanej ligi. Działa
 niezależnie od terminarza, więc analiza jest możliwa zawsze.
 
+**Skaner dnia** — jeden ranking rynków ze **wszystkich** meczów terminarza,
+zamiast otwierania meczu po meczu. Przeliczenie nie zużywa limitu API: dane
+historyczne siedzą już w cache, liczy się tylko procesor.
+
+```
+Mecz                              Rynek                     5     10     20    najsłabsze  Wilson
+Talleres – Velez    22:00  GOLE   Gole w meczu pon. 3,5    90%    90%    95%      90%       89%
+                                                          9/10  18/20  38/40                38/40
+```
+
+- **Najsłabsze okno** — najniższe pokrycie wśród okien 5/10/20. Odsiewa typy
+  oparte na jednej dobrej serii.
+- **Wilson** — dolna granica przedziału na **najszerszej** próbce (okno 20 ×
+  dwie drużyny, czyli do 40 obserwacji). To po niej idzie ranking: okno główne
+  daje zbyt wiele remisów, bo przy próbce 18/20 każdy typ wychodzi na 78%.
+- **Filtry** — minimalne pokrycie, grupa rynków, pomijanie meczów rozegranych.
+- Strzałka w ostatniej kolumnie otwiera pełne macierze dla danego meczu.
+
+Skaner działa tylko dla lig obecnych w CSV — pozostałe mecze terminarza są
+oznaczone „brak historii w CSV" i pomijane.
+
 **4. Macierze pokrycia** — sedno narzędzia. Dla każdej linii:
 
 ```

--- a/STATS.md
+++ b/STATS.md
@@ -105,6 +105,39 @@ ligowej zwracał 3 mecze, przez co terminarz był praktycznie pusty. Endpoint
 `lookupeventstats.php` tnie z kolei do 5 pozycji i zwraca same strzały:
 rożnych, kartek ani fauli nie ma tam w ogóle.
 
+## Przepływ pracy
+
+**Historia z CSV dociąga się sama** przy pierwszej analizie danej ligi. Nie ma
+kroku „najpierw pobierz wyniki".
+
+```
+1. Klucz API          jednorazowo, zostaje w przeglądarce
+2. Pobierz terminarz  1 zapytanie · dziś albo jutro
+3. Skanuj  ────────►  ranking typów z całego dnia   ─┐
+   albo Analizuj ───► pojedynczy mecz               ─┴─► 4. Macierze pokrycia
+```
+
+Krok 3 i 4 nie kosztują ani jednego zapytania API. Realne zużycie to
+**2 zapytania dziennie** ze 100 dostępnych: jedno na terminarz na dziś, drugie
+na jutro.
+
+Sekcja **Źródło danych** (wybór ligi, zakres sezonów, „Wczytaj ligę") jest
+potrzebna wyłącznie do **własnego zestawienia** — pary drużyn spoza terminarza,
+np. gdy chcesz przejrzeć mecz z przyszłej kolejki albo porównać dwie dowolne
+ekipy. Przy pracy z terminarza możesz ją całkowicie pominąć.
+
+### Co się cachuje
+
+| Warstwa | Czas życia | Uwagi |
+|---|---|---|
+| Terminarz API-Football | 3 min | ponowne kliknięcie w tym oknie nie kosztuje zapytania |
+| CSV w przeglądarce | 12 h | `localStorage`, budżet 3,5 MB |
+| CSV na serwerze | 6 h | katalog `.stats-cache/` |
+| Sparsowane ligi | do przeładowania strony | pula w pamięci, zerowy koszt |
+
+W praktyce: pierwsza analiza z danej ligi trwa chwilę (pobranie 1–3 plików
+CSV), każda kolejna z tej samej ligi jest natychmiastowa.
+
 ## Jak czytać dashboard
 
 **1. Źródło danych** — liga, zakres historii (1–4 sezony), okno główne,

--- a/STATS.md
+++ b/STATS.md
@@ -114,9 +114,9 @@ bezpośrednie starcia i pełne dane źródłowe stojące za macierzami.
 ## Cache
 
 - **Przeglądarka** — `localStorage`, budżet ok. 3,5 MB, najstarsze wpisy
-  usuwane automatycznie.
+  usuwane automatycznie. Terminarz 30 minut, sezony 12 godzin.
 - **Serwer** — katalog `.stats-cache/` (poza repozytorium). Terminarz 30 minut,
-  sezony 12 godzin. Gdy źródło nie odpowiada, serwer oddaje ostatnią znaną
+  sezony 6 godzin. Gdy źródło nie odpowiada, serwer oddaje ostatnią znaną
   wersję zamiast błędu.
 
 Przycisk **Cache** w nagłówku czyści oba naraz.

--- a/STATS.md
+++ b/STATS.md
@@ -18,7 +18,60 @@ Aplikacja działa też bez serwera (otwarta z dowolnego innego hosta lokalnego),
 ale wtedy przechodzi na publiczne proxy CORS — wolniejsze i zawodne. Nagłówek
 strony pokazuje, które proxy jest aktualnie używane.
 
-## Skąd biorą się dane
+## Dwa źródła i podział obowiązków
+
+| | Terminarz | Historia do macierzy |
+|---|---|---|
+| **API-Football** | ✅ dziś i jutro, 39 lig, statusy live | ❌ zablokowane na planie Free |
+| **football-data.co.uk** | ⚠️ ok. tygodnia, tylko w sezonie | ✅ bez limitów, komplet statystyk |
+
+Terminarz idzie więc z API-Football, a macierze liczą się z CSV. Kliknięcie
+**Analizuj** przy meczu z terminarza automatycznie wczytuje odpowiednią
+dywizję CSV i dopasowuje nazwy drużyn.
+
+### Klucz API-Football
+
+Wklej klucz z [dashboard.api-football.com](https://dashboard.api-football.com)
+w sekcji **Klucz API-Football**. Zostaje wyłącznie w `localStorage` tej
+przeglądarki — nie ma go w żadnym pliku repozytorium. Przycisk **Sprawdź
+połączenie** pokazuje plan i zużycie limitu.
+
+Bez klucza moduł działa dalej, tylko terminarz live jest wyłączony.
+
+### Ograniczenia planu Free (sprawdzone na żywo)
+
+- `/fixtures?date=` — **tylko dziś ±1 dzień**. Dalsze daty: *„Free plans do not
+  have access to this date"*.
+- Sezony — **wyłącznie 2022–2024**. Sezon bieżący: *„Free plans do not have
+  access to this season"*.
+- Parametr `last` — zablokowany, więc „ostatnie N meczów drużyny" jest
+  nieosiągalne.
+- Budżet — 100 zapytań na dobę, 10 na minutę.
+
+Dlatego **statystyki za ostatnie mecze nie idą z API-Football**: najnowszy
+dostępny sezon skończył się w maju 2025. Płatny plan zdejmuje te limity, ale
+przy 20-meczowym oknie jedna analiza to ok. 41 zapytań (1 na listę meczów + 1
+na statystyki każdego meczu), więc CSV pozostaje sensowniejszym źródłem
+historii nawet wtedy.
+
+Licznik zapytań w nagłówku jest **lokalny**. api-sports.io wysyła wprawdzie
+nagłówki `x-ratelimit-*`, ale bez `Access-Control-Expose-Headers`, więc
+przeglądarka ich nie ujawnia — wartość autorytatywną pobiera przycisk
+**Sprawdź połączenie**.
+
+### Mostek nazw drużyn
+
+API-Football pisze „Manchester City", CSV — „Man City". Dopasowanie idzie
+tokenami: równe, prefiks, albo skrót jako podciąg ze wspólnym prefiksem
+(„nottm" wewnątrz „nottingham"). Sam podciąg nie wystarcza — bez wymogu
+prefiksu „real" pasowałoby do „arsenal". Gdy pewności brak, moduł prosi
+o ręczne wskazanie zamiast zgadywać.
+
+Sprawdzone na pełnych składach Premier League i Serie A: 40/40 automatycznie,
+w tym „Nottingham Forest" → „Nott'm Forest", „AC Milan" → „Milan",
+„Hellas Verona" → „Verona".
+
+## Skąd biorą się dane historyczne
 
 [football-data.co.uk](https://www.football-data.co.uk) — darmowe pliki CSV,
 bez klucza API i bez limitów zapytań. Jeden plik to cały sezon ligi z kompletem

--- a/STATS.md
+++ b/STATS.md
@@ -18,6 +18,28 @@ serwuje pliki aplikacji i pośredniczy w pobieraniu danych.
 działa w tle** — stronę możesz otwierać skąd chcesz (inny port, Live Server).
 Aplikacja wykryje proxy pod `http://localhost:8787` i użyje go.
 
+### Windows: uruchomienie jednym kliknięciem
+
+W repozytorium jest `start-windows.cmd`. Kliknij go dwukrotnie — sprawdzi
+Node.js, wystartuje serwer i otworzy aplikację pod właściwym adresem. Okno
+konsoli musi pozostać otwarte; jego zamknięcie zatrzymuje serwer.
+
+> **Zanim przejdziesz z `file://` na `http://localhost:8787`**
+>
+> To dwa różne originy, więc mają **osobny `localStorage`**. Dane pozostałych
+> modułów (budżet, zadania, kredyt, zakłady) nie przeniosą się same i nowy
+> adres wyglądałby na pustą aplikację.
+>
+> Migracja: na Dashboardzie kliknij **Eksport**, otwórz
+> `http://localhost:8787/index.html` i kliknij **Import**, wskazując pobrany
+> plik `lifeos_backup_*.json`. Eksport obejmuje wszystkie moduły łącznie
+> z zakładami i ustawieniami.
+
+Jeśli nie chcesz nic przenosić — zostań przy `file://`. Terminarz live działa
+tam bez przeszkód (api-sports.io wysyła `Access-Control-Allow-Origin: *`, co
+dopuszcza origin „null"); blokowane są wyłącznie pliki CSV, które wczytasz
+importem opisanym niżej.
+
 ### Gdy nic nie działa: import plików z dysku
 
 Przeglądarka blokuje localhost w dwóch układach, **niezależnie od tego, czy

--- a/server.js
+++ b/server.js
@@ -84,6 +84,7 @@ async function handleCsv(req, res, url) {
       res.writeHead(200, {
         'Content-Type': 'text/csv; charset=utf-8',
         'Access-Control-Allow-Origin': '*',
+        'Access-Control-Expose-Headers': 'X-Fd-Missing, X-Fd-Cache',
         'X-Fd-Cache': 'hit'
       });
       return res.end(hit);
@@ -96,23 +97,33 @@ async function handleCsv(req, res, url) {
       signal: AbortSignal.timeout(30000)
     });
     if (!upstream.ok) {
-      /* Sezon jeszcze nieopublikowany zwraca 404 — to normalny stan, nie awaria. */
+      /* Sezon jeszcze nieopublikowany zwraca 404 — to normalny stan, nie awaria.
+         Oznaczamy to nagłówkiem, żeby klient odróżnił "u źródła nie ma pliku"
+         od "404 z serwera, który w ogóle nie zna tego endpointu". */
       const stale = await readCache(target, Infinity);
       if (stale !== null) {
         res.writeHead(200, {
           'Content-Type': 'text/csv; charset=utf-8',
           'Access-Control-Allow-Origin': '*',
+          'Access-Control-Expose-Headers': 'X-Fd-Missing, X-Fd-Cache',
           'X-Fd-Cache': 'stale'
         });
         return res.end(stale);
       }
-      return sendCors(res, upstream.status, `football-data.co.uk: HTTP ${upstream.status} dla ${target}`);
+      res.writeHead(upstream.status, {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Expose-Headers': 'X-Fd-Missing, X-Fd-Cache',
+        'X-Fd-Missing': upstream.status === 404 ? '1' : '0'
+      });
+      return res.end(`football-data.co.uk: HTTP ${upstream.status} dla ${target}`);
     }
     const body = await upstream.text();
     await writeCache(target, body);
     res.writeHead(200, {
       'Content-Type': 'text/csv; charset=utf-8',
       'Access-Control-Allow-Origin': '*',
+      'Access-Control-Expose-Headers': 'X-Fd-Missing, X-Fd-Cache',
       'X-Fd-Cache': 'miss'
     });
     res.end(body);
@@ -122,6 +133,7 @@ async function handleCsv(req, res, url) {
       res.writeHead(200, {
         'Content-Type': 'text/csv; charset=utf-8',
         'Access-Control-Allow-Origin': '*',
+        'Access-Control-Expose-Headers': 'X-Fd-Missing, X-Fd-Cache',
         'X-Fd-Cache': 'stale'
       });
       return res.end(stale);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/* ============================================================
+   LifeOS — lokalny serwer statyczny + proxy do football-data.co.uk
+
+   Po co proxy: football-data.co.uk nie wysyła nagłówka
+   Access-Control-Allow-Origin, więc przeglądarka blokuje pobranie
+   plików CSV bezpośrednio ze strony. Ten serwer pobiera je po
+   stronie Node i oddaje z poprawnym CORS + cache na dysku.
+
+   Uruchomienie:  node server.js         (domyślnie http://localhost:8787)
+                  PORT=9000 node server.js
+   Wymaga Node 18+ (globalny fetch). Zero zależności.
+   ============================================================ */
+
+const http = require('http');
+const fs = require('fs');
+const fsp = require('fs/promises');
+const path = require('path');
+
+const ROOT = __dirname;
+const PORT = Number(process.env.PORT || 8787);
+const CACHE_DIR = path.join(ROOT, '.stats-cache');
+const UPSTREAM = 'https://www.football-data.co.uk';
+
+/* Terminarz odświeżamy często, archiwalne sezony rzadko. */
+const TTL_FIXTURES = 30 * 60 * 1000;
+const TTL_SEASON = 6 * 60 * 60 * 1000;
+
+/* Wpuszczamy wyłącznie ścieżki, o które faktycznie prosi aplikacja. */
+const ALLOWED_PATH = /^(fixtures\.csv|mmz4281\/\d{4}\/[A-Z]{1,3}\d\.csv|new\/[A-Z]{3}\.csv)$/;
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.csv': 'text/csv; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+  '.md': 'text/markdown; charset=utf-8'
+};
+
+const cacheFile = target => path.join(CACHE_DIR, `${target.replace(/[^a-z0-9]/gi, '_')}.csv`);
+
+async function readCache(target, ttl) {
+  try {
+    const file = cacheFile(target);
+    const stat = await fsp.stat(file);
+    if (Date.now() - stat.mtimeMs > ttl) return null;
+    return await fsp.readFile(file, 'utf8');
+  } catch { return null; }
+}
+
+async function writeCache(target, body) {
+  try {
+    await fsp.mkdir(CACHE_DIR, { recursive: true });
+    await fsp.writeFile(cacheFile(target), body, 'utf8');
+  } catch { /* cache jest opcjonalny — brak zapisu nie psuje odpowiedzi */ }
+}
+
+function sendCors(res, status, body, type = 'text/plain; charset=utf-8') {
+  res.writeHead(status, {
+    'Content-Type': type,
+    'Access-Control-Allow-Origin': '*',
+    'Cache-Control': 'no-cache'
+  });
+  res.end(body);
+}
+
+async function handleCsv(req, res, url) {
+  const target = url.searchParams.get('path') || '';
+  if (!ALLOWED_PATH.test(target)) {
+    return sendCors(res, 400, `Niedozwolona ścieżka: ${target}`);
+  }
+  const ttl = target === 'fixtures.csv' ? TTL_FIXTURES : TTL_SEASON;
+  const fresh = url.searchParams.get('fresh') === '1';
+
+  if (!fresh) {
+    const hit = await readCache(target, ttl);
+    if (hit !== null) {
+      res.writeHead(200, {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Access-Control-Allow-Origin': '*',
+        'X-Fd-Cache': 'hit'
+      });
+      return res.end(hit);
+    }
+  }
+
+  try {
+    const upstream = await fetch(`${UPSTREAM}/${target}`, {
+      headers: { 'User-Agent': 'LifeOS-stats/1.0', Accept: 'text/csv,*/*' },
+      signal: AbortSignal.timeout(30000)
+    });
+    if (!upstream.ok) {
+      /* Sezon jeszcze nieopublikowany zwraca 404 — to normalny stan, nie awaria. */
+      const stale = await readCache(target, Infinity);
+      if (stale !== null) {
+        res.writeHead(200, {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Access-Control-Allow-Origin': '*',
+          'X-Fd-Cache': 'stale'
+        });
+        return res.end(stale);
+      }
+      return sendCors(res, upstream.status, `football-data.co.uk: HTTP ${upstream.status} dla ${target}`);
+    }
+    const body = await upstream.text();
+    await writeCache(target, body);
+    res.writeHead(200, {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+      'X-Fd-Cache': 'miss'
+    });
+    res.end(body);
+  } catch (error) {
+    const stale = await readCache(target, Infinity);
+    if (stale !== null) {
+      res.writeHead(200, {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Access-Control-Allow-Origin': '*',
+        'X-Fd-Cache': 'stale'
+      });
+      return res.end(stale);
+    }
+    sendCors(res, 502, `Nie udało się pobrać ${target}: ${error.message}`);
+  }
+}
+
+async function handleStatic(req, res, url) {
+  const rel = decodeURIComponent(url.pathname).replace(/^\/+/, '') || 'index.html';
+  const file = path.join(ROOT, rel);
+  if (!file.startsWith(ROOT)) return sendCors(res, 403, 'Poza katalogiem aplikacji');
+  try {
+    const stat = await fsp.stat(file);
+    if (stat.isDirectory()) return handleStatic(req, res, new URL(`${url.pathname.replace(/\/$/, '')}/index.html`, 'http://x'));
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(file).toLowerCase()] || 'application/octet-stream' });
+    fs.createReadStream(file).pipe(res);
+  } catch {
+    sendCors(res, 404, `Nie znaleziono: ${rel}`);
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  if (req.method === 'OPTIONS') return sendCors(res, 204, '');
+  if (url.pathname === '/api/fd/health') {
+    return sendCors(res, 200, JSON.stringify({ ok: true, upstream: UPSTREAM }), 'application/json; charset=utf-8');
+  }
+  if (url.pathname === '/api/fd/csv') return handleCsv(req, res, url);
+  if (url.pathname === '/api/fd/purge') {
+    await fsp.rm(CACHE_DIR, { recursive: true, force: true }).catch(() => {});
+    return sendCors(res, 200, JSON.stringify({ ok: true }), 'application/json; charset=utf-8');
+  }
+  return handleStatic(req, res, url);
+});
+
+server.listen(PORT, () => {
+  console.log(`LifeOS działa na http://localhost:${PORT}`);
+  console.log(`Statystyki:      http://localhost:${PORT}/stats.html`);
+  console.log(`Proxy CSV:       /api/fd/csv?path=mmz4281/2526/E0.csv`);
+  console.log(`Cache na dysku:  ${CACHE_DIR}`);
+});

--- a/start-windows.cmd
+++ b/start-windows.cmd
@@ -1,0 +1,59 @@
+@echo off
+rem ============================================================
+rem  LifeOS - uruchomienie lokalnego serwera (Windows)
+rem
+rem  Po co: przegladarka blokuje pobieranie plikow CSV, gdy
+rem  strona jest otwarta bezposrednio z dysku (file://). Ten
+rem  skrypt startuje serwer i otwiera aplikacje pod adresem
+rem  http://localhost:8787, gdzie wszystko dziala automatycznie.
+rem
+rem  Uzycie: kliknij dwukrotnie ten plik.
+rem  Zatrzymanie: zamknij to okno albo nacisnij Ctrl+C.
+rem ============================================================
+
+setlocal
+cd /d "%~dp0"
+
+where node >nul 2>nul
+if errorlevel 1 goto :no_node
+
+if not exist "server.js" goto :no_server
+
+echo.
+echo   Uruchamiam LifeOS...
+echo   Adres: http://localhost:8787/stats.html
+echo.
+echo   To okno musi pozostac otwarte. Zamkniecie go zatrzymuje serwer.
+echo.
+
+rem Przegladarke otwieramy z opoznieniem, zeby serwer zdazyl wstac.
+start "" /min cmd /c "timeout /t 2 /nobreak >nul & start "" http://localhost:8787/stats.html"
+
+node server.js
+goto :end
+
+:no_node
+echo.
+echo   Nie znaleziono Node.js.
+echo.
+echo   Aplikacja dziala takze bez niego - otworz stats.html jak dotad
+echo   i skorzystaj z importu plikow CSV w sekcji "Zrodlo danych".
+echo.
+echo   Jesli wolisz wersje automatyczna, zainstaluj Node.js (wersja LTS)
+echo   ze strony https://nodejs.org i uruchom ten plik ponownie.
+echo.
+pause
+goto :end
+
+:no_server
+echo.
+echo   Nie znaleziono pliku server.js w katalogu:
+echo   %cd%
+echo.
+echo   Upewnij sie, ze ten skrypt lezy w tym samym folderze co reszta
+echo   plikow aplikacji.
+echo.
+pause
+
+:end
+endlocal

--- a/stats.css
+++ b/stats.css
@@ -123,6 +123,11 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
 }
 .st-flow-hint .material-symbols-outlined { font-size: 18px; flex-shrink: 0; margin-top: 1px; }
 .st-flow-hint em { font-style: normal; font-weight: 600; }
+.st-flow-hint.warn { background: var(--tc-warn-tint); color: var(--tc-warn); border-color: transparent; }
+.st-flow-hint code {
+  font-family: var(--mono); font-size: 11px;
+  background: rgba(15, 23, 42, .08); padding: 1px 5px; border-radius: 4px;
+}
 
 /* -------------------- Znacznik źródła -------------------- */
 .st-quota {

--- a/stats.css
+++ b/stats.css
@@ -168,6 +168,11 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
   cursor: pointer; user-select: none;
 }
 .st-check input { width: 15px; height: 15px; accent-color: var(--tc-accent); cursor: pointer; }
+.st-check em {
+  font-style: normal; font-family: var(--mono); font-weight: 700; font-size: 11px;
+  background: var(--tc-surface); color: var(--tc-muted); padding: 1px 6px; border-radius: 999px; margin-left: 2px;
+}
+.st-check:has(input:checked) em { background: #fff; color: var(--tc-accent-ink); }
 .st-check:has(input:checked) { border-color: var(--tc-accent); background: var(--tc-accent-tint); color: var(--tc-accent-ink); }
 
 .st-load-status {
@@ -180,6 +185,19 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
 .st-load-status .material-symbols-outlined { font-size: 17px; color: var(--tc-muted); }
 .st-load-status .ok { color: var(--tc-pos); }
 .st-load-status .bad { color: var(--tc-neg); }
+
+/* -------------------- Zwijanie paneli -------------------- */
+.st-collapse {
+  display: inline-grid; place-items: center;
+  width: 28px; height: 28px; flex-shrink: 0;
+  overflow: hidden;
+  border: 1px solid var(--tc-line); border-radius: var(--tc-radius-sm);
+  background: var(--tc-card); color: var(--tc-muted);
+  cursor: pointer; transition: all .14s;
+}
+.st-collapse:hover { border-color: var(--tc-accent); background: var(--tc-accent-tint); color: var(--tc-accent); }
+.st-collapse .material-symbols-outlined { font-size: 18px; }
+.tc-card.is-collapsed { display: none; }
 
 /* -------------------- Terminarz live (API-Football) ------ */
 .st-field input[type="password"],
@@ -222,12 +240,19 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
 
 /* -------------------- Terminarz -------------------------- */
 .st-fx-group + .st-fx-group { border-top: 1px solid var(--tc-line); }
+.st-fx-group > summary.st-fx-head { list-style: none; cursor: pointer; user-select: none; }
+.st-fx-group > summary.st-fx-head::-webkit-details-marker { display: none; }
 .st-fx-head {
   display: flex; align-items: center; justify-content: space-between; gap: 10px;
   padding: 10px 16px;
   background: var(--tc-surface);
   border-bottom: 1px solid var(--tc-line);
 }
+.st-fx-group:not([open]) > .st-fx-head { border-bottom: 0; }
+.st-fx-group > summary.st-fx-head:hover { background: var(--tc-accent-tint); }
+.st-fx-head-l { display: inline-flex; align-items: center; gap: 6px; min-width: 0; }
+.st-fx-head .chev { font-size: 18px; color: var(--tc-muted-2); transition: transform .16s; }
+.st-fx-group[open] > .st-fx-head .chev { transform: rotate(180deg); }
 .st-fx-head strong { font-size: 12px; color: var(--tc-ink); }
 .st-fx-head span { font-size: 11px; color: var(--tc-muted); font-family: var(--mono); }
 .st-fx-tbl td { vertical-align: middle; }

--- a/stats.css
+++ b/stats.css
@@ -243,6 +243,23 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
 .st-fx-name { max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .st-fx-score { width: 64px; font-weight: 700; }
 
+/* -------------------- Import plików z dysku -------------- */
+.st-import { border-top: 1px solid var(--tc-line); padding: 13px 16px 15px; background: var(--tc-surface); }
+.st-import-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 9px; }
+.st-import-head .material-symbols-outlined { font-size: 18px; color: var(--tc-accent); }
+.st-import-head strong { font-size: 12.5px; color: var(--tc-ink); }
+.st-import-head .sub { font-size: 11px; color: var(--tc-muted); }
+.st-import-links { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
+.st-import-links a {
+  font-family: var(--mono); font-size: 11px;
+  padding: 4px 9px; border-radius: 999px;
+  background: var(--tc-card); border: 1px solid var(--tc-line-strong);
+  color: var(--tc-accent-ink); text-decoration: none;
+}
+.st-import-links a:hover { border-color: var(--tc-accent); background: var(--tc-accent-tint); }
+.st-import-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.st-import .st-load-status { margin-top: 10px; border-top: 0; border-radius: var(--tc-radius-sm); background: var(--tc-card); }
+
 /* -------------------- Terminarz -------------------------- */
 .st-fx-group + .st-fx-group { border-top: 1px solid var(--tc-line); }
 .st-fx-group > summary.st-fx-head { list-style: none; cursor: pointer; user-select: none; }

--- a/stats.css
+++ b/stats.css
@@ -387,6 +387,24 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
 .st-legend .item { display: inline-flex; align-items: center; gap: 5px; }
 .st-legend .sw { width: 13px; height: 13px; border-radius: 3px; border: 1px solid rgba(15,23,42,.08); }
 
+/* -------------------- Skaner dnia ------------------------ */
+#scan-block.is-locked { opacity: .55; }
+#scan-block.is-locked .st-btn.primary { pointer-events: none; }
+
+.st-scan thead th.lbl:nth-child(2) { min-width: 250px; }
+.st-scan tbody td.lbl { white-space: normal; vertical-align: middle; padding: 9px 16px; }
+.st-scan-fx { font-size: 12.5px; font-weight: 600; color: var(--tc-ink); }
+.st-scan-fx strong { font-weight: 700; }
+.st-scan-meta { display: flex; align-items: center; gap: 6px; margin-top: 3px; font-size: 10.5px; color: var(--tc-muted); font-weight: 500; }
+.st-scan-grp {
+  display: inline-block; margin-right: 6px;
+  font-size: 9px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
+  color: var(--tc-accent-ink); background: var(--tc-accent-tint);
+  padding: 2px 6px; border-radius: 4px; vertical-align: 1px;
+}
+.st-scan tbody tr:hover td.lbl { background: #fbfcfe; }
+.st-scan .st-btn { height: 30px; padding: 0 10px; }
+
 /* -------------------- Pasek formy ------------------------ */
 .st-form-block { border-top: 1px solid var(--tc-line); padding: 12px 16px 14px; background: var(--tc-surface); }
 .st-form-title { display: flex; align-items: baseline; gap: 9px; flex-wrap: wrap; margin-bottom: 9px; }

--- a/stats.css
+++ b/stats.css
@@ -1,7 +1,7 @@
 /* ============================================================
-   STATYSTYKI — pomoc przy budowaniu kuponów (TheSportsDB)
-   Dziedziczy komponenty z trading.css i betting.css; tutaj
-   tokeny dla body[data-page="stats"] + macierz pokrycia.
+   STATYSTYKI — macierze pokrycia rynków (football-data.co.uk)
+   Dziedziczy komponenty z trading.css; tutaj tokeny dla
+   body[data-page="stats"] + siatki, macierze i paski formy.
    ============================================================ */
 
 body[data-page="stats"] {
@@ -48,16 +48,32 @@ body[data-page="stats"] .tc-card {
   border-radius: var(--tc-radius);
   box-shadow: var(--bt-shadow);
   background: var(--tc-card);
+  overflow: hidden;
 }
 body[data-page="stats"] .tc-card-head {
-  padding: 13px 16px;
+  display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;
+  padding: 12px 16px;
   border-bottom: 1px solid var(--tc-line);
   background: linear-gradient(180deg, #fbfcfe 0%, #ffffff 100%);
-  border-radius: var(--tc-radius) var(--tc-radius) 0 0;
 }
-body[data-page="stats"] .tc-card-head h3 { font-size: 13px; font-weight: 700; }
-body[data-page="stats"] .tc-empty { padding: 34px 20px; }
+body[data-page="stats"] .tc-card-head h3 {
+  display: flex; align-items: center; gap: 8px;
+  margin: 0; font-size: 13px; font-weight: 700; color: var(--tc-ink);
+}
+body[data-page="stats"] .tc-card-head h3 .material-symbols-outlined { font-size: 18px; color: var(--tc-accent); }
+body[data-page="stats"] .tc-card-head .sub { font-size: 11.5px; color: var(--tc-muted); }
+body[data-page="stats"] .tc-empty { padding: 34px 20px; text-align: center; color: var(--tc-muted); }
+body[data-page="stats"] .tc-empty h4 { margin: 8px 0 4px; font-size: 15px; color: var(--tc-ink); }
+body[data-page="stats"] .tc-empty p { margin: 0; font-size: 12.5px; }
 body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-size: 9.5px; letter-spacing: .09em; }
+
+.mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.num { text-align: right; }
+.strong { font-weight: 700; }
+.win { color: var(--tc-pos); }
+.loss { color: var(--tc-neg); }
+.spin { animation: st-spin 1s linear infinite; }
+@keyframes st-spin { to { transform: rotate(360deg); } }
 
 /* -------------------- Pasek kroków ----------------------- */
 .st-steps { display: flex; align-items: stretch; gap: 0; flex-wrap: wrap; }
@@ -84,6 +100,7 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
   font-size: 12px;
   font-weight: 700;
   border: 1px solid var(--tc-line-strong);
+  text-align: center;
 }
 .st-step .k { font-size: 12px; font-weight: 600; color: var(--tc-muted); }
 .st-step .v { font-size: 11px; color: var(--tc-muted-2); margin-top: 1px; }
@@ -97,7 +114,7 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
   .st-steps { gap: 8px; }
 }
 
-/* -------------------- Licznik zapytań -------------------- */
+/* -------------------- Znacznik źródła -------------------- */
 .st-quota {
   display: inline-flex;
   align-items: center;
@@ -110,140 +127,140 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
   color: var(--tc-muted);
   white-space: nowrap;
 }
-.st-quota .bar { width: 54px; height: 5px; border-radius: 3px; background: var(--tc-line-strong); overflow: hidden; position: relative; }
-.st-quota .bar i { position: absolute; inset: 0 auto 0 0; background: var(--tc-accent); }
-.st-quota.warn { border-color: var(--tc-warn); color: var(--tc-warn); background: var(--tc-warn-tint); }
-.st-quota.warn .bar i { background: var(--tc-warn); }
-.st-quota.bad { border-color: var(--tc-neg); color: var(--tc-neg); background: var(--tc-neg-tint); }
-.st-quota.bad .bar i { background: var(--tc-neg); }
-.st-quota strong { font-family: var(--mono); font-weight: 700; color: inherit; }
+.st-quota strong { font-weight: 700; color: var(--tc-ink-2); }
 
-/* -------------------- Ligi ------------------------------- */
-.st-leagues { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 8px; padding: 14px; }
-.st-league {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 9px 11px;
-  border: 1px solid var(--tc-line);
-  border-radius: var(--tc-radius-sm);
-  background: var(--tc-card);
+/* -------------------- Panel sterowania ------------------- */
+.st-controls {
+  display: flex; align-items: flex-end; gap: 12px; flex-wrap: wrap;
+  padding: 14px 16px;
+}
+.st-field { display: flex; flex-direction: column; gap: 5px; min-width: 150px; }
+.st-field.wide { flex: 1; min-width: 220px; }
+.st-field > span {
+  font-size: 10px; font-weight: 700; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--tc-muted);
+}
+.st-field select {
+  height: 38px; padding: 0 10px;
+  border: 1px solid var(--tc-line-strong); border-radius: var(--tc-radius-sm);
+  background: var(--tc-card); color: var(--tc-ink);
+  font-family: inherit; font-size: 13px; font-weight: 500;
   cursor: pointer;
-  text-align: left;
-  font-family: inherit;
-  transition: all .14s;
 }
-.st-league:hover { border-color: var(--tc-accent); background: var(--tc-accent-tint); }
-.st-league.active { border-color: var(--tc-accent); background: var(--tc-accent-tint); box-shadow: 0 0 0 2px rgba(0, 87, 192, .12); }
-.st-league img { width: 22px; height: 22px; object-fit: contain; flex-shrink: 0; }
-.st-league .t { min-width: 0; flex: 1; }
-.st-league .n { font-size: 12.5px; font-weight: 600; color: var(--tc-ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.st-league .c { font-size: 11px; color: var(--tc-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.st-league .cnt {
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--tc-muted);
-  background: var(--tc-surface);
-  border-radius: 999px;
-  padding: 2px 8px;
-  flex-shrink: 0;
-}
-.st-league.active .cnt { background: #fff; color: var(--tc-accent-ink); }
+.st-field select:focus { outline: none; border-color: var(--tc-accent); box-shadow: 0 0 0 3px rgba(0,87,192,.14); }
+.st-field .st-seg { height: 38px; align-items: center; }
 
-.st-league-search {
-  padding: 12px 14px;
+.st-check {
+  display: inline-flex; align-items: center; gap: 8px;
+  height: 38px; padding: 0 13px;
+  border: 1px solid var(--tc-line-strong); border-radius: var(--tc-radius-sm);
+  background: var(--tc-card); font-size: 12.5px; font-weight: 600; color: var(--tc-ink-2);
+  cursor: pointer; user-select: none;
+}
+.st-check input { width: 15px; height: 15px; accent-color: var(--tc-accent); cursor: pointer; }
+.st-check:has(input:checked) { border-color: var(--tc-accent); background: var(--tc-accent-tint); color: var(--tc-accent-ink); }
+
+.st-load-status {
+  display: flex; align-items: center; gap: 8px;
+  padding: 11px 16px;
+  border-top: 1px solid var(--tc-line);
+  background: var(--tc-surface);
+  font-size: 12px; color: var(--tc-ink-2);
+}
+.st-load-status .material-symbols-outlined { font-size: 17px; color: var(--tc-muted); }
+.st-load-status .ok { color: var(--tc-pos); }
+.st-load-status .bad { color: var(--tc-neg); }
+
+/* -------------------- Terminarz -------------------------- */
+.st-fx-group + .st-fx-group { border-top: 1px solid var(--tc-line); }
+.st-fx-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  padding: 10px 16px;
+  background: var(--tc-surface);
   border-bottom: 1px solid var(--tc-line);
-  background: var(--tc-surface);
 }
-.st-league-search input {
-  width: 100%;
-  height: 34px;
-  padding: 0 11px;
-  border: 1px solid var(--tc-line-strong);
-  border-radius: var(--tc-radius-sm);
-  background: var(--tc-card);
-  font-family: inherit;
-  font-size: 13px;
-  color: var(--tc-ink);
-}
-.st-league-search input:focus { outline: none; border-color: var(--tc-accent); box-shadow: 0 0 0 3px rgba(0, 87, 192, .14); }
+.st-fx-head strong { font-size: 12px; color: var(--tc-ink); }
+.st-fx-head span { font-size: 11px; color: var(--tc-muted); font-family: var(--mono); }
+.st-fx-tbl td { vertical-align: middle; }
+.st-fx-tbl .st-btn { height: 30px; padding: 0 11px; font-size: 12px; }
 
-/* -------------------- Mecze ------------------------------ */
-/* przy ~70 meczach w lidze lista musi się przewijać, a nie rozpychać stronę */
-#matches { max-height: 520px; overflow-y: auto; }
-#matches::-webkit-scrollbar { width: 8px; }
-#matches::-webkit-scrollbar-thumb { background: var(--tc-line-strong); border-radius: 4px; }
-#matches .tc-tbl thead th { position: sticky; top: 0; z-index: 2; }
-
-.st-match-row { cursor: pointer; }
-.st-match-row:hover td { background: var(--tc-accent-tint) !important; }
-.st-match-row.active td { background: var(--tc-accent-tint) !important; box-shadow: inset 3px 0 0 var(--tc-accent); }
-.st-team { display: flex; align-items: center; gap: 7px; min-width: 0; }
-.st-team img { width: 18px; height: 18px; object-fit: contain; flex-shrink: 0; }
-.st-team span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 600; color: var(--tc-ink); }
-.st-time { font-family: var(--mono); font-weight: 700; font-variant-numeric: tabular-nums; }
-.st-status {
-  font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase;
-  padding: 2px 7px; border-radius: 999px; white-space: nowrap;
-  background: var(--tc-surface); color: var(--tc-muted);
-}
-.st-status.live { background: var(--tc-neg-tint); color: var(--tc-neg); }
-.st-status.ns { background: var(--tc-accent-tint); color: var(--tc-accent-ink); }
-.st-status.ft { background: var(--tc-pos-tint); color: var(--tc-pos); }
-
-/* -------------------- Nagłówek meczu --------------------- */
-.st-fixture-hero {
+/* -------------------- Nagłówek analizy ------------------- */
+.st-hero {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   gap: 18px;
   align-items: center;
-  padding: 18px 20px;
+  padding: 20px;
   border-bottom: 1px solid var(--tc-line);
   background: linear-gradient(180deg, #f7f9fd 0%, #ffffff 100%);
 }
-.st-fx-team { display: flex; align-items: center; gap: 11px; min-width: 0; }
-.st-fx-team.away { flex-direction: row-reverse; text-align: right; }
-.st-fx-team img { width: 38px; height: 38px; object-fit: contain; flex-shrink: 0; }
-.st-fx-team .n { font-size: 15px; font-weight: 700; color: var(--tc-ink); overflow: hidden; text-overflow: ellipsis; }
-.st-fx-team .s { font-size: 11.5px; color: var(--tc-muted); }
-.st-fx-mid { text-align: center; }
-.st-fx-mid .lam { font-family: var(--mono); font-size: 20px; font-weight: 700; color: var(--tc-accent); font-variant-numeric: tabular-nums; }
-.st-fx-mid .k { font-size: 9.5px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; color: var(--tc-muted); }
+.st-hero-team { min-width: 0; }
+.st-hero-team.away { text-align: right; }
+.st-hero-team .n { font-size: 17px; font-weight: 700; color: var(--tc-ink); }
+.st-hero-team .s { font-size: 11.5px; color: var(--tc-muted); margin-top: 2px; }
+.st-hero-mid { text-align: center; }
+.st-hero-mid .k { font-size: 9.5px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; color: var(--tc-muted); }
+.st-hero-mid .lam { font-family: var(--mono); font-size: 24px; font-weight: 700; color: var(--tc-accent); font-variant-numeric: tabular-nums; }
+.st-hero-mid .odds { font-size: 11px; color: var(--tc-muted); font-family: var(--mono); }
 @media (max-width: 720px) {
-  .st-fixture-hero { grid-template-columns: 1fr; gap: 12px; }
-  .st-fx-team.away { flex-direction: row; text-align: left; }
+  .st-hero { grid-template-columns: 1fr; gap: 12px; text-align: left; }
+  .st-hero-team.away { text-align: left; }
 }
 
-.st-fx-meta {
+.st-tiles {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   border-bottom: 1px solid var(--tc-line);
 }
-.st-fx-meta .cell { padding: 11px 14px; border-right: 1px solid var(--tc-line); }
-.st-fx-meta .cell:last-child { border-right: 0; }
-.st-fx-meta .k { font-size: 9.5px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; color: var(--tc-muted); }
-.st-fx-meta .v { font-family: var(--mono); font-size: 15px; font-weight: 700; color: var(--tc-ink); margin-top: 2px; font-variant-numeric: tabular-nums; }
-.st-fx-meta .n { font-size: 11px; color: var(--tc-muted); margin-top: 1px; }
-
-.st-history-toolbar {
-  display: flex; align-items: center; justify-content: space-between; gap: 12px;
-  padding: 10px 14px; border-bottom: 1px solid var(--tc-line);
-  background: var(--tc-surface); color: var(--tc-muted); font-size: 11.5px;
+.st-tile {
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 15px;
+  border-right: 1px solid var(--tc-line);
 }
-.st-history-toolbar .st-seg { flex-shrink: 0; }
-.st-recommendations { border-bottom: 1px solid var(--tc-line); }
-.st-rec-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 8px; padding: 12px 14px 15px; }
-.st-rec { display: grid; grid-template-columns: 1fr auto; gap: 4px 10px; padding: 10px 11px; border: 1px solid var(--tc-line); border-radius: var(--tc-radius-sm); }
-.st-rec strong { font-size: 11.5px; color: var(--tc-ink); }
-.st-rec .value { font-family: var(--mono); font-size: 15px; font-weight: 700; }
-.st-rec small { grid-column: 1 / -1; color: var(--tc-muted); font-size: 10.5px; }
+.st-tile:last-child { border-right: 0; }
+.st-tile .material-symbols-outlined { font-size: 20px; color: var(--tc-accent); }
+.st-tile .k { font-size: 9.5px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--tc-muted); }
+.st-tile .v { font-family: var(--mono); font-size: 18px; font-weight: 700; color: var(--tc-ink); font-variant-numeric: tabular-nums; }
+
+/* -------------------- Szybka nawigacja ------------------- */
+.st-jump {
+  display: flex; gap: 7px; flex-wrap: wrap;
+  position: sticky; top: 0; z-index: 5;
+  padding: 10px 12px;
+  border: 1px solid var(--tc-line);
+  border-radius: var(--tc-radius);
+  background: rgba(255, 255, 255, .93);
+  backdrop-filter: blur(8px);
+  box-shadow: var(--bt-shadow);
+}
+.st-jump a {
+  padding: 5px 12px; border-radius: 999px;
+  background: var(--tc-surface); border: 1px solid var(--tc-line);
+  font-size: 11.5px; font-weight: 600; color: var(--tc-muted); text-decoration: none;
+  transition: all .14s;
+}
+.st-jump a:hover { border-color: var(--tc-accent); background: var(--tc-accent-tint); color: var(--tc-accent-ink); }
+
+/* -------------------- Skrót typów ------------------------ */
+.st-rec-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(215px, 1fr)); gap: 8px; padding: 14px 16px; }
+.st-rec {
+  display: grid; grid-template-columns: 1fr auto; gap: 3px 10px; align-items: baseline;
+  padding: 11px 12px; border: 1px solid var(--tc-line); border-radius: var(--tc-radius-sm);
+}
+.st-rec .grp {
+  grid-column: 1 / -1;
+  font-size: 9px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; color: var(--tc-muted);
+}
+.st-rec strong { font-size: 12px; color: var(--tc-ink); }
+.st-rec .value { font-family: var(--mono); font-size: 16px; font-weight: 700; }
+.st-rec small { grid-column: 1 / -1; color: var(--tc-muted); font-size: 10.5px; line-height: 1.5; }
+.st-rec small.model { color: var(--tc-accent); font-weight: 600; }
+.st-rec.t6 { background: #d2f2e2; border-color: #a9e2c4; }
 .st-rec.t5 { background: #dcf5e7; border-color: #b9e8ce; }
 .st-rec.t4 { background: #eaf8f0; }
 .st-rec.t3 { background: #f6f8fa; }
 .st-rec.t2 { background: #fdf3e3; }
 .st-rec.t1 { background: #fbe9e7; }
-@media (max-width: 620px) { .st-history-toolbar { align-items: flex-start; flex-direction: column; } }
 
 /* -------------------- MACIERZ POKRYCIA ------------------- */
 .st-matrix-wrap { overflow-x: auto; }
@@ -252,8 +269,7 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
 
 .st-matrix { width: 100%; border-collapse: separate; border-spacing: 0; font-size: 12px; }
 .st-matrix thead th {
-  position: sticky; top: 0;
-  padding: 9px 8px;
+  padding: 8px;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: .06em;
@@ -264,18 +280,35 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
   text-align: center;
   white-space: nowrap;
 }
-.st-matrix thead th:first-child { text-align: left; padding-left: 14px; min-width: 190px; }
+.st-matrix thead tr.grp th { border-bottom: 1px solid var(--tc-line); }
+.st-matrix thead tr.grp th[colspan] { color: var(--tc-ink); font-size: 11px; letter-spacing: .02em; text-transform: none; }
+.st-matrix thead th small { display: block; font-weight: 500; font-size: 9px; text-transform: none; letter-spacing: 0; opacity: .8; }
+/* Tylko kolumna opisu — bez :first-child, bo w drugim wierszu nagłówka
+   trafiałby on w komórkę „5" i rozpychał pierwsze okno. */
+.st-matrix thead th.lbl { text-align: left; padding-left: 16px; min-width: 210px; }
+.st-matrix thead tr + tr th { min-width: 70px; }
+.st-matrix thead th.sep, .st-matrix tbody td.sep { width: 5px; min-width: 5px; padding: 0; background: var(--tc-surface); }
+
 .st-matrix tbody td { border-bottom: 1px solid var(--tc-line); padding: 0; text-align: center; }
 .st-matrix tbody tr:last-child td { border-bottom: 0; }
+.st-matrix tbody tr:hover td:not(.sep) { background: #fbfcfe; }
 .st-matrix tbody td.lbl {
   text-align: left;
-  padding: 9px 14px;
+  padding: 8px 16px;
   font-weight: 600;
   color: var(--tc-ink);
   white-space: nowrap;
   background: var(--tc-card);
 }
-.st-matrix tbody td.lbl small { display: block; font-weight: 500; font-size: 10.5px; color: var(--tc-muted); }
+.st-matrix tbody td.lbl .ln {
+  font-family: var(--mono); font-size: 11px; font-weight: 700;
+  color: var(--tc-accent-ink); background: var(--tc-accent-tint);
+  padding: 1px 7px; border-radius: 5px; margin-left: 4px;
+}
+.st-matrix tbody tr.gap td { height: 7px; padding: 0; background: var(--tc-surface); border-bottom: 1px solid var(--tc-line); }
+.st-matrix tbody tr.gap:hover td { background: var(--tc-surface); }
+.st-matrix.wide tbody td { padding: 9px 12px; }
+.st-matrix.wide tbody td.lbl { padding: 9px 16px; }
 
 .mx {
   display: flex;
@@ -283,52 +316,94 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
   align-items: center;
   justify-content: center;
   gap: 1px;
-  padding: 7px 4px;
-  min-width: 78px;
-  min-height: 46px;
+  padding: 6px 4px;
+  min-width: 70px;
+  min-height: 44px;
   border-left: 1px solid var(--tc-line);
 }
-.mx .p { font-family: var(--mono); font-size: 15px; font-weight: 700; font-variant-numeric: tabular-nums; line-height: 1.1; }
+.mx .p { font-family: var(--mono); font-size: 14px; font-weight: 700; font-variant-numeric: tabular-nums; line-height: 1.1; }
 .mx .h { font-family: var(--mono); font-size: 10px; font-variant-numeric: tabular-nums; opacity: .78; }
-.mx .h.agree { font-weight: 700; }
 .mx.empty { color: var(--tc-muted-2); }
 .mx.empty .p { color: var(--tc-muted-2); font-weight: 500; }
+.mx.pooled { box-shadow: inset 0 0 0 1px rgba(15,23,42,.10); }
+.mx.model { font-style: normal; }
+.mx.model .h { opacity: .6; }
 
-/* skala pokrycia */
+/* skala pokrycia — im ciemniej, tym częściej linia była przekroczona */
+.mx.t6 { background: #c8efdb; } .mx.t6 .p { color: #044c2e; }
 .mx.t5 { background: #dcf5e7; } .mx.t5 .p { color: #06603a; }
 .mx.t4 { background: #eaf8f0; } .mx.t4 .p { color: #0b8a4a; }
 .mx.t3 { background: #f6f8fa; } .mx.t3 .p { color: var(--tc-ink-2); }
 .mx.t2 { background: #fdf3e3; } .mx.t2 .p { color: var(--tc-warn); }
 .mx.t1 { background: #fbe9e7; } .mx.t1 .p { color: var(--tc-neg); }
 
-/* rozbieżność modelu z historią */
-.mx .h.diff { color: var(--tc-warn); font-weight: 700; }
+.edge-pos { color: var(--tc-pos); font-weight: 700; }
+.edge-neg { color: var(--tc-neg); }
 
-.st-matrix-title {
-  display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;
-  padding: 11px 14px;
-  border-bottom: 1px solid var(--tc-line);
-  background: var(--tc-card);
+.st-legend {
+  display: flex; gap: 14px; flex-wrap: wrap; align-items: center;
+  padding: 11px 16px; border-top: 1px solid var(--tc-line);
+  background: var(--tc-surface); font-size: 11.5px; color: var(--tc-muted);
 }
-.st-matrix-title strong { font-size: 12.5px; color: var(--tc-ink); }
-.st-matrix-title .sub { font-size: 11.5px; color: var(--tc-muted); }
-
-.st-legend { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; padding: 11px 14px; border-top: 1px solid var(--tc-line); background: var(--tc-surface); font-size: 11.5px; color: var(--tc-muted); }
 .st-legend .item { display: inline-flex; align-items: center; gap: 5px; }
 .st-legend .sw { width: 13px; height: 13px; border-radius: 3px; border: 1px solid rgba(15,23,42,.08); }
 
-/* -------------------- Pomocnicze ------------------------- */
-.st-toolbar {
-  display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap;
-  padding: 11px 15px;
-  border-bottom: 1px solid var(--tc-line);
-  background: linear-gradient(180deg, #fbfcfe 0%, #ffffff 100%);
+/* -------------------- Pasek formy ------------------------ */
+.st-form-block { border-top: 1px solid var(--tc-line); padding: 12px 16px 14px; background: var(--tc-surface); }
+.st-form-title { display: flex; align-items: baseline; gap: 9px; flex-wrap: wrap; margin-bottom: 9px; }
+.st-form-title strong { font-size: 12px; color: var(--tc-ink); }
+.st-form-title span { font-size: 10.5px; color: var(--tc-muted); }
+.st-form-row { display: flex; align-items: center; gap: 12px; margin-top: 6px; }
+.st-form-row .tn {
+  width: 165px; flex-shrink: 0;
+  font-size: 11.5px; font-weight: 600; color: var(--tc-ink-2);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.st-toolbar .grp { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.st-form { display: flex; gap: 3px; flex-wrap: wrap; }
+.st-form i { width: 15px; height: 15px; border-radius: 4px; display: block; }
+.st-form i.hit { background: var(--tc-pos); }
+.st-form i.miss { background: var(--tc-line-strong); }
+.st-form i.void { background: repeating-linear-gradient(45deg, #e2e8f0, #e2e8f0 2px, #fff 2px, #fff 4px); }
+@media (max-width: 620px) { .st-form-row { flex-direction: column; align-items: flex-start; gap: 4px; } .st-form-row .tn { width: auto; } }
 
+/* -------------------- Profile drużyn --------------------- */
+.st-profiles { display: grid; grid-template-columns: 1fr 1fr; }
+.st-profile { border-right: 1px solid var(--tc-line); }
+.st-profile:last-child { border-right: 0; }
+.st-profile-head {
+  padding: 10px 16px; background: var(--tc-surface); border-bottom: 1px solid var(--tc-line);
+  font-size: 12.5px; font-weight: 700; color: var(--tc-ink);
+}
+.st-profile-head span { font-weight: 500; font-size: 11px; color: var(--tc-muted); margin-left: 6px; }
+.st-profile-tbl { width: 100%; border-collapse: collapse; font-size: 12px; }
+.st-profile-tbl thead th {
+  padding: 7px 12px; text-align: right;
+  font-size: 9.5px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
+  color: var(--tc-muted); border-bottom: 1px solid var(--tc-line);
+}
+.st-profile-tbl thead th:first-child { text-align: left; padding-left: 16px; }
+.st-profile-tbl tbody td { padding: 7px 12px; border-bottom: 1px solid var(--tc-line); }
+.st-profile-tbl tbody tr:last-child td { border-bottom: 0; }
+.st-profile-tbl tbody td.lbl { text-align: left; padding-left: 16px; font-weight: 600; color: var(--tc-ink-2); }
+.st-profile-tbl tbody td.strong { color: var(--tc-accent-ink); }
+@media (max-width: 820px) { .st-profiles { grid-template-columns: 1fr; } .st-profile { border-right: 0; border-bottom: 1px solid var(--tc-line); } }
+
+/* -------------------- Historia --------------------------- */
+.st-history { border-bottom: 1px solid var(--tc-line); }
+.st-history:last-child { border-bottom: 0; }
+.st-history summary {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  padding: 11px 16px; cursor: pointer; background: var(--tc-surface);
+  font-size: 12px; color: var(--tc-ink);
+}
+.st-history summary::marker { color: var(--tc-muted-2); }
+.st-history summary span { font-size: 11px; color: var(--tc-muted); font-weight: 500; }
+.st-history[open] summary { border-bottom: 1px solid var(--tc-line); }
+
+/* -------------------- Pomocnicze ------------------------- */
 .st-btn {
   display: inline-flex; align-items: center; gap: 6px;
-  height: 36px; padding: 0 16px;
+  height: 38px; padding: 0 16px;
   border-radius: var(--tc-radius-sm);
   border: 1px solid var(--tc-line-strong);
   background: var(--tc-card);
@@ -341,8 +416,6 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
 .st-btn .material-symbols-outlined { font-size: 18px; }
 .st-btn.primary { background: var(--tc-accent); border-color: var(--tc-accent); color: #fff; box-shadow: 0 4px 12px -4px rgba(0,87,192,.55); }
 .st-btn.primary:hover:not(:disabled) { background: var(--tc-accent-ink); border-color: var(--tc-accent-ink); }
-.st-btn.spin .material-symbols-outlined { animation: st-spin 1s linear infinite; }
-@keyframes st-spin { to { transform: rotate(360deg); } }
 
 .st-seg { display: inline-flex; background: var(--tc-surface); border: 1px solid var(--tc-line); border-radius: var(--tc-radius-sm); padding: 3px; }
 .st-seg button {
@@ -354,35 +427,16 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
 
 .st-note {
   display: flex; align-items: flex-start; gap: 8px;
-  padding: 10px 13px; border-radius: var(--tc-radius-sm);
-  font-size: 12px; line-height: 1.5;
-  background: var(--tc-surface); border: 1px solid var(--tc-line); color: var(--tc-ink-2);
+  padding: 12px 16px;
+  font-size: 12px; line-height: 1.55;
+  background: var(--tc-surface); color: var(--tc-ink-2);
 }
 .st-note .material-symbols-outlined { font-size: 17px; flex-shrink: 0; margin-top: 1px; }
-.st-note.warn { background: var(--tc-warn-tint); border-color: transparent; color: var(--tc-warn); }
-.st-note.bad { background: var(--tc-neg-tint); border-color: transparent; color: var(--tc-neg); }
-.st-note.good { background: var(--tc-pos-tint); border-color: transparent; color: var(--tc-pos); }
-.st-note strong { font-weight: 700; }
-.st-notes { display: flex; flex-direction: column; gap: 8px; padding: 13px 15px; }
-
-.st-h2h-list { display: flex; flex-direction: column; }
-.st-h2h-row {
-  display: grid; grid-template-columns: 92px 1fr auto 1fr auto;
-  gap: 10px; align-items: center;
-  padding: 8px 14px; border-bottom: 1px solid var(--tc-line); font-size: 12px;
-}
-.st-h2h-row:last-child { border-bottom: 0; }
-.st-h2h-row .d { font-family: var(--mono); font-size: 11px; color: var(--tc-muted); }
-.st-h2h-row .sc { font-family: var(--mono); font-weight: 700; font-size: 13px; padding: 1px 8px; border-radius: 5px; background: var(--tc-surface); }
-.st-h2h-row .tn { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.st-h2h-row .tn.a { text-align: right; }
-.st-h2h-row .ex { font-family: var(--mono); font-size: 10.5px; color: var(--tc-muted); white-space: nowrap; }
-@media (max-width: 760px) { .st-h2h-row { grid-template-columns: 1fr auto 1fr; } .st-h2h-row .d, .st-h2h-row .ex { display: none; } }
-
-.st-key-missing { display: flex; flex-direction: column; align-items: center; gap: 12px; padding: 44px 24px; text-align: center; }
-.st-key-missing .material-symbols-outlined { font-size: 40px; color: var(--tc-muted-2); }
-.st-key-missing h4 { margin: 0; font-size: 15px; color: var(--tc-ink); }
-.st-key-missing p { margin: 0; font-size: 12.5px; color: var(--tc-muted); max-width: 420px; line-height: 1.6; }
+.st-note.warn { background: var(--tc-warn-tint); color: var(--tc-warn); }
+.st-note.bad { background: var(--tc-neg-tint); color: var(--tc-neg); }
+.st-note.good { background: var(--tc-pos-tint); color: var(--tc-pos); }
+.st-note code { font-family: var(--mono); font-size: 11px; background: rgba(15,23,42,.06); padding: 1px 5px; border-radius: 4px; }
+.st-notes { display: flex; flex-direction: column; gap: 1px; }
 
 .st-section { display: flex; align-items: center; gap: 10px; margin: 22px 0 12px; }
 .st-section .ico {
@@ -394,12 +448,3 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
 .st-section .desc { font-size: 11.5px; color: var(--tc-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .st-section .line { flex: 1; height: 1px; background: var(--tc-line); min-width: 12px; }
 .st-stack { display: flex; flex-direction: column; gap: 14px; }
-
-.st-ff { display: flex; flex-direction: column; gap: 5px; }
-.st-ff label { font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--tc-muted); }
-.st-ff input {
-  width: 100%; height: 38px; padding: 0 11px;
-  border: 1px solid var(--tc-line-strong); border-radius: var(--tc-radius-sm);
-  background: var(--tc-card); color: var(--tc-ink); font-family: var(--mono); font-size: 13px;
-}
-.st-ff input:focus { outline: none; border-color: var(--tc-accent); box-shadow: 0 0 0 3px rgba(0,87,192,.14); }

--- a/stats.css
+++ b/stats.css
@@ -171,6 +171,45 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
 .st-load-status .ok { color: var(--tc-pos); }
 .st-load-status .bad { color: var(--tc-neg); }
 
+/* -------------------- Terminarz live (API-Football) ------ */
+.st-field input[type="password"],
+.st-field input[type="search"] {
+  height: 38px; padding: 0 11px;
+  border: 1px solid var(--tc-line-strong); border-radius: var(--tc-radius-sm);
+  background: var(--tc-card); color: var(--tc-ink);
+  font-family: inherit; font-size: 13px;
+}
+.st-field input[type="password"] { font-family: var(--mono); letter-spacing: .06em; }
+.st-field input:focus { outline: none; border-color: var(--tc-accent); box-shadow: 0 0 0 3px rgba(0,87,192,.14); }
+
+#af-block.is-locked { opacity: .55; }
+#af-block.is-locked .st-btn.primary { pointer-events: none; }
+
+.st-status {
+  display: inline-block;
+  font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase;
+  padding: 3px 8px; border-radius: 999px; white-space: nowrap;
+  background: var(--tc-surface); color: var(--tc-muted);
+}
+.st-status.ns { background: var(--tc-accent-tint); color: var(--tc-accent-ink); font-family: var(--mono); }
+.st-status.ft { background: var(--tc-pos-tint); color: var(--tc-pos); }
+.st-status.off { background: var(--tc-warn-tint); color: var(--tc-warn); }
+.st-status.live { background: var(--tc-neg-tint); color: var(--tc-neg); animation: st-pulse 1.8s ease-in-out infinite; }
+@keyframes st-pulse { 50% { opacity: .55; } }
+
+.st-badge {
+  display: inline-block; margin-right: 7px;
+  font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase;
+  padding: 2px 7px; border-radius: 5px;
+  background: var(--tc-surface); color: var(--tc-muted-2); border: 1px solid var(--tc-line);
+}
+.st-badge.ok { background: var(--tc-accent-tint); color: var(--tc-accent-ink); border-color: transparent; }
+.st-muted { color: var(--tc-muted-2); }
+
+.st-fx-status { width: 84px; }
+.st-fx-name { max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.st-fx-score { width: 64px; font-weight: 700; }
+
 /* -------------------- Terminarz -------------------------- */
 .st-fx-group + .st-fx-group { border-top: 1px solid var(--tc-line); }
 .st-fx-head {

--- a/stats.css
+++ b/stats.css
@@ -114,6 +114,16 @@ body[data-page="stats"] .tc-tbl thead th { background: var(--tc-surface); font-s
   .st-steps { gap: 8px; }
 }
 
+.st-flow-hint {
+  display: flex; align-items: flex-start; gap: 9px;
+  margin-top: 10px; padding: 11px 14px;
+  border: 1px solid var(--tc-line); border-radius: var(--tc-radius);
+  background: var(--tc-accent-tint); color: var(--tc-accent-ink);
+  font-size: 12px; line-height: 1.55;
+}
+.st-flow-hint .material-symbols-outlined { font-size: 18px; flex-shrink: 0; margin-top: 1px; }
+.st-flow-hint em { font-style: normal; font-weight: 600; }
+
 /* -------------------- Znacznik źródła -------------------- */
 .st-quota {
   display: inline-flex;

--- a/stats.html
+++ b/stats.html
@@ -89,9 +89,10 @@
           <h2>Klucz API-Football</h2>
           <span class="desc">Terminarz live z 39 lig — klucz zostaje wyłącznie w tej przeglądarce</span>
           <span class="line"></span>
+          <button class="st-collapse" data-collapse="key-block" title="Zwiń / rozwiń"><span class="material-symbols-outlined">expand_less</span></button>
         </div>
 
-        <section class="tc-card">
+        <section class="tc-card" id="key-block">
           <div class="st-controls">
             <label class="st-field wide">
               <span>Klucz z dashboard.api-football.com</span>
@@ -109,6 +110,7 @@
           <h2>Terminarz live</h2>
           <span class="desc" id="af-day-label">—</span>
           <span class="line"></span>
+          <button class="st-collapse" data-collapse="af-block" title="Zwiń / rozwiń"><span class="material-symbols-outlined">expand_less</span></button>
         </div>
 
         <section class="tc-card" id="af-block">
@@ -124,6 +126,10 @@
               <span>Filtruj ligę lub drużynę</span>
               <input type="search" id="af-filter" placeholder="np. Premier League, Ekstraklasa, Arsenal…">
             </label>
+            <label class="st-check" title="Pokazuje wyłącznie mecze z lig, dla których mamy historię w CSV">
+              <input type="checkbox" id="af-only-covered">
+              <span>Tylko z analizą <em id="af-covered-count">0</em></span>
+            </label>
             <button class="st-btn primary" id="af-load"><span class="material-symbols-outlined">download</span>Pobierz terminarz</button>
           </div>
           <div class="st-load-status"><span class="material-symbols-outlined">insights</span><span id="af-summary">Pobranie terminarza kosztuje 1 zapytanie z dziennego limitu.</span></div>
@@ -136,6 +142,7 @@
           <h2>Skaner dnia</h2>
           <span class="desc">Ranking najlepszych pokryć ze wszystkich meczów naraz</span>
           <span class="line"></span>
+          <button class="st-collapse" data-collapse="scan-block" title="Zwiń / rozwiń"><span class="material-symbols-outlined">expand_less</span></button>
         </div>
 
         <section class="tc-card" id="scan-block">
@@ -170,9 +177,10 @@
           <h2>Źródło danych</h2>
           <span class="desc">football-data.co.uk — komplet statystyk meczowych, bez klucza API</span>
           <span class="line"></span>
+          <button class="st-collapse" data-collapse="source-block" title="Zwiń / rozwiń"><span class="material-symbols-outlined">expand_less</span></button>
         </div>
 
-        <section class="tc-card">
+        <section class="tc-card" id="source-block">
           <div class="st-controls">
             <label class="st-field wide">
               <span>Liga</span>

--- a/stats.html
+++ b/stats.html
@@ -221,6 +221,21 @@
             <span class="material-symbols-outlined">info</span>
             Wybierz ligę i kliknij <strong>Wczytaj ligę</strong>. Pobrane pliki zostają w pamięci przeglądarki.
           </div>
+
+          <div class="st-import">
+            <div class="st-import-head">
+              <span class="material-symbols-outlined">upload_file</span>
+              <strong>Awaryjnie: wczytaj pliki CSV z dysku</strong>
+              <span class="sub">gdy ani lokalne, ani publiczne proxy nie działa</span>
+            </div>
+            <div class="st-import-links" id="import-links"></div>
+            <div class="st-import-actions">
+              <input type="file" id="import-input" accept=".csv,text/csv" multiple hidden>
+              <button class="st-btn primary" id="import-btn"><span class="material-symbols-outlined">upload</span>Wskaż pobrane pliki</button>
+              <button class="st-btn" id="import-clear"><span class="material-symbols-outlined">delete</span>Wyczyść import</button>
+            </div>
+            <div class="st-load-status" id="import-status"></div>
+          </div>
         </section>
 
         <!-- KROK 2: TERMINARZ -->

--- a/stats.html
+++ b/stats.html
@@ -83,6 +83,14 @@
           Sekcja <em>Źródło danych</em> niżej jest potrzebna tylko do <em>własnego zestawienia</em>, czyli pary drużyn spoza terminarza.</span>
         </div>
 
+        <div class="st-flow-hint warn" id="proxy-warning" style="display:none">
+          <span class="material-symbols-outlined">running_with_errors</span>
+          <span><strong>Brak lokalnego proxy.</strong> Dane historyczne idą przez publiczne pośredniki CORS,
+          które bywają wyłączane bez ostrzeżenia — wtedy analiza kończy się błędem „Failed to fetch”.
+          Uruchom <code>node server.js</code> w katalogu aplikacji; wykryję je automatycznie także wtedy,
+          gdy stronę otwierasz z innego miejsca.</span>
+        </div>
+
         <!-- KLUCZ API -->
         <div class="st-section">
           <span class="ico"><span class="material-symbols-outlined">key</span></span>

--- a/stats.html
+++ b/stats.html
@@ -46,10 +46,10 @@
         </div>
       </div>
       <div class="site-header__right tc-hdr-actions" aria-label="Akcje strony">
-        <span class="st-quota" title="Publiczne API TheSportsDB"><strong>TheSportsDB</strong> · Free</span>
+        <span class="st-quota" id="proxy-badge" title="Źródło danych"></span>
         <a class="tc-hdr-btn" href="betting.html" title="Wróć do zakładów"><span class="material-symbols-outlined">arrow_back</span>Zakłady</a>
         <div class="tc-hdr-sep"></div>
-        <button id="clear-cache-btn" class="tc-hdr-btn" title="Wyczyść zapisane odpowiedzi API"><span class="material-symbols-outlined">cached</span>Cache</button>
+        <button id="clear-cache-btn" class="tc-hdr-btn" title="Wyczyść pobrane pliki CSV"><span class="material-symbols-outlined">cached</span>Cache</button>
       </div>
     </header>
 
@@ -60,11 +60,11 @@
         <div class="st-steps" id="steps">
           <div class="st-step active" data-step="1">
             <span class="num">1</span>
-            <div><div class="k">Pobierz mecze</div><div class="v" id="step1-sub">Wybierz dzień i kliknij</div></div>
+            <div><div class="k">Wczytaj ligę</div><div class="v" id="step1-sub">Wybierz rozgrywki i zakres sezonów</div></div>
           </div>
           <div class="st-step" data-step="2">
             <span class="num">2</span>
-            <div><div class="k">Wybierz ligę</div><div class="v" id="step2-sub">—</div></div>
+            <div><div class="k">Terminarz</div><div class="v" id="step2-sub">Mecze na dziś, jutro i tydzień</div></div>
           </div>
           <div class="st-step" data-step="3">
             <span class="num">3</span>
@@ -72,69 +72,94 @@
           </div>
           <div class="st-step" data-step="4">
             <span class="num">4</span>
-            <div><div class="k">Macierz pokrycia</div><div class="v" id="step4-sub">—</div></div>
+            <div><div class="k">Macierze pokrycia</div><div class="v" id="step4-sub">—</div></div>
           </div>
         </div>
 
-        <!-- KROK 1 -->
+        <!-- KROK 1: ŹRÓDŁO -->
         <div class="st-section">
-          <span class="ico"><span class="material-symbols-outlined">calendar_month</span></span>
-          <h2>Mecze</h2>
-          <span class="desc">Terminarz piłkarski z publicznego API TheSportsDB</span>
+          <span class="ico"><span class="material-symbols-outlined">database</span></span>
+          <h2>Źródło danych</h2>
+          <span class="desc">football-data.co.uk — komplet statystyk meczowych, bez klucza API</span>
           <span class="line"></span>
         </div>
 
         <section class="tc-card">
-          <div class="st-toolbar">
-            <div class="grp">
-              <div class="st-seg" id="day-seg">
-                <button data-day="-1">Wczoraj</button>
-                <button data-day="0" class="active">Dziś</button>
-                <button data-day="1">Jutro</button>
+          <div class="st-controls">
+            <label class="st-field wide">
+              <span>Liga</span>
+              <select id="league-select"></select>
+            </label>
+            <label class="st-field">
+              <span>Zakres historii</span>
+              <select id="season-select">
+                <option value="1">Bieżący sezon</option>
+                <option value="2">2 sezony</option>
+                <option value="3">3 sezony</option>
+                <option value="4">4 sezony</option>
+              </select>
+            </label>
+            <label class="st-field">
+              <span>Okno główne</span>
+              <div class="st-seg" id="focus-seg">
+                <button data-window="5">5</button>
+                <button data-window="10">10</button>
+                <button data-window="20">20</button>
               </div>
-              <span class="desc" id="day-label" style="font-size:12px;color:var(--tc-muted)"></span>
-            </div>
-            <div class="grp">
-              <button class="st-btn primary" id="fetch-fixtures"><span class="material-symbols-outlined">download</span>Pobierz mecze</button>
-            </div>
+            </label>
+            <label class="st-check" title="Gospodarz liczony tylko z meczów u siebie, gość tylko z wyjazdowych">
+              <input type="checkbox" id="venue-toggle">
+              <span>Filtr dom–wyjazd</span>
+            </label>
+            <button class="st-btn primary" id="load-league"><span class="material-symbols-outlined">download</span>Wczytaj ligę</button>
           </div>
-          <div id="fixtures-status"></div>
+          <div class="st-load-status" id="load-status">
+            <span class="material-symbols-outlined">info</span>
+            Wybierz ligę i kliknij <strong>Wczytaj ligę</strong>. Pobrane pliki zostają w pamięci przeglądarki.
+          </div>
         </section>
 
-        <!-- KROK 2: LIGI -->
-        <div id="leagues-block" style="display:none">
+        <!-- KROK 2: TERMINARZ -->
+        <div id="fixtures-block" style="display:none">
           <div class="st-section">
-            <span class="ico"><span class="material-symbols-outlined">emoji_events</span></span>
-            <h2>Ligi</h2>
-            <span class="desc" id="leagues-desc">—</span>
+            <span class="ico"><span class="material-symbols-outlined">calendar_month</span></span>
+            <h2>Terminarz</h2>
+            <span class="desc">Nadchodzące mecze wybranej ligi wraz z kursami</span>
             <span class="line"></span>
           </div>
           <section class="tc-card">
-            <div class="st-league-search">
-              <input type="search" id="league-search" placeholder="Filtruj ligi lub kraje…">
-            </div>
-            <div class="st-leagues" id="leagues"></div>
+            <div id="fixtures-body"></div>
           </section>
-        </div>
 
-        <!-- KROK 3: MECZE LIGI -->
-        <div id="matches-block" style="display:none">
-          <div class="st-section">
-            <span class="ico"><span class="material-symbols-outlined">stadium</span></span>
-            <h2>Mecze w lidze</h2>
-            <span class="desc" id="matches-desc">—</span>
-            <span class="line"></span>
+          <div id="custom-block">
+            <div class="st-section">
+              <span class="ico"><span class="material-symbols-outlined">tune</span></span>
+              <h2>Własne zestawienie</h2>
+              <span class="desc">Dowolna para drużyn — działa też poza terminarzem</span>
+              <span class="line"></span>
+            </div>
+            <section class="tc-card">
+              <div class="st-controls">
+                <label class="st-field wide">
+                  <span>Gospodarz</span>
+                  <select id="home-select"></select>
+                </label>
+                <button class="st-btn" id="swap-teams" title="Zamień strony"><span class="material-symbols-outlined">swap_horiz</span></button>
+                <label class="st-field wide">
+                  <span>Gość</span>
+                  <select id="away-select"></select>
+                </label>
+                <button class="st-btn primary" id="analyse-custom"><span class="material-symbols-outlined">insights</span>Analizuj</button>
+              </div>
+            </section>
           </div>
-          <section class="tc-card">
-            <div class="tc-tbl-wrap" id="matches"></div>
-          </section>
         </div>
 
         <!-- KROK 4: ANALIZA -->
         <div id="analysis-block" style="display:none">
           <div class="st-section">
             <span class="ico"><span class="material-symbols-outlined">grid_on</span></span>
-            <h2>Macierz pokrycia</h2>
+            <h2>Macierze pokrycia</h2>
             <span class="desc" id="analysis-desc">—</span>
             <span class="line"></span>
           </div>

--- a/stats.html
+++ b/stats.html
@@ -46,7 +46,8 @@
         </div>
       </div>
       <div class="site-header__right tc-hdr-actions" aria-label="Akcje strony">
-        <span class="st-quota" id="proxy-badge" title="Źródło danych"></span>
+        <span class="st-quota" id="af-quota" title="Limit zapytań API-Football"></span>
+        <span class="st-quota" id="proxy-badge" title="Źródło danych historycznych"></span>
         <a class="tc-hdr-btn" href="betting.html" title="Wróć do zakładów"><span class="material-symbols-outlined">arrow_back</span>Zakłady</a>
         <div class="tc-hdr-sep"></div>
         <button id="clear-cache-btn" class="tc-hdr-btn" title="Wyczyść pobrane pliki CSV"><span class="material-symbols-outlined">cached</span>Cache</button>
@@ -64,7 +65,7 @@
           </div>
           <div class="st-step" data-step="2">
             <span class="num">2</span>
-            <div><div class="k">Terminarz</div><div class="v" id="step2-sub">Mecze na dziś, jutro i tydzień</div></div>
+            <div><div class="k">Terminarz</div><div class="v" id="step2-sub">Mecze na dziś i jutro</div></div>
           </div>
           <div class="st-step" data-step="3">
             <span class="num">3</span>
@@ -75,6 +76,53 @@
             <div><div class="k">Macierze pokrycia</div><div class="v" id="step4-sub">—</div></div>
           </div>
         </div>
+
+        <!-- KLUCZ API -->
+        <div class="st-section">
+          <span class="ico"><span class="material-symbols-outlined">key</span></span>
+          <h2>Klucz API-Football</h2>
+          <span class="desc">Terminarz live z 39 lig — klucz zostaje wyłącznie w tej przeglądarce</span>
+          <span class="line"></span>
+        </div>
+
+        <section class="tc-card">
+          <div class="st-controls">
+            <label class="st-field wide">
+              <span>Klucz z dashboard.api-football.com</span>
+              <input type="password" id="api-key" autocomplete="off" spellcheck="false" placeholder="wklej klucz…">
+            </label>
+            <button class="st-btn" id="save-key"><span class="material-symbols-outlined">save</span>Zapisz</button>
+            <button class="st-btn primary" id="test-key"><span class="material-symbols-outlined">wifi_tethering</span>Sprawdź połączenie</button>
+          </div>
+          <div class="st-load-status" id="key-state"></div>
+        </section>
+
+        <!-- TERMINARZ LIVE -->
+        <div class="st-section">
+          <span class="ico"><span class="material-symbols-outlined">bolt</span></span>
+          <h2>Terminarz live</h2>
+          <span class="desc" id="af-day-label">—</span>
+          <span class="line"></span>
+        </div>
+
+        <section class="tc-card" id="af-block">
+          <div class="st-controls">
+            <label class="st-field">
+              <span>Dzień</span>
+              <div class="st-seg" id="af-day-seg">
+                <button data-day="0" class="active">Dziś</button>
+                <button data-day="1">Jutro</button>
+              </div>
+            </label>
+            <label class="st-field wide">
+              <span>Filtruj ligę lub drużynę</span>
+              <input type="search" id="af-filter" placeholder="np. Premier League, Ekstraklasa, Arsenal…">
+            </label>
+            <button class="st-btn primary" id="af-load"><span class="material-symbols-outlined">download</span>Pobierz terminarz</button>
+          </div>
+          <div class="st-load-status"><span class="material-symbols-outlined">insights</span><span id="af-summary">Pobranie terminarza kosztuje 1 zapytanie z dziennego limitu.</span></div>
+          <div id="af-body"></div>
+        </section>
 
         <!-- KROK 1: ŹRÓDŁO -->
         <div class="st-section">

--- a/stats.html
+++ b/stats.html
@@ -124,6 +124,40 @@
           <div id="af-body"></div>
         </section>
 
+        <!-- SKANER DNIA -->
+        <div class="st-section">
+          <span class="ico"><span class="material-symbols-outlined">radar</span></span>
+          <h2>Skaner dnia</h2>
+          <span class="desc">Ranking najlepszych pokryć ze wszystkich meczów naraz</span>
+          <span class="line"></span>
+        </div>
+
+        <section class="tc-card" id="scan-block">
+          <div class="st-controls">
+            <label class="st-field">
+              <span>Minimalne pokrycie</span>
+              <select id="scan-min">
+                <option value="0.5">od 50%</option>
+                <option value="0.6">od 60%</option>
+                <option value="0.7">od 70%</option>
+                <option value="0.8">od 80%</option>
+                <option value="0.9">od 90%</option>
+              </select>
+            </label>
+            <label class="st-field wide">
+              <span>Grupa rynków</span>
+              <select id="scan-group"><option value="all">Wszystkie rynki</option></select>
+            </label>
+            <label class="st-check" title="Pomija mecze już rozegrane">
+              <input type="checkbox" id="scan-upcoming">
+              <span>Tylko nierozpoczęte</span>
+            </label>
+            <button class="st-btn primary" id="scan-run"><span class="material-symbols-outlined">radar</span>Skanuj</button>
+          </div>
+          <div class="st-load-status"><span class="material-symbols-outlined">insights</span><span id="scan-summary">—</span></div>
+          <div id="scan-body"></div>
+        </section>
+
         <!-- KROK 1: ŹRÓDŁO -->
         <div class="st-section">
           <span class="ico"><span class="material-symbols-outlined">database</span></span>

--- a/stats.html
+++ b/stats.html
@@ -61,20 +61,26 @@
         <div class="st-steps" id="steps">
           <div class="st-step active" data-step="1">
             <span class="num">1</span>
-            <div><div class="k">Wczytaj ligę</div><div class="v" id="step1-sub">Wybierz rozgrywki i zakres sezonów</div></div>
+            <div><div class="k">Klucz API</div><div class="v" id="step1-sub">Jednorazowo, zostaje w przeglądarce</div></div>
           </div>
           <div class="st-step" data-step="2">
             <span class="num">2</span>
-            <div><div class="k">Terminarz</div><div class="v" id="step2-sub">Mecze na dziś i jutro</div></div>
+            <div><div class="k">Pobierz terminarz</div><div class="v" id="step2-sub">Dziś albo jutro · 1 zapytanie</div></div>
           </div>
           <div class="st-step" data-step="3">
             <span class="num">3</span>
-            <div><div class="k">Wybierz mecz</div><div class="v" id="step3-sub">—</div></div>
+            <div><div class="k">Skanuj lub wybierz mecz</div><div class="v" id="step3-sub">—</div></div>
           </div>
           <div class="st-step" data-step="4">
             <span class="num">4</span>
             <div><div class="k">Macierze pokrycia</div><div class="v" id="step4-sub">—</div></div>
           </div>
+        </div>
+
+        <div class="st-flow-hint">
+          <span class="material-symbols-outlined">tips_and_updates</span>
+          <span>Historia z CSV dociąga się <strong>sama</strong> przy pierwszej analizie danej ligi — nie musisz nic wczytywać wcześniej.
+          Sekcja <em>Źródło danych</em> niżej jest potrzebna tylko do <em>własnego zestawienia</em>, czyli pary drużyn spoza terminarza.</span>
         </div>
 
         <!-- KLUCZ API -->

--- a/stats.js
+++ b/stats.js
@@ -1,263 +1,1285 @@
-/* Statystyki piłkarskie — TheSportsDB v1, publiczny klucz Free „123”.
-   API jest wywoływane wyłącznie po akcji użytkownika, a odpowiedzi są cache'owane. */
-const API_BASE = 'https://www.thesportsdb.com/api/v1/json/123';
-const CACHE_STORE = 'lifeos_thesportsdb_cache_v1';
-const HISTORY_WINDOWS = [5, 10, 20];
-const TTL = { fixtures: 30 * 60 * 1000, history: 6 * 60 * 60 * 1000 };
+/* ============================================================
+   STATYSTYKI — silnik pokrycia rynków (football-data.co.uk)
+
+   Dlaczego nie TheSportsDB: darmowy klucz "123" obcina każdą
+   odpowiedź do 3 rekordów (terminarz) i 5 pozycji statystyk
+   (same strzały). Rożnych, kartek i fauli tam po prostu nie ma.
+
+   football-data.co.uk daje w jednym pliku CSV cały sezon ligi
+   z kompletem: gole, gole do przerwy, strzały, strzały celne,
+   faule, rożne, żółte i czerwone kartki oraz kursy zamknięcia.
+   Bez klucza, bez limitów zapytań.
+
+   Serwis nie wysyła nagłówka CORS, więc pliki idą przez proxy:
+   najpierw lokalne (node server.js), a gdy go nie ma — publiczne
+   z automatycznym przełączaniem.
+   ============================================================ */
+
+/* ---------- KATALOG LIG ---------- */
+
+/* Pliki mmz4281 — pełny zestaw statystyk meczowych. */
+const MAIN_LEAGUES = [
+  { id: 'E0', country: 'Anglia', name: 'Premier League' },
+  { id: 'E1', country: 'Anglia', name: 'Championship' },
+  { id: 'E2', country: 'Anglia', name: 'League One' },
+  { id: 'E3', country: 'Anglia', name: 'League Two' },
+  { id: 'EC', country: 'Anglia', name: 'National League' },
+  { id: 'SC0', country: 'Szkocja', name: 'Premiership' },
+  { id: 'SC1', country: 'Szkocja', name: 'Championship' },
+  { id: 'SC2', country: 'Szkocja', name: 'League One' },
+  { id: 'SC3', country: 'Szkocja', name: 'League Two' },
+  { id: 'D1', country: 'Niemcy', name: 'Bundesliga' },
+  { id: 'D2', country: 'Niemcy', name: '2. Bundesliga' },
+  { id: 'I1', country: 'Włochy', name: 'Serie A' },
+  { id: 'I2', country: 'Włochy', name: 'Serie B' },
+  { id: 'SP1', country: 'Hiszpania', name: 'La Liga' },
+  { id: 'SP2', country: 'Hiszpania', name: 'La Liga 2' },
+  { id: 'F1', country: 'Francja', name: 'Ligue 1' },
+  { id: 'F2', country: 'Francja', name: 'Ligue 2' },
+  { id: 'N1', country: 'Holandia', name: 'Eredivisie' },
+  { id: 'B1', country: 'Belgia', name: 'Jupiler Pro League' },
+  { id: 'P1', country: 'Portugalia', name: 'Liga Portugal' },
+  { id: 'T1', country: 'Turcja', name: 'Süper Lig' },
+  { id: 'G1', country: 'Grecja', name: 'Super League' }
+];
+
+/* Pliki new/ — jeden plik = pełna historia ligi, ale tylko gole i kursy. */
+const EXTRA_LEAGUES = [
+  { id: 'POL', country: 'Polska', name: 'Ekstraklasa' },
+  { id: 'ARG', country: 'Argentyna', name: 'Liga Profesional' },
+  { id: 'AUT', country: 'Austria', name: 'Bundesliga' },
+  { id: 'BRA', country: 'Brazylia', name: 'Serie A' },
+  { id: 'CHN', country: 'Chiny', name: 'Super League' },
+  { id: 'DNK', country: 'Dania', name: 'Superliga' },
+  { id: 'FIN', country: 'Finlandia', name: 'Veikkausliiga' },
+  { id: 'IRL', country: 'Irlandia', name: 'Premier Division' },
+  { id: 'JPN', country: 'Japonia', name: 'J1 League' },
+  { id: 'MEX', country: 'Meksyk', name: 'Liga MX' },
+  { id: 'NOR', country: 'Norwegia', name: 'Eliteserien' },
+  { id: 'ROU', country: 'Rumunia', name: 'Liga I' },
+  { id: 'RUS', country: 'Rosja', name: 'Premier Liga' },
+  { id: 'SWE', country: 'Szwecja', name: 'Allsvenskan' },
+  { id: 'SWZ', country: 'Szwajcaria', name: 'Super League' },
+  { id: 'USA', country: 'USA', name: 'MLS' }
+];
+
+/* Drużyna po awansie ma krótką historię w swojej lidze — dobieramy
+   mecze z ligi sąsiedniej, żeby okno 20 spotkań miało pokrycie. */
+const RELATED_DIVISIONS = {
+  E0: ['E1'], E1: ['E0', 'E2'], E2: ['E1', 'E3'], E3: ['E2', 'EC'], EC: ['E3'],
+  SC0: ['SC1'], SC1: ['SC0', 'SC2'], SC2: ['SC1', 'SC3'], SC3: ['SC2'],
+  D1: ['D2'], D2: ['D1'], I1: ['I2'], I2: ['I1'],
+  SP1: ['SP2'], SP2: ['SP1'], F1: ['F2'], F2: ['F1']
+};
+
+const LEAGUE_BY_ID = new Map([...MAIN_LEAGUES.map(l => [l.id, { ...l, kind: 'main' }]),
+  ...EXTRA_LEAGUES.map(l => [l.id, { ...l, kind: 'extra' }])]);
+
+/* ---------- PROXY ---------- */
+
+const UPSTREAM = 'https://www.football-data.co.uk';
+const PROXIES = [
+  { id: 'local', label: 'lokalne proxy (server.js)', build: (_url, target) => `api/fd/csv?path=${encodeURIComponent(target)}` },
+  { id: 'allorigins', label: 'allorigins.win', build: url => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}` },
+  { id: 'codetabs', label: 'codetabs.com', build: url => `https://api.codetabs.com/v1/proxy?quest=${encodeURIComponent(url)}` },
+  { id: 'jina', label: 'r.jina.ai', build: url => `https://r.jina.ai/${url}` }
+];
+
+/* ---------- STAŁE ---------- */
+
+const CACHE_KEY = 'lifeos_fd_cache_v1';
+const PREFS_KEY = 'lifeos_stats_prefs_v1';
+const CACHE_BUDGET = 3_500_000;
+const WINDOWS = [5, 10, 20];
+const TTL = { fixtures: 30 * 60 * 1000, season: 12 * 60 * 60 * 1000 };
+const CARD_POINTS = { yellow: 10, red: 25 };
+
+/* Kolejność pól w kompaktowym zapisie cache — nie zmieniać bez bumpu CACHE_KEY. */
+const FIELDS = ['ts', 'home', 'away', 'fthg', 'ftag', 'hthg', 'htag', 'hs', 'as', 'hst', 'ast',
+  'hf', 'af', 'hc', 'ac', 'hy', 'ay', 'hr', 'ar', 'oh', 'od', 'oa', 'oOver', 'oUnder'];
+
+/* ---------- STAN ---------- */
+
+const state = {
+  leagueId: 'E0',
+  seasons: 3,
+  venueSplit: false,
+  focusWindow: 10,
+  matches: [],
+  teams: [],
+  fixtures: [],
+  analysis: null,
+  proxy: null,
+  busy: false,
+  loadedLabel: ''
+};
 
 let cache = {};
-let dayOffset = 0;
-let fixtures = [];
-let leagues = [];
-let selectedLeagueId = null;
-let selectedFixture = null;
-let analysis = null;
-let leagueFilter = '';
-let historyWindow = 5;
-let busy = false;
+
+/* ---------- NARZĘDZIA ---------- */
 
 const el = id => document.getElementById(id);
-const esc = value => String(value == null ? '' : value).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+const esc = value => String(value == null ? '' : value).replace(/[&<>"']/g, c =>
+  ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
-const num = (value, fallback = null) => { const parsed = Number(value); return Number.isFinite(parsed) ? parsed : fallback; };
+const num = value => {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+const fmtPct = (value, dp = 0) => Number.isFinite(value) ? `${(value * 100).toFixed(dp)}%` : '—';
+const fmtNum = (value, dp = 2) => Number.isFinite(value) ? value.toFixed(dp) : '—';
+const fmtLine = value => String(value).replace('.', ',');
+const fairOdds = value => Number.isFinite(value) && value > 0.001 ? (1 / value).toFixed(2) : '—';
+const fmtDate = ts => new Date(ts).toLocaleDateString('pl-PL', { day: '2-digit', month: '2-digit', year: '2-digit' });
 
-function todayISO(offset = 0) {
-  const date = new Date();
-  date.setUTCDate(date.getUTCDate() + offset);
-  return date.toISOString().slice(0, 10);
-}
-function fmtPct(value, dp = 0) { return Number.isFinite(value) ? `${(value * 100).toFixed(dp)}%` : '—'; }
-function fairOdds(value) { return Number.isFinite(value) && value > 0 ? (1 / value).toFixed(2) : '—'; }
 function toast(message, kind = '') {
   const node = document.createElement('div');
   node.className = `tc-toast ${kind}`;
   node.textContent = message;
   el('toasts').appendChild(node);
-  setTimeout(() => node.remove(), 3400);
-}
-function loadCache() {
-  try { cache = JSON.parse(localStorage.getItem(CACHE_STORE) || '{}') || {}; } catch { cache = {}; }
-}
-function saveCache() {
-  try { localStorage.setItem(CACHE_STORE, JSON.stringify(cache)); } catch { /* cache jest opcjonalny */ }
-}
-async function apiGet(path, ttl) {
-  const hit = cache[path];
-  if (hit && Date.now() - hit.ts < ttl) return { data: hit.data, cached: true };
-  let response;
-  try { response = await fetch(`${API_BASE}/${path}`); }
-  catch { throw new Error('Brak połączenia z TheSportsDB. Sprawdź internet.'); }
-  if (!response.ok) throw new Error(`TheSportsDB zwróciło błąd HTTP ${response.status}.`);
-  const data = await response.json();
-  cache[path] = { ts: Date.now(), data };
-  saveCache();
-  return { data, cached: false };
+  setTimeout(() => node.remove(), 3800);
 }
 
-function eventDate(event) {
-  if (event.strTimestamp) return new Date(event.strTimestamp);
-  const time = (event.strTime || '00:00:00').slice(0, 8);
-  return new Date(`${event.dateEvent}T${time}Z`);
+function mean(values) {
+  const valid = values.filter(Number.isFinite);
+  return valid.length ? valid.reduce((sum, value) => sum + value, 0) / valid.length : null;
 }
-function eventStatus(event) {
-  const status = String(event.strStatus || '').toLowerCase();
-  const hasScore = event.intHomeScore !== null && event.intHomeScore !== '' && event.intAwayScore !== null && event.intAwayScore !== '';
-  if (hasScore || status.includes('finished')) return { short: 'FT', elapsed: null };
-  if (status.includes('postpon')) return { short: 'PST', elapsed: null };
-  if (status.includes('live') || status.includes('progress')) return { short: 'LIVE', elapsed: null };
-  return { short: 'NS', elapsed: null };
+
+/* Kody sezonów football-data: 2526 = 2025/26. Nowy sezon liczymy od lipca. */
+function seasonCodes(count) {
+  const now = new Date();
+  const first = now.getUTCFullYear() - (now.getUTCMonth() < 6 ? 1 : 0);
+  return Array.from({ length: count }, (_, i) => {
+    const start = first - i;
+    return `${String(start).slice(2)}${String(start + 1).slice(2)}`;
+  });
 }
-function adaptEvent(event) {
-  const date = eventDate(event);
+
+function parseDate(value, time) {
+  const match = String(value || '').trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/);
+  if (!match) return null;
+  const [, d, m, y] = match;
+  const year = y.length === 2 ? 2000 + Number(y) : Number(y);
+  const clock = String(time || '').match(/^(\d{1,2}):(\d{2})/);
+  return Date.UTC(year, Number(m) - 1, Number(d), clock ? Number(clock[1]) : 12, clock ? Number(clock[2]) : 0);
+}
+
+/* Parser CSV z obsługą cudzysłowów — nazwy sędziów bywają cytowane. */
+function parseCsv(text) {
+  const clean = text.replace(/^﻿/, '');
+  const rows = [];
+  let row = [], field = '', quoted = false;
+  for (let i = 0; i < clean.length; i++) {
+    const char = clean[i];
+    if (quoted) {
+      if (char !== '"') field += char;
+      else if (clean[i + 1] === '"') { field += '"'; i++; }
+      else quoted = false;
+    } else if (char === '"') quoted = true;
+    else if (char === ',') { row.push(field); field = ''; }
+    else if (char === '\n') { row.push(field); rows.push(row); row = []; field = ''; }
+    else if (char !== '\r') field += char;
+  }
+  if (field !== '' || row.length) { row.push(field); rows.push(row); }
+  if (!rows.length) return [];
+  const header = rows.shift().map(name => name.trim());
+  return rows
+    .filter(cells => cells.some(cell => cell.trim() !== ''))
+    .map(cells => Object.fromEntries(header.map((name, i) => [name, (cells[i] ?? '').trim()])));
+}
+
+/* ---------- CACHE PRZEGLĄDARKI ---------- */
+
+function loadCache() {
+  try { cache = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}') || {}; } catch { cache = {}; }
+}
+
+function saveCache() {
+  try {
+    let payload = JSON.stringify(cache);
+    while (payload.length > CACHE_BUDGET) {
+      const oldest = Object.entries(cache).sort((a, b) => a[1].ts - b[1].ts)[0];
+      if (!oldest) break;
+      delete cache[oldest[0]];
+      payload = JSON.stringify(cache);
+    }
+    localStorage.setItem(CACHE_KEY, payload);
+  } catch { /* brak miejsca w localStorage nie może psuć analizy */ }
+}
+
+const packMatch = match => FIELDS.map(field => match[field] ?? null);
+const unpackMatch = tuple => Object.fromEntries(FIELDS.map((field, i) => [field, tuple[i]]));
+
+function loadPrefs() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(PREFS_KEY) || '{}');
+    Object.assign(state, {
+      leagueId: LEAGUE_BY_ID.has(saved.leagueId) ? saved.leagueId : state.leagueId,
+      seasons: [1, 2, 3, 4].includes(saved.seasons) ? saved.seasons : state.seasons,
+      venueSplit: Boolean(saved.venueSplit),
+      focusWindow: WINDOWS.includes(saved.focusWindow) ? saved.focusWindow : state.focusWindow,
+      proxy: saved.proxy || null
+    });
+  } catch { /* domyślne ustawienia wystarczą */ }
+}
+
+function savePrefs() {
+  const { leagueId, seasons, venueSplit, focusWindow, proxy } = state;
+  try { localStorage.setItem(PREFS_KEY, JSON.stringify({ leagueId, seasons, venueSplit, focusWindow, proxy })); } catch { /* opcjonalne */ }
+}
+
+/* ---------- POBIERANIE ---------- */
+
+async function fetchWithTimeout(url, ms = 30000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  try { return await fetch(url, { signal: controller.signal }); }
+  finally { clearTimeout(timer); }
+}
+
+/* Proxy potrafi dokleić preambułę (r.jina.ai) — tniemy do nagłówka CSV. */
+function unwrapCsv(text) {
+  const start = text.search(/^(?:﻿)?(Div|Country),/m);
+  return start > 0 ? text.slice(start) : text;
+}
+
+function looksLikeCsv(text) {
+  return /^(?:﻿)?(Div|Country),/m.test(text);
+}
+
+async function fetchCsv(target) {
+  const url = `${UPSTREAM}/${target}`;
+  const ordered = state.proxy
+    ? [...PROXIES.filter(p => p.id === state.proxy), ...PROXIES.filter(p => p.id !== state.proxy)]
+    : PROXIES;
+  const problems = [];
+  for (const proxy of ordered) {
+    try {
+      const response = await fetchWithTimeout(proxy.build(url, target));
+      if (!response.ok) {
+        /* 404 to brak sezonu u źródła, a nie wina proxy — nie próbujemy dalej. */
+        if (response.status === 404) return null;
+        problems.push(`${proxy.label}: HTTP ${response.status}`);
+        continue;
+      }
+      const text = unwrapCsv(await response.text());
+      if (!looksLikeCsv(text)) { problems.push(`${proxy.label}: odpowiedź nie jest plikiem CSV`); continue; }
+      if (state.proxy !== proxy.id) { state.proxy = proxy.id; savePrefs(); }
+      renderProxyBadge();
+      return text;
+    } catch (error) {
+      problems.push(`${proxy.label}: ${error.name === 'AbortError' ? 'przekroczony czas' : error.message}`);
+    }
+  }
+  throw new Error(`Nie udało się pobrać ${target}. Próby — ${problems.join('; ')}`);
+}
+
+async function getMatches(target, ttl) {
+  const hit = cache[target];
+  if (hit && Date.now() - hit.ts < ttl) return hit.rows.map(unpackMatch);
+  const text = await fetchCsv(target);
+  if (text === null) { cache[target] = { ts: Date.now(), rows: [] }; saveCache(); return []; }
+  const rows = parseCsv(text).map(normalizeRow).filter(Boolean);
+  cache[target] = { ts: Date.now(), rows: rows.map(packMatch) };
+  saveCache();
+  return rows;
+}
+
+/* ---------- NORMALIZACJA ---------- */
+
+const firstNum = (row, keys) => {
+  for (const key of keys) { const value = num(row[key]); if (value !== null) return value; }
+  return null;
+};
+
+/* Kursy: najpierw zamknięcia (kolumny z C), potem otwarcia. */
+const ODDS_HOME = ['PSCH', 'AvgCH', 'B365CH', 'MaxCH', 'PSH', 'AvgH', 'B365H', 'MaxH'];
+const ODDS_DRAW = ['PSCD', 'AvgCD', 'B365CD', 'MaxCD', 'PSD', 'AvgD', 'B365D', 'MaxD'];
+const ODDS_AWAY = ['PSCA', 'AvgCA', 'B365CA', 'MaxCA', 'PSA', 'AvgA', 'B365A', 'MaxA'];
+const ODDS_OVER = ['PC>2.5', 'AvgC>2.5', 'B365C>2.5', 'P>2.5', 'Avg>2.5', 'B365>2.5'];
+const ODDS_UNDER = ['PC<2.5', 'AvgC<2.5', 'B365C<2.5', 'P<2.5', 'Avg<2.5', 'B365<2.5'];
+
+function normalizeRow(row) {
+  const home = (row.HomeTeam || row.Home || '').trim();
+  const away = (row.AwayTeam || row.Away || '').trim();
+  const ts = parseDate(row.Date, row.Time);
+  const fthg = num(row.FTHG ?? row.HG);
+  const ftag = num(row.FTAG ?? row.AG);
+  if (!home || !away || ts === null || fthg === null || ftag === null) return null;
   return {
-    fixture: { id: String(event.idEvent), date: date.toISOString(), timestamp: date.getTime() / 1000, status: eventStatus(event) },
-    league: { id: String(event.idLeague || event.strLeague || 'other'), name: event.strLeague || 'Inne rozgrywki', country: event.strCountry || '', logo: event.strLeagueBadge || '' },
-    teams: {
-      home: { id: String(event.idHomeTeam), name: event.strHomeTeam || '—', logo: event.strHomeTeamBadge || '' },
-      away: { id: String(event.idAwayTeam), name: event.strAwayTeam || '—', logo: event.strAwayTeamBadge || '' }
-    },
-    goals: { home: num(event.intHomeScore), away: num(event.intAwayScore) },
-    raw: event
+    ts, home, away, fthg, ftag,
+    hthg: num(row.HTHG), htag: num(row.HTAG),
+    hs: num(row.HS), as: num(row.AS), hst: num(row.HST), ast: num(row.AST),
+    hf: num(row.HF), af: num(row.AF), hc: num(row.HC), ac: num(row.AC),
+    hy: num(row.HY), ay: num(row.AY), hr: num(row.HR), ar: num(row.AR),
+    oh: firstNum(row, ODDS_HOME), od: firstNum(row, ODDS_DRAW), oa: firstNum(row, ODDS_AWAY),
+    oOver: firstNum(row, ODDS_OVER), oUnder: firstNum(row, ODDS_UNDER)
   };
 }
-function completedSample(events, teamId) {
-  return [...new Map((events || []).map(event => [event.idEvent, event])).values()]
-    .map(adaptEvent)
-    .filter(match => match.fixture.status.short === 'FT' && (match.teams.home.id === String(teamId) || match.teams.away.id === String(teamId)))
-    .map(match => {
-      const home = match.teams.home.id === String(teamId);
-      const scored = home ? match.goals.home : match.goals.away;
-      const conceded = home ? match.goals.away : match.goals.home;
-      return { id: match.fixture.id, date: match.fixture.date.slice(0, 10), opponent: home ? match.teams.away.name : match.teams.home.name, scored, conceded, total: scored + conceded, btts: scored > 0 && conceded > 0, won: scored > conceded, draw: scored === conceded };
-    }).sort((a, b) => b.date.localeCompare(a.date));
-}
-function cachedTeamEvents(teamId) {
-  const events = [];
-  for (const [path, entry] of Object.entries(cache)) {
-    const payload = entry?.data;
-    if (!payload) continue;
-    const list = path.startsWith('eventsday.php') ? payload.events : path.startsWith('eventslast.php') ? payload.results : null;
-    if (!Array.isArray(list)) continue;
-    events.push(...list.filter(event => String(event.idHomeTeam) === String(teamId) || String(event.idAwayTeam) === String(teamId)));
-  }
-  return events;
-}
-async function fetchTeamHistory(teamId, wanted) {
-  const { data } = await apiGet(`eventslast.php?id=${encodeURIComponent(teamId)}`, TTL.history);
-  const apiEvents = data.results || data.events || [];
-  return completedSample([...apiEvents, ...cachedTeamEvents(teamId)], teamId).slice(0, wanted);
+
+function normalizeFixture(row) {
+  const home = (row.HomeTeam || row.Home || '').trim();
+  const away = (row.AwayTeam || row.Away || '').trim();
+  const ts = parseDate(row.Date, row.Time);
+  if (!home || !away || ts === null) return null;
+  return {
+    div: (row.Div || '').trim(), ts, home, away, time: (row.Time || '').trim(),
+    oh: firstNum(row, ODDS_HOME), od: firstNum(row, ODDS_DRAW), oa: firstNum(row, ODDS_AWAY),
+    oOver: firstNum(row, ODDS_OVER), oUnder: firstNum(row, ODDS_UNDER)
+  };
 }
 
-function mean(values) { const valid = values.filter(Number.isFinite); return valid.length ? valid.reduce((sum, value) => sum + value, 0) / valid.length : null; }
-function empirical(values, predicate) {
-  const valid = values.filter(value => value !== null && value !== undefined);
-  if (!valid.length) return null;
-  const hits = valid.filter(predicate).length;
-  return { p: hits / valid.length, hits, n: valid.length };
+/* ---------- PERSPEKTYWA DRUŻYNY ---------- */
+
+/* Jeden mecz widziany oczami jednej drużyny — wszystkie metryki
+   sprowadzone do trójki: zdobyte / stracone / suma w meczu. */
+function perspective(match, team) {
+  const home = match.home === team;
+  const side = (h, a) => {
+    if (h === null || a === null) return { f: null, a: null, t: null };
+    return { f: home ? h : a, a: home ? a : h, t: h + a };
+  };
+  const goals = side(match.fthg, match.ftag);
+  const half = side(match.hthg, match.htag);
+  const shots = side(match.hs, match.as);
+  const target = side(match.hst, match.ast);
+  const corners = side(match.hc, match.ac);
+  const fouls = side(match.hf, match.af);
+  const yellow = side(match.hy, match.ay);
+  const red = side(match.hr, match.ar);
+  const points = (y, r) => (y === null && r === null) ? null : (y ?? 0) * CARD_POINTS.yellow + (r ?? 0) * CARD_POINTS.red;
+  const cardsFor = points(yellow.f, red.f);
+  const cardsAgainst = points(yellow.a, red.a);
+
+  return {
+    ts: match.ts,
+    venue: home ? 'H' : 'A',
+    opponent: home ? match.away : match.home,
+    score: `${match.fthg}:${match.ftag}`,
+    gf: goals.f, ga: goals.a, gt: goals.t,
+    htf: half.f, hta: half.a, htt: half.t,
+    sf: shots.f, sa: shots.a, st: shots.t,
+    tf: target.f, ta: target.a, tt: target.t,
+    cf: corners.f, ca: corners.a, ct: corners.t,
+    ff: fouls.f, fa: fouls.a, ft: fouls.t,
+    yf: yellow.f, ya: yellow.a, yt: yellow.t,
+    rf: red.f, ra: red.a, rt: red.t,
+    pf: cardsFor, pa: cardsAgainst,
+    pt: cardsFor === null || cardsAgainst === null ? null : cardsFor + cardsAgainst,
+    won: goals.f > goals.a, drew: goals.f === goals.a, lost: goals.f < goals.a,
+    btts: goals.f > 0 && goals.a > 0,
+    clean: goals.a === 0, blank: goals.f === 0,
+    raw: match
+  };
 }
+
+/* ---------- REJESTR RYNKÓW ---------- */
+
+/* Każda grupa opisuje jedną rodzinę statystyk: klucze perspektywy
+   dla sumy w meczu / zdobytych / straconych + linie do sprawdzenia. */
+const GROUPS = [
+  {
+    id: 'gole', label: 'Gole', icon: 'sports_soccer', probe: 'gt',
+    rows: [
+      { key: 'gt', scope: 'match', label: 'Gole w meczu', lines: [0.5, 1.5, 2.5, 3.5, 4.5] },
+      { key: 'gf', scope: 'team', label: 'Gole strzelone', lines: [0.5, 1.5, 2.5] },
+      { key: 'ga', scope: 'team', label: 'Gole stracone', lines: [0.5, 1.5, 2.5] },
+      { key: 'htt', scope: 'match', label: 'Gole do przerwy', lines: [0.5, 1.5, 2.5] }
+    ]
+  },
+  {
+    id: 'rozne', label: 'Rzuty rożne', icon: 'flag', probe: 'ct',
+    rows: [
+      { key: 'ct', scope: 'match', label: 'Rożne w meczu', lines: [7.5, 8.5, 9.5, 10.5, 11.5, 12.5] },
+      { key: 'cf', scope: 'team', label: 'Rożne drużyny', lines: [2.5, 3.5, 4.5, 5.5, 6.5] },
+      { key: 'ca', scope: 'team', label: 'Rożne rywala', lines: [2.5, 3.5, 4.5, 5.5, 6.5] }
+    ]
+  },
+  {
+    id: 'kartki', label: 'Kartki', icon: 'style', probe: 'yt',
+    rows: [
+      { key: 'yt', scope: 'match', label: 'Żółte w meczu', lines: [1.5, 2.5, 3.5, 4.5, 5.5, 6.5] },
+      { key: 'yf', scope: 'team', label: 'Żółte drużyny', lines: [0.5, 1.5, 2.5, 3.5] },
+      { key: 'pt', scope: 'match', label: 'Punkty kartkowe', lines: [24.5, 34.5, 44.5, 54.5, 64.5] },
+      { key: 'rt', scope: 'match', label: 'Czerwone w meczu', lines: [0.5] }
+    ]
+  },
+  {
+    id: 'strzaly', label: 'Strzały', icon: 'sports_handball', probe: 'st',
+    rows: [
+      { key: 'st', scope: 'match', label: 'Strzały w meczu', lines: [18.5, 20.5, 22.5, 24.5, 26.5, 28.5] },
+      { key: 'sf', scope: 'team', label: 'Strzały drużyny', lines: [8.5, 10.5, 12.5, 14.5] },
+      { key: 'tt', scope: 'match', label: 'Celne w meczu', lines: [5.5, 6.5, 7.5, 8.5, 9.5, 10.5] },
+      { key: 'tf', scope: 'team', label: 'Celne drużyny', lines: [2.5, 3.5, 4.5, 5.5] }
+    ]
+  },
+  {
+    id: 'faule', label: 'Faule', icon: 'sports', probe: 'ft',
+    rows: [
+      { key: 'ft', scope: 'match', label: 'Faule w meczu', lines: [17.5, 19.5, 21.5, 23.5, 25.5] },
+      { key: 'ff', scope: 'team', label: 'Faule drużyny', lines: [8.5, 10.5, 12.5, 14.5] }
+    ]
+  }
+];
+
+/* Rynki zerojedynkowe — bez linii, liczone tak samo jak pokrycie. */
+const BOOLEAN_MARKETS = [
+  { key: 'btts', label: 'Obie drużyny strzelą', no: 'Któraś drużyna nie strzeli', scope: 'match' },
+  { key: 'won', label: 'Wygrana drużyny', no: 'Drużyna nie wygra', scope: 'team' },
+  { key: 'lost', label: 'Porażka drużyny', no: 'Drużyna nie przegra', scope: 'team' },
+  { key: 'drew', label: 'Remis', no: 'Rozstrzygnięcie', scope: 'match' },
+  { key: 'clean', label: 'Czyste konto', no: 'Drużyna straci gola', scope: 'team' },
+  { key: 'blank', label: 'Drużyna nie strzeli', no: 'Drużyna strzeli gola', scope: 'team' }
+];
+
+/* ---------- STATYSTYKA ---------- */
+
+function coverage(records, key, predicate) {
+  const values = records.map(record => record[key]).filter(value => value !== null && value !== undefined);
+  if (!values.length) return null;
+  const hits = values.filter(predicate).length;
+  return { hits, n: values.length, p: hits / values.length };
+}
+
+const over = line => value => value > line;
+
+/* Dolna granica przedziału Wilsona — kara za małą próbkę. */
 function wilsonLower(hits, n, z = 1.282) {
   if (!n) return null;
   const p = hits / n, z2 = z * z;
   return clamp((p + z2 / (2 * n) - z * Math.sqrt((p * (1 - p) + z2 / (4 * n)) / n)) / (1 + z2 / n), 0, 1);
 }
+
 function poissonPmf(k, lambda) {
   if (!Number.isFinite(lambda) || lambda <= 0) return k === 0 ? 1 : 0;
   let value = Math.exp(-lambda);
   for (let i = 1; i <= k; i++) value *= lambda / i;
   return value;
 }
-function pOver(lambda, line) {
+
+function poissonOver(lambda, line) {
   if (!Number.isFinite(lambda) || lambda < 0) return null;
   let cdf = 0;
   for (let k = 0; k <= Math.floor(line); k++) cdf += poissonPmf(k, lambda);
   return clamp(1 - cdf, 0, 1);
 }
-function outcomeProbs(homeLambda, awayLambda) {
-  if (!Number.isFinite(homeLambda) || !Number.isFinite(awayLambda)) return { home: null, draw: null, away: null };
+
+function outcomeProbs(lambdaHome, lambdaAway) {
+  if (!Number.isFinite(lambdaHome) || !Number.isFinite(lambdaAway)) return { home: null, draw: null, away: null };
   let home = 0, draw = 0, away = 0;
-  for (let i = 0; i <= 12; i++) for (let j = 0; j <= 12; j++) {
-    const p = poissonPmf(i, homeLambda) * poissonPmf(j, awayLambda);
-    if (i > j) home += p; else if (i === j) draw += p; else away += p;
+  for (let i = 0; i <= 12; i++) {
+    for (let j = 0; j <= 12; j++) {
+      const p = poissonPmf(i, lambdaHome) * poissonPmf(j, lambdaAway);
+      if (i > j) home += p; else if (i === j) draw += p; else away += p;
+    }
   }
   const total = home + draw + away;
   return { home: home / total, draw: draw / total, away: away / total };
 }
-function tone(p) { return !Number.isFinite(p) ? 'empty' : p >= .8 ? 't5' : p >= .65 ? 't4' : p >= .45 ? 't3' : p >= .3 ? 't2' : 't1'; }
 
-async function analyseFixture(fixture) {
-  const [home, away] = await Promise.all([
-    fetchTeamHistory(fixture.teams.home.id, historyWindow),
-    fetchTeamHistory(fixture.teams.away.id, historyWindow)
-  ]);
-  const lambdaHome = mean([mean(home.map(m => m.scored)), mean(away.map(m => m.conceded))]);
-  const lambdaAway = mean([mean(away.map(m => m.scored)), mean(home.map(m => m.conceded))]);
-  return { fixture, recent: { home, away, window: historyWindow }, lambdaHome, lambdaAway, lambdaTotal: (lambdaHome ?? 0) + (lambdaAway ?? 0) };
+/* Kursy bukmachera zawierają marżę — normalizujemy do sumy 1. */
+function devig(odds) {
+  const valid = odds.filter(value => Number.isFinite(value) && value > 1);
+  if (valid.length !== odds.length) return odds.map(() => null);
+  const raw = odds.map(value => 1 / value);
+  const total = raw.reduce((sum, value) => sum + value, 0);
+  return raw.map(value => value / total);
 }
 
-function matrixCell(model, observed) {
-  const shown = model ?? observed?.p;
-  const title = observed ? `${observed.hits}/${observed.n} trafień · dolna granica Wilsona ${fmtPct(wilsonLower(observed.hits, observed.n))}` : `Model Poissona · kurs godziwy ${fairOdds(model)}`;
-  return `<td><div class="mx ${tone(shown)}" title="${esc(title)}"><span class="p">${fmtPct(shown)}</span>${observed ? `<span class="h">${observed.hits}/${observed.n}</span>` : ''}</div></td>`;
-}
-function buildRecommendations(a) {
-  const all = [...a.recent.home, ...a.recent.away];
-  const definitions = [
-    ['Gole pow. 1,5', all.map(m => m.total), v => v > 1.5],
-    ['Gole pow. 2,5', all.map(m => m.total), v => v > 2.5],
-    ['Obie drużyny strzelą', all.map(m => m.btts), Boolean],
-    [`${a.fixture.teams.home.name} strzeli`, a.recent.home.map(m => m.scored), v => v > 0],
-    [`${a.fixture.teams.away.name} strzeli`, a.recent.away.map(m => m.scored), v => v > 0]
-  ];
-  const picks = definitions.map(([label, values, test]) => ({ label, ...empirical(values, test) })).filter(p => Number.isFinite(p.p)).map(p => ({ ...p, lower: wilsonLower(p.hits, p.n) })).sort((x, y) => y.lower - x.lower);
-  return `<div class="st-recommendations"><div class="st-matrix-title"><strong>Rekomendacje statystyczne</strong><span class="sub">ranking wg dolnej granicy Wilsona (80%)</span></div><div class="st-rec-grid">${picks.map(p => `<div class="st-rec ${tone(p.p)}"><strong>${esc(p.label)}</strong><span class="value">${fmtPct(p.p)}</span><small>${p.hits}/${p.n} trafień · konserwatywnie ${fmtPct(p.lower)}</small></div>`).join('')}</div></div>`;
-}
-function buildGoalsMatrix(a) {
-  const lines = [.5, 1.5, 2.5, 3.5, 4.5];
-  const all = [...a.recent.home, ...a.recent.away];
-  const rows = [
-    ['Gole w meczu', a.lambdaTotal, all.map(m => m.total)],
-    [`Gole: ${a.fixture.teams.home.name}`, a.lambdaHome, a.recent.home.map(m => m.scored)],
-    [`Gole: ${a.fixture.teams.away.name}`, a.lambdaAway, a.recent.away.map(m => m.scored)]
-  ];
-  return `<div class="st-matrix-title"><strong>Gole</strong><span class="sub">model Poissona + pokrycie ostatnich dostępnych meczów</span></div><div class="st-matrix-wrap"><table class="st-matrix"><thead><tr><th>Rynek</th>${lines.map(line => `<th>pow. ${String(line).replace('.', ',')}</th>`).join('')}</tr></thead><tbody>${rows.map(([label, lambda, values]) => `<tr><td class="lbl">${esc(label)}</td>${lines.map(line => matrixCell(pOver(lambda, line), empirical(values, value => value > line))).join('')}</tr>`).join('')}</tbody></table></div>`;
-}
-function buildOutcomes(a) {
-  const probs = outcomeProbs(a.lambdaHome, a.lambdaAway);
-  const items = [['Wygrana gospodarza', probs.home], ['Remis', probs.draw], ['Wygrana gościa', probs.away], ['Gospodarz nie przegra', probs.home + probs.draw], ['Gość nie przegra', probs.away + probs.draw]];
-  return `<div class="st-matrix-title"><strong>Wynik meczu</strong><span class="sub">model bramkowy</span></div><div class="st-matrix-wrap"><table class="st-matrix"><thead><tr><th>Rynek</th><th>Prawdopodobieństwo</th><th>Kurs godziwy</th></tr></thead><tbody>${items.map(([label, p]) => `<tr><td class="lbl">${esc(label)}</td>${matrixCell(p, null)}<td><div class="mx t3"><span class="p">${fairOdds(p)}</span></div></td></tr>`).join('')}</tbody></table></div>`;
-}
-function historyList(title, team, rows) {
-  return `<div class="tc-card-head"><h3>${esc(title)}</h3><span class="sub">${rows.length} spotkań</span></div><div class="st-h2h-list">${rows.map(m => `<div class="st-h2h-row"><span class="d">${esc(m.date)}</span><span class="tn">${esc(team)}</span><span class="sc">${m.scored} : ${m.conceded}</span><span class="tn a">${esc(m.opponent)}</span><span class="ex">${m.total} gole${m.btts ? ' · BTTS' : ''}</span></div>`).join('')}</div>`;
+function tone(p) {
+  if (!Number.isFinite(p)) return 'empty';
+  if (p >= 0.85) return 't6';
+  if (p >= 0.7) return 't5';
+  if (p >= 0.55) return 't4';
+  if (p >= 0.4) return 't3';
+  if (p >= 0.25) return 't2';
+  return 't1';
 }
 
-function setStep(n) { document.querySelectorAll('.st-step').forEach(step => { const value = Number(step.dataset.step); step.classList.toggle('done', value < n); step.classList.toggle('active', value === n); }); }
-function renderDayLabel() { const date = new Date(`${todayISO(dayOffset)}T00:00:00Z`); el('day-label').textContent = date.toLocaleDateString('pl-PL', { weekday: 'long', day: '2-digit', month: 'long', year: 'numeric', timeZone: 'UTC' }); }
-function renderFixturesStatus(html) { el('fixtures-status').innerHTML = html; }
-function groupLeagues(list) {
-  const map = new Map();
-  for (const match of list) { if (!map.has(match.league.id)) map.set(match.league.id, { ...match.league, count: 0 }); map.get(match.league.id).count++; }
-  return [...map.values()].sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, 'pl'));
+/* ---------- WCZYTYWANIE LIGI ---------- */
+
+function indexTeams(matches) {
+  const set = new Set();
+  for (const match of matches) { set.add(match.home); set.add(match.away); }
+  return [...set].sort((a, b) => a.localeCompare(b, 'pl'));
 }
-function renderLeagues() {
-  el('leagues-block').style.display = leagues.length ? '' : 'none';
-  const q = leagueFilter.trim().toLowerCase();
-  const visible = q ? leagues.filter(l => `${l.name} ${l.country}`.toLowerCase().includes(q)) : leagues;
-  el('leagues-desc').textContent = `${leagues.length} lig · ${fixtures.length} meczów`;
-  el('leagues').innerHTML = visible.map(l => `<button class="st-league ${selectedLeagueId === l.id ? 'active' : ''}" data-league="${esc(l.id)}"><span class="t"><span class="n">${esc(l.name)}</span><span class="c">${esc(l.country)}</span></span><span class="cnt">${l.count}</span></button>`).join('') || '<div class="tc-empty">Brak lig</div>';
-  el('leagues').querySelectorAll('[data-league]').forEach(button => button.addEventListener('click', () => selectLeague(button.dataset.league)));
+
+async function loadDivision(id, seasons) {
+  const league = LEAGUE_BY_ID.get(id);
+  if (!league) return [];
+  if (league.kind === 'extra') {
+    const rows = await getMatches(`new/${id}.csv`, TTL.season);
+    const cutoff = Date.now() - seasons * 400 * 24 * 60 * 60 * 1000;
+    return rows.filter(match => match.ts >= cutoff);
+  }
+  const codes = seasonCodes(seasons);
+  const batches = await Promise.all(codes.map(code => getMatches(`mmz4281/${code}/${id}.csv`, TTL.season).catch(() => [])));
+  return batches.flat();
 }
-function statusTag(status) { return status.short === 'FT' ? '<span class="st-status ft">Zakończony</span>' : status.short === 'NS' ? '<span class="st-status ns">Przed meczem</span>' : `<span class="st-status live">${esc(status.short)}</span>`; }
-function renderMatches() {
-  if (!selectedLeagueId) { el('matches-block').style.display = 'none'; return; }
-  const list = fixtures.filter(match => match.league.id === selectedLeagueId).sort((a, b) => a.fixture.timestamp - b.fixture.timestamp);
-  el('matches-block').style.display = '';
-  el('matches-desc').textContent = `${leagues.find(l => l.id === selectedLeagueId)?.name || ''} · ${list.length} meczów`;
-  el('matches').innerHTML = `<table class="tc-tbl"><thead><tr><th>Godz.</th><th>Gospodarz</th><th>Wynik</th><th>Gość</th><th>Status</th><th></th></tr></thead><tbody>${list.map(match => `<tr class="st-match-row" data-fx="${match.fixture.id}"><td class="st-time">${new Date(match.fixture.date).toLocaleTimeString('pl-PL', { hour: '2-digit', minute: '2-digit' })}</td><td><span class="st-team"><span>${esc(match.teams.home.name)}</span></span></td><td class="num mono">${match.goals.home == null ? '—' : `${match.goals.home} : ${match.goals.away}`}</td><td><span class="st-team"><span>${esc(match.teams.away.name)}</span></span></td><td>${statusTag(match.fixture.status)}</td><td><button class="st-btn primary" data-analyse="${match.fixture.id}"><span class="material-symbols-outlined">insights</span>Analizuj</button></td></tr>`).join('')}</tbody></table>`;
-  el('matches').querySelectorAll('[data-analyse]').forEach(button => button.addEventListener('click', event => { event.stopPropagation(); runAnalysis(button.dataset.analyse); }));
-  el('matches').querySelectorAll('[data-fx]').forEach(row => row.addEventListener('click', () => runAnalysis(row.dataset.fx)));
-}
-function renderAnalysis() {
-  if (!analysis) { el('analysis-block').style.display = 'none'; return; }
-  const a = analysis, fx = a.fixture;
-  el('analysis-block').style.display = '';
-  el('analysis-desc').textContent = `${fx.teams.home.name} – ${fx.teams.away.name}`;
-  const available = Math.min(a.recent.home.length, a.recent.away.length);
-  const warning = available < a.recent.window ? `TheSportsDB Free zwraca endpointem <code>eventslast</code> maksymalnie ostatnie dostępne spotkania (zwykle 5). Wybrano ${a.recent.window}, ale wspólna próbka ma ${available}. Cache kolejnych dni może ją stopniowo powiększyć.` : `Analiza obejmuje po ${available} ostatnich dostępnych spotkań drużyn.`;
-  el('analysis').innerHTML = `<section class="tc-card"><div class="st-fixture-hero"><div class="st-fx-team"><div><div class="n">${esc(fx.teams.home.name)}</div><div class="s">${a.recent.home.length} meczów</div></div></div><div class="st-fx-mid"><div class="k">Oczekiwane gole</div><div class="lam">${(a.lambdaHome ?? 0).toFixed(2)} – ${(a.lambdaAway ?? 0).toFixed(2)}</div></div><div class="st-fx-team away"><div><div class="n">${esc(fx.teams.away.name)}</div><div class="s">${a.recent.away.length} meczów</div></div></div></div><div class="st-history-toolbar"><span>Zakres historii:</span><div class="st-seg" id="history-seg">${HISTORY_WINDOWS.map(n => `<button data-window="${n}" class="${n === a.recent.window ? 'active' : ''}">Ostatnie ${n}</button>`).join('')}</div></div><div class="st-notes"><div class="st-note warn"><span class="material-symbols-outlined">info</span><span>${warning}</span></div><div class="st-note"><span class="material-symbols-outlined">analytics</span><span>TheSportsDB Free nie udostępnia rożnych, strzałów, kartek ani predykcji. Rekomendacje bazują wyłącznie na wynikach i golach; nie są poradą bukmacherską.</span></div></div></section><section class="tc-card">${buildRecommendations(a)}${buildGoalsMatrix(a)}${buildOutcomes(a)}</section><section class="tc-card">${historyList(`Historia: ${fx.teams.home.name}`, fx.teams.home.name, a.recent.home)}${historyList(`Historia: ${fx.teams.away.name}`, fx.teams.away.name, a.recent.away)}</section>`;
-  el('history-seg').querySelectorAll('button').forEach(button => button.addEventListener('click', () => { const next = Number(button.dataset.window); if (next !== historyWindow && !busy) { historyWindow = next; runAnalysis(fx.fixture.id); } }));
-}
-async function fetchFixtures() {
-  if (busy) return;
-  busy = true;
-  const button = el('fetch-fixtures'); button.disabled = true;
-  const date = todayISO(dayOffset);
-  renderFixturesStatus('<div class="st-note"><span class="material-symbols-outlined">hourglass_top</span><span>Pobieram mecze…</span></div>');
+
+async function loadLeague() {
+  if (state.busy) return;
+  state.busy = true;
+  el('load-league').disabled = true;
+  renderLoadStatus('<span class="material-symbols-outlined spin">progress_activity</span>Pobieram dane ligi…');
   try {
-    const { data, cached } = await apiGet(`eventsday.php?d=${date}&s=Soccer`, TTL.fixtures);
-    fixtures = (data.events || []).map(adaptEvent);
-    leagues = groupLeagues(fixtures); selectedLeagueId = null; selectedFixture = null; analysis = null;
-    renderLeagues(); renderMatches(); renderAnalysis(); setStep(2);
-    el('step1-sub').textContent = `${fixtures.length} meczów, ${leagues.length} lig`;
-    renderFixturesStatus(`<div class="st-notes"><div class="st-note good"><span class="material-symbols-outlined">check_circle</span><span>Pobrano <strong>${fixtures.length}</strong> meczów z TheSportsDB${cached ? ' (cache)' : ''}.</span></div></div>`);
-  } catch (error) { renderFixturesStatus(`<div class="st-note bad"><span class="material-symbols-outlined">error</span><span>${esc(error.message)}</span></div>`); toast(error.message, 'err'); }
-  finally { busy = false; button.disabled = false; }
+    const matches = await loadDivision(state.leagueId, state.seasons);
+    if (!matches.length) throw new Error('Źródło nie zwróciło żadnych rozegranych meczów dla tej ligi i zakresu sezonów.');
+    state.matches = matches.sort((a, b) => b.ts - a.ts);
+    state.teams = indexTeams(state.matches);
+    state.analysis = null;
+    const league = LEAGUE_BY_ID.get(state.leagueId);
+    state.loadedLabel = `${league.country} · ${league.name}`;
+    const oldest = state.matches[state.matches.length - 1];
+    renderLoadStatus(`<span class="material-symbols-outlined ok">check_circle</span>
+      <strong>${state.matches.length}</strong> meczów, <strong>${state.teams.length}</strong> drużyn
+      · od ${fmtDate(oldest.ts)} do ${fmtDate(state.matches[0].ts)}`);
+    await loadFixtures();
+    renderTeamPickers();
+    renderFixtures();
+    renderAnalysis();
+    setStep(2);
+    el('step1-sub').textContent = state.loadedLabel;
+  } catch (error) {
+    renderLoadStatus(`<span class="material-symbols-outlined bad">error</span>${esc(error.message)}`);
+    toast(error.message, 'err');
+  } finally {
+    state.busy = false;
+    el('load-league').disabled = false;
+  }
 }
-function selectLeague(id) { selectedLeagueId = id; analysis = null; el('step2-sub').textContent = leagues.find(l => l.id === id)?.name || '—'; setStep(3); renderLeagues(); renderMatches(); renderAnalysis(); }
-async function runAnalysis(id) {
-  if (busy) return;
-  const fixture = fixtures.find(match => match.fixture.id === String(id)); if (!fixture) return;
-  busy = true; selectedFixture = fixture; el('analysis-block').style.display = ''; el('analysis').innerHTML = '<section class="tc-card"><div class="tc-empty"><span class="material-symbols-outlined">hourglass_top</span><h4>Liczę…</h4><p>Pobieram ostatnie wyniki obu drużyn z TheSportsDB.</p></div></section>';
-  try { analysis = await analyseFixture(fixture); setStep(4); el('step3-sub').textContent = `${fixture.teams.home.name} – ${fixture.teams.away.name}`; el('step4-sub').textContent = `${analysis.recent.home.length} / ${analysis.recent.away.length} meczów`; renderAnalysis(); el('analysis-block').scrollIntoView({ behavior: 'smooth', block: 'start' }); }
-  catch (error) { analysis = null; el('analysis').innerHTML = `<section class="tc-card"><div class="tc-empty"><span class="material-symbols-outlined">error</span><h4>Nie udało się przeanalizować</h4><p>${esc(error.message)}</p></div></section>`; toast(error.message, 'err'); }
-  finally { busy = false; }
+
+async function loadFixtures() {
+  const league = LEAGUE_BY_ID.get(state.leagueId);
+  if (league.kind !== 'main') { state.fixtures = []; return; }
+  try {
+    const hit = cache['fixtures.csv'];
+    let rows;
+    if (hit && Date.now() - hit.ts < TTL.fixtures) rows = hit.rows;
+    else {
+      const text = await fetchCsv('fixtures.csv');
+      rows = text === null ? [] : parseCsv(text).map(normalizeFixture).filter(Boolean);
+      cache['fixtures.csv'] = { ts: Date.now(), rows };
+      saveCache();
+    }
+    state.fixtures = rows.filter(fixture => fixture.div === state.leagueId).sort((a, b) => a.ts - b.ts);
+  } catch { state.fixtures = []; }
 }
-function clearCache() { cache = {}; saveCache(); toast('Cache TheSportsDB wyczyszczony'); }
+
+/* Drużyna po awansie/spadku ma za mało meczów — dobieramy z ligi sąsiedniej. */
+async function topUpTeam(team, needed) {
+  const related = RELATED_DIVISIONS[state.leagueId] || [];
+  const extra = [];
+  for (const div of related) {
+    const rows = await loadDivision(div, state.seasons).catch(() => []);
+    extra.push(...rows.filter(match => match.home === team || match.away === team));
+    if (extra.length >= needed) break;
+  }
+  return extra;
+}
+
+/* ---------- ANALIZA ---------- */
+
+async function buildAnalysis(homeTeam, awayTeam, fixture = null) {
+  const maxWindow = Math.max(...WINDOWS);
+  const forTeam = team => state.matches
+    .filter(match => match.home === team || match.away === team)
+    .map(match => perspective(match, team))
+    .sort((a, b) => b.ts - a.ts);
+
+  let home = forTeam(homeTeam);
+  let away = forTeam(awayTeam);
+  const borrowed = [];
+
+  for (const [team, list, label] of [[homeTeam, home, 'home'], [awayTeam, away, 'away']]) {
+    if (list.length >= maxWindow) continue;
+    const extra = await topUpTeam(team, maxWindow - list.length);
+    if (!extra.length) continue;
+    const merged = [...list, ...extra.map(match => perspective(match, team))]
+      .filter((record, index, all) => all.findIndex(other => other.ts === record.ts && other.opponent === record.opponent) === index)
+      .sort((a, b) => b.ts - a.ts);
+    if (label === 'home') home = merged; else away = merged;
+    borrowed.push(team);
+  }
+
+  /* Filtr dom–wyjazd zawęża próbkę do meczów granych na tym samym terenie. */
+  const homeRecs = state.venueSplit ? home.filter(record => record.venue === 'H') : home;
+  const awayRecs = state.venueSplit ? away.filter(record => record.venue === 'A') : away;
+
+  const h2h = state.matches
+    .filter(match => (match.home === homeTeam && match.away === awayTeam) || (match.home === awayTeam && match.away === homeTeam))
+    .map(match => perspective(match, homeTeam))
+    .sort((a, b) => b.ts - a.ts)
+    .slice(0, 10);
+
+  return {
+    homeTeam, awayTeam, fixture,
+    home: homeRecs, away: awayRecs,
+    homeAll: home, awayAll: away,
+    borrowed, h2h,
+    projections: projections(homeRecs, awayRecs)
+  };
+}
+
+/* Oczekiwana wartość metryki = średnia z tego, co drużyna kreuje,
+   i tego, na co pozwala rywal. Liczona na oknie 10 meczów. */
+function projectPair(homeRecs, awayRecs, keyFor, keyAgainst, window = 10) {
+  const h = homeRecs.slice(0, window), a = awayRecs.slice(0, window);
+  const homeSide = mean([mean(h.map(r => r[keyFor])), mean(a.map(r => r[keyAgainst]))]);
+  const awaySide = mean([mean(a.map(r => r[keyFor])), mean(h.map(r => r[keyAgainst]))]);
+  if (!Number.isFinite(homeSide) || !Number.isFinite(awaySide)) return { home: null, away: null, total: null };
+  return { home: homeSide, away: awaySide, total: homeSide + awaySide };
+}
+
+function projections(homeRecs, awayRecs) {
+  return {
+    goals: projectPair(homeRecs, awayRecs, 'gf', 'ga'),
+    corners: projectPair(homeRecs, awayRecs, 'cf', 'ca'),
+    yellow: projectPair(homeRecs, awayRecs, 'yf', 'ya'),
+    points: projectPair(homeRecs, awayRecs, 'pf', 'pa'),
+    shots: projectPair(homeRecs, awayRecs, 'sf', 'sa'),
+    target: projectPair(homeRecs, awayRecs, 'tf', 'ta'),
+    fouls: projectPair(homeRecs, awayRecs, 'ff', 'fa')
+  };
+}
+
+/* Klucz metryki -> odpowiadająca projekcja, żeby model i pokrycie
+   stały obok siebie w tej samej tabeli. */
+const PROJECTION_FOR = {
+  gt: a => a.projections.goals.total, gf: a => a.projections.goals.home, ga: a => a.projections.goals.away,
+  ct: a => a.projections.corners.total, cf: a => a.projections.corners.home, ca: a => a.projections.corners.away,
+  yt: a => a.projections.yellow.total, yf: a => a.projections.yellow.home,
+  pt: a => a.projections.points.total,
+  st: a => a.projections.shots.total, sf: a => a.projections.shots.home,
+  tt: a => a.projections.target.total, tf: a => a.projections.target.home,
+  ft: a => a.projections.fouls.total, ff: a => a.projections.fouls.home
+};
+
+/* Punkty kartkowe rosną skokowo — Poisson na nich kłamie, więc pomijamy model. */
+const MODEL_BLACKLIST = new Set(['pt', 'rt', 'htt']);
+
+function modelProb(analysis, key, line) {
+  if (MODEL_BLACKLIST.has(key)) return null;
+  const projector = PROJECTION_FOR[key];
+  if (!projector) return null;
+  return poissonOver(projector(analysis), line);
+}
+
+/* ---------- SKRÓT TYPÓW ---------- */
+
+/* Kandydat trafia na listę tylko wtedy, gdy trzyma poziom w każdym
+   oknie 5/10/20 — jednorazowa seria z pięciu meczów to za mało.
+   Górny próg odcina zdarzenia niemal pewne: pokrycie 100% oznacza
+   kurs godziwy 1,00, więc na taki rynek i tak nie ma jak zagrać. */
+const CERTAINTY_CAP = 0.93;
+
+function shortlist(analysis) {
+  const picks = [];
+  const push = (label, group, samples, modelP) => {
+    const pooled = samples.pooled;
+    if (!pooled || pooled.n < 8) return;
+    const consistent = samples.windows.filter(w => w && w.n >= 3);
+    if (consistent.length < 2) return;
+    const worst = Math.min(...consistent.map(w => w.p));
+    const lower = wilsonLower(pooled.hits, pooled.n);
+    picks.push({ label, group, p: pooled.p, hits: pooled.hits, n: pooled.n, lower, worst, modelP });
+  };
+
+  /* Rynki drużynowe pooluje się z prób obu ekip — etykieta musi to mówić. */
+  const scoped = (row, text) => row.scope === 'team' ? `${text} (każda z drużyn)` : text;
+
+  for (const group of GROUPS) {
+    if (!hasMetric(analysis, group.probe)) continue;
+    for (const row of group.rows) {
+      if (!hasMetric(analysis, row.key)) continue;
+      for (const line of row.lines) {
+        const pack = poolSamples(analysis, row, line);
+        const model = modelProb(analysis, row.key, line);
+        push(scoped(row, `${row.label} pow. ${fmtLine(line)}`), group.label, pack.over, model);
+        push(scoped(row, `${row.label} pon. ${fmtLine(line)}`), group.label, pack.under, invert(model));
+      }
+    }
+  }
+  for (const market of BOOLEAN_MARKETS) {
+    const pack = poolBoolean(analysis, market);
+    push(scoped(market, market.label), 'Zdarzenia', pack.yes, null);
+    push(scoped(market, market.no), 'Zdarzenia', pack.no, null);
+  }
+
+  return picks
+    .filter(pick => pick.worst >= 0.5 && pick.lower >= 0.5 && pick.p <= CERTAINTY_CAP)
+    .sort((a, b) => (b.lower - a.lower) || (b.worst - a.worst))
+    .slice(0, 12);
+}
+
+const invert = p => Number.isFinite(p) ? 1 - p : null;
+
+function mergeCoverage(a, b) {
+  if (!a && !b) return null;
+  const hits = (a?.hits || 0) + (b?.hits || 0);
+  const n = (a?.n || 0) + (b?.n || 0);
+  return n ? { hits, n, p: hits / n } : null;
+}
+
+const flipCoverage = c => c ? { hits: c.n - c.hits, n: c.n, p: 1 - c.p } : null;
+
+/* Rynek "drużynowy" liczymy każdej ekipie z jej własnej perspektywy,
+   "meczowy" — z obu prób, bo opisuje to samo zdarzenie. */
+function poolSamples(analysis, row, line) {
+  const window = state.focusWindow;
+  const home = coverage(analysis.home.slice(0, window), row.key, over(line));
+  const away = coverage(analysis.away.slice(0, window), row.key, over(line));
+  const pooled = mergeCoverage(home, away);
+  const windows = WINDOWS.map(size =>
+    mergeCoverage(coverage(analysis.home.slice(0, size), row.key, over(line)),
+      coverage(analysis.away.slice(0, size), row.key, over(line))));
+  return {
+    over: { pooled, windows },
+    under: { pooled: flipCoverage(pooled), windows: windows.map(flipCoverage) }
+  };
+}
+
+function poolBoolean(analysis, market) {
+  const window = state.focusWindow;
+  const pooled = mergeCoverage(
+    coverage(analysis.home.slice(0, window), market.key, Boolean),
+    coverage(analysis.away.slice(0, window), market.key, Boolean));
+  const windows = WINDOWS.map(size => mergeCoverage(
+    coverage(analysis.home.slice(0, size), market.key, Boolean),
+    coverage(analysis.away.slice(0, size), market.key, Boolean)));
+  return { yes: { pooled, windows }, no: { pooled: flipCoverage(pooled), windows: windows.map(flipCoverage) } };
+}
+
+function hasMetric(analysis, key) {
+  return [...analysis.home, ...analysis.away].some(record => record[key] !== null && record[key] !== undefined);
+}
+
+/* ---------- RENDER: STEROWANIE ---------- */
+
+function setStep(n) {
+  document.querySelectorAll('.st-step').forEach(step => {
+    const value = Number(step.dataset.step);
+    step.classList.toggle('done', value < n);
+    step.classList.toggle('active', value === n);
+  });
+}
+
+function renderLoadStatus(html) { el('load-status').innerHTML = html; }
+
+function renderProxyBadge() {
+  const proxy = PROXIES.find(item => item.id === state.proxy);
+  el('proxy-badge').innerHTML = proxy
+    ? `<strong>${esc(proxy.id === 'local' ? 'Proxy lokalne' : 'Proxy publiczne')}</strong> · ${esc(proxy.label)}`
+    : '<strong>football-data.co.uk</strong> · darmowe CSV';
+}
+
+function renderLeaguePicker() {
+  const optionsFor = list => list.map(league =>
+    `<option value="${esc(league.id)}" ${state.leagueId === league.id ? 'selected' : ''}>${esc(league.country)} — ${esc(league.name)}</option>`).join('');
+  el('league-select').innerHTML =
+    `<optgroup label="Pełna statystyka (rożne, kartki, strzały, faule)">${optionsFor(MAIN_LEAGUES)}</optgroup>` +
+    `<optgroup label="Tylko gole i kursy">${optionsFor(EXTRA_LEAGUES)}</optgroup>`;
+  el('season-select').value = String(state.seasons);
+  el('venue-toggle').checked = state.venueSplit;
+  document.querySelectorAll('#focus-seg button').forEach(button =>
+    button.classList.toggle('active', Number(button.dataset.window) === state.focusWindow));
+}
+
+function renderTeamPickers() {
+  const options = ['<option value="">— wybierz drużynę —</option>',
+    ...state.teams.map(team => `<option value="${esc(team)}">${esc(team)}</option>`)].join('');
+  el('home-select').innerHTML = options;
+  el('away-select').innerHTML = options;
+  el('custom-block').style.display = state.teams.length ? '' : 'none';
+}
+
+function fixtureBuckets() {
+  const startOfDay = ts => { const d = new Date(ts); return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()); };
+  const today = startOfDay(Date.now());
+  const day = 24 * 60 * 60 * 1000;
+  return [
+    { id: 'today', label: 'Dziś', test: ts => startOfDay(ts) === today },
+    { id: 'tomorrow', label: 'Jutro', test: ts => startOfDay(ts) === today + day },
+    { id: 'week', label: 'Najbliższe 7 dni', test: ts => startOfDay(ts) > today + day && startOfDay(ts) <= today + 7 * day }
+  ];
+}
+
+function renderFixtures() {
+  const block = el('fixtures-block');
+  const league = LEAGUE_BY_ID.get(state.leagueId);
+  if (!state.matches.length) { block.style.display = 'none'; return; }
+  block.style.display = '';
+
+  if (league.kind !== 'main') {
+    el('fixtures-body').innerHTML = `<div class="st-note"><span class="material-symbols-outlined">info</span>
+      <span>Dla tej ligi źródło nie publikuje terminarza. Użyj <strong>własnego zestawienia</strong> poniżej — analiza działa dla dowolnej pary drużyn.</span></div>`;
+    return;
+  }
+  if (!state.fixtures.length) {
+    el('fixtures-body').innerHTML = `<div class="st-note"><span class="material-symbols-outlined">event_busy</span>
+      <span>Plik <code>fixtures.csv</code> nie zawiera meczów tej ligi. Publikowany jest na ok. tydzień naprzód i bywa pusty w przerwie między sezonami — skorzystaj z <strong>własnego zestawienia</strong>.</span></div>`;
+    return;
+  }
+
+  const buckets = fixtureBuckets().map(bucket => ({ ...bucket, list: state.fixtures.filter(fixture => bucket.test(fixture.ts)) }))
+    .filter(bucket => bucket.list.length);
+  if (!buckets.length) {
+    el('fixtures-body').innerHTML = `<div class="st-note"><span class="material-symbols-outlined">event_busy</span>
+      <span>Brak meczów w najbliższych 7 dniach (${state.fixtures.length} pozycji w pliku poza tym oknem).</span></div>`;
+    return;
+  }
+
+  el('fixtures-body').innerHTML = buckets.map(bucket => `
+    <div class="st-fx-group">
+      <div class="st-fx-head"><strong>${esc(bucket.label)}</strong><span>${bucket.list.length} mecz(e)</span></div>
+      <div class="tc-tbl-wrap">
+        <table class="tc-tbl st-fx-tbl">
+          <thead><tr><th>Data</th><th>Godz.</th><th>Gospodarz</th><th>Gość</th><th class="num">1</th><th class="num">X</th><th class="num">2</th><th class="num">pow. 2,5</th><th></th></tr></thead>
+          <tbody>${bucket.list.map(fixture => `
+            <tr>
+              <td class="mono">${fmtDate(fixture.ts)}</td>
+              <td class="mono">${esc(fixture.time || '—')}</td>
+              <td><strong>${esc(fixture.home)}</strong></td>
+              <td>${esc(fixture.away)}</td>
+              <td class="num mono">${fmtNum(fixture.oh)}</td>
+              <td class="num mono">${fmtNum(fixture.od)}</td>
+              <td class="num mono">${fmtNum(fixture.oa)}</td>
+              <td class="num mono">${fmtNum(fixture.oOver)}</td>
+              <td><button class="st-btn primary" data-fixture="${esc(fixture.home)}|${esc(fixture.away)}">
+                <span class="material-symbols-outlined">insights</span>Analizuj</button></td>
+            </tr>`).join('')}</tbody>
+        </table>
+      </div>
+    </div>`).join('');
+
+  el('fixtures-body').querySelectorAll('[data-fixture]').forEach(button =>
+    button.addEventListener('click', () => {
+      const [home, away] = button.dataset.fixture.split('|');
+      const fixture = state.fixtures.find(item => item.home === home && item.away === away) || null;
+      runAnalysis(home, away, fixture);
+    }));
+}
+
+/* ---------- RENDER: ANALIZA ---------- */
+
+function coverageCell(sample, extraClass = '') {
+  if (!sample) return '<td class="mx-td"><div class="mx empty"><span class="p">—</span></div></td>';
+  const title = `${sample.hits} z ${sample.n} · dolna granica Wilsona ${fmtPct(wilsonLower(sample.hits, sample.n))} · kurs godziwy ${fairOdds(sample.p)}`;
+  return `<td class="mx-td"><div class="mx ${tone(sample.p)} ${extraClass}" title="${esc(title)}">
+    <span class="p">${fmtPct(sample.p)}</span><span class="h">${sample.hits}/${sample.n}</span></div></td>`;
+}
+
+function modelCell(p) {
+  if (!Number.isFinite(p)) return '<td class="mx-td"><div class="mx empty"><span class="p">—</span></div></td>';
+  return `<td class="mx-td"><div class="mx ${tone(p)} model" title="Model Poissona · kurs godziwy ${fairOdds(p)}">
+    <span class="p">${fmtPct(p)}</span><span class="h">${fairOdds(p)}</span></div></td>`;
+}
+
+/* Pasek ostatnich 20 meczów: jedna kropka = jeden mecz, zapełniona = trafienie. */
+function formStrip(records, key, predicate) {
+  const dots = records.slice(0, 20).reverse().map(record => {
+    const value = record[key];
+    if (value === null || value === undefined) return '<i class="void"></i>';
+    const hit = predicate(value);
+    return `<i class="${hit ? 'hit' : 'miss'}" title="${fmtDate(record.ts)} ${record.venue === 'H' ? 'dom' : 'wyjazd'} vs ${esc(record.opponent)} · ${value}"></i>`;
+  }).join('');
+  return `<div class="st-form">${dots}</div>`;
+}
+
+function matrixRow(analysis, row, line) {
+  const predicate = over(line);
+  const cellFor = (records, size) => coverageCell(coverage(records.slice(0, size), row.key, predicate));
+  const pooled = mergeCoverage(
+    coverage(analysis.home.slice(0, state.focusWindow), row.key, predicate),
+    coverage(analysis.away.slice(0, state.focusWindow), row.key, predicate));
+
+  return `<tr>
+    <td class="lbl">${esc(row.label)} <span class="ln">pow. ${fmtLine(line)}</span></td>
+    ${WINDOWS.map(size => cellFor(analysis.home, size)).join('')}
+    <td class="sep"></td>
+    ${WINDOWS.map(size => cellFor(analysis.away, size)).join('')}
+    <td class="sep"></td>
+    ${coverageCell(pooled, 'pooled')}
+    ${modelCell(modelProb(analysis, row.key, line))}
+  </tr>`;
+}
+
+function buildMatrix(analysis, group) {
+  if (!hasMetric(analysis, group.probe)) {
+    return `<section class="tc-card st-group" id="grp-${group.id}">
+      <div class="tc-card-head"><h3><span class="material-symbols-outlined">${group.icon}</span>${esc(group.label)}</h3></div>
+      <div class="st-note warn"><span class="material-symbols-outlined">info</span>
+        <span>Ta liga nie ma w źródle danych z tej kategorii — dostępne są tylko gole i kursy.</span></div>
+    </section>`;
+  }
+
+  const rows = group.rows
+    .filter(row => hasMetric(analysis, row.key))
+    .map(row => row.lines.map(line => matrixRow(analysis, row, line)).join(''))
+    .join('<tr class="gap"><td colspan="12"></td></tr>');
+
+  return `<section class="tc-card st-group" id="grp-${group.id}">
+    <div class="tc-card-head">
+      <h3><span class="material-symbols-outlined">${group.icon}</span>${esc(group.label)}</h3>
+      <span class="sub">pokrycie linii w oknach 5 / 10 / 20 meczów</span>
+    </div>
+    <div class="st-matrix-wrap">
+      <table class="st-matrix">
+        <thead>
+          <tr class="grp">
+            <th rowspan="2" class="lbl">Rynek</th>
+            <th colspan="3">${esc(analysis.homeTeam)}</th>
+            <th class="sep" rowspan="2"></th>
+            <th colspan="3">${esc(analysis.awayTeam)}</th>
+            <th class="sep" rowspan="2"></th>
+            <th rowspan="2">Razem<br><small>2 × ost. ${state.focusWindow}</small></th>
+            <th rowspan="2">Model<br><small>kurs godziwy</small></th>
+          </tr>
+          <tr>${WINDOWS.map(size => `<th>${size}</th>`).join('')}${WINDOWS.map(size => `<th>${size}</th>`).join('')}</tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+    ${buildFormBlock(analysis, group)}
+  </section>`;
+}
+
+/* Dla najciekawszej linii w grupie pokazujemy przebieg mecz po meczu. */
+function buildFormBlock(analysis, group) {
+  const row = group.rows.find(item => item.scope === 'match' && hasMetric(analysis, item.key));
+  if (!row) return '';
+  const line = row.lines[Math.floor(row.lines.length / 2)];
+  return `<div class="st-form-block">
+    <div class="st-form-title"><strong>${esc(row.label)} pow. ${fmtLine(line)}</strong><span>ostatnie 20 meczów, od najstarszego</span></div>
+    <div class="st-form-row"><span class="tn">${esc(analysis.homeTeam)}</span>${formStrip(analysis.home, row.key, over(line))}</div>
+    <div class="st-form-row"><span class="tn">${esc(analysis.awayTeam)}</span>${formStrip(analysis.away, row.key, over(line))}</div>
+  </div>`;
+}
+
+function buildOutcomes(analysis) {
+  const goals = analysis.projections.goals;
+  const probs = outcomeProbs(goals.home, goals.away);
+  const fixture = analysis.fixture;
+  const market = fixture ? devig([fixture.oh, fixture.od, fixture.oa]) : [null, null, null];
+  /* null + null daje w JS zero — bez tej straży brak kursu udawałby ogromną przewagę. */
+  const add = (a, b) => Number.isFinite(a) && Number.isFinite(b) ? a + b : null;
+  const items = [
+    ['Wygrana gospodarza', probs.home, market[0], fixture?.oh],
+    ['Remis', probs.draw, market[1], fixture?.od],
+    ['Wygrana gościa', probs.away, market[2], fixture?.oa],
+    ['Gospodarz nie przegra', add(probs.home, probs.draw), add(market[0], market[1]), null],
+    ['Gość nie przegra', add(probs.away, probs.draw), add(market[2], market[1]), null]
+  ];
+
+  return `<section class="tc-card st-group" id="grp-wynik">
+    <div class="tc-card-head"><h3><span class="material-symbols-outlined">emoji_events</span>Wynik meczu</h3>
+      <span class="sub">model bramkowy${fixture ? ' vs kurs rynkowy' : ''}</span></div>
+    <div class="st-matrix-wrap">
+      <table class="st-matrix wide">
+        <thead><tr><th class="lbl">Rynek</th><th>Model</th><th>Kurs godziwy</th><th>Rynek</th><th>Kurs bukmachera</th><th>Przewaga</th></tr></thead>
+        <tbody>${items.map(([label, p, mp, odds]) => {
+          const edge = Number.isFinite(p) && Number.isFinite(mp) ? p - mp : null;
+          return `<tr>
+            <td class="lbl">${esc(label)}</td>
+            ${modelCell(p)}
+            <td class="mono num">${fairOdds(p)}</td>
+            <td class="mono num">${fmtPct(mp)}</td>
+            <td class="mono num">${fmtNum(odds)}</td>
+            <td class="mono num ${edge > 0.03 ? 'edge-pos' : edge < -0.03 ? 'edge-neg' : ''}">${Number.isFinite(edge) ? `${edge > 0 ? '+' : ''}${(edge * 100).toFixed(1)} pkt` : '—'}</td>
+          </tr>`;
+        }).join('')}</tbody>
+      </table>
+    </div>
+  </section>`;
+}
+
+function buildBooleanMatrix(analysis) {
+  const rows = BOOLEAN_MARKETS.map(market => {
+    const cellFor = (records, size) => coverageCell(coverage(records.slice(0, size), market.key, Boolean));
+    const pooled = mergeCoverage(
+      coverage(analysis.home.slice(0, state.focusWindow), market.key, Boolean),
+      coverage(analysis.away.slice(0, state.focusWindow), market.key, Boolean));
+    return `<tr>
+      <td class="lbl">${esc(market.label)}</td>
+      ${WINDOWS.map(size => cellFor(analysis.home, size)).join('')}
+      <td class="sep"></td>
+      ${WINDOWS.map(size => cellFor(analysis.away, size)).join('')}
+      <td class="sep"></td>
+      ${coverageCell(pooled, 'pooled')}
+      <td class="mx-td"><div class="mx empty"><span class="p">—</span></div></td>
+    </tr>`;
+  }).join('');
+
+  return `<section class="tc-card st-group" id="grp-zdarzenia">
+    <div class="tc-card-head"><h3><span class="material-symbols-outlined">rule</span>Zdarzenia</h3>
+      <span class="sub">rynki bez linii</span></div>
+    <div class="st-matrix-wrap">
+      <table class="st-matrix">
+        <thead>
+          <tr class="grp">
+            <th rowspan="2" class="lbl">Rynek</th>
+            <th colspan="3">${esc(analysis.homeTeam)}</th><th class="sep" rowspan="2"></th>
+            <th colspan="3">${esc(analysis.awayTeam)}</th><th class="sep" rowspan="2"></th>
+            <th rowspan="2">Razem<br><small>2 × ost. ${state.focusWindow}</small></th><th rowspan="2">Model</th>
+          </tr>
+          <tr>${WINDOWS.map(size => `<th>${size}</th>`).join('')}${WINDOWS.map(size => `<th>${size}</th>`).join('')}</tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  </section>`;
+}
+
+function buildShortlist(analysis) {
+  const picks = shortlist(analysis);
+  if (!picks.length) {
+    return `<section class="tc-card"><div class="st-note"><span class="material-symbols-outlined">filter_alt_off</span>
+      <span>Żaden rynek nie utrzymał pokrycia powyżej 50% we wszystkich oknach. To sam w sobie sygnał — ten mecz jest statystycznie niejednoznaczny.</span></div></section>`;
+  }
+  return `<section class="tc-card st-group">
+    <div class="tc-card-head"><h3><span class="material-symbols-outlined">bolt</span>Skrót typów</h3>
+      <span class="sub">rynki trzymające poziom w każdym oknie, ranking wg dolnej granicy Wilsona</span></div>
+    <div class="st-rec-grid">${picks.map(pick => `
+      <div class="st-rec ${tone(pick.lower)}">
+        <span class="grp">${esc(pick.group)}</span>
+        <strong>${esc(pick.label)}</strong>
+        <span class="value">${fmtPct(pick.p)}</span>
+        <small>${pick.hits}/${pick.n} trafień · konserwatywnie ${fmtPct(pick.lower)} · kurs godziwy ${fairOdds(pick.lower)}</small>
+        ${Number.isFinite(pick.modelP) ? `<small class="model">model ${fmtPct(pick.modelP)}</small>` : ''}
+      </div>`).join('')}</div>
+  </section>`;
+}
+
+function buildLegend() {
+  const steps = [['t1', 'do 25%'], ['t2', '25–40%'], ['t3', '40–55%'], ['t4', '55–70%'], ['t5', '70–85%'], ['t6', 'od 85%']];
+  const swatch = { t1: '#fbe9e7', t2: '#fdf3e3', t3: '#f6f8fa', t4: '#eaf8f0', t5: '#dcf5e7', t6: '#c8efdb' };
+  return `<section class="tc-card"><div class="st-legend">
+    <span><strong>Pokrycie linii</strong></span>
+    ${steps.map(([id, label]) => `<span class="item"><span class="sw" style="background:${swatch[id]}"></span>${label}</span>`).join('')}
+    <span class="item">Duża liczba w komórce = procent trafień, mała = <em>trafienia / mecze w próbce</em>.</span>
+  </div></section>`;
+}
+
+function buildProfiles(analysis) {
+  const metrics = [
+    ['Gole', 'gf', 'ga'], ['Rożne', 'cf', 'ca'], ['Strzały', 'sf', 'sa'],
+    ['Celne', 'tf', 'ta'], ['Żółte', 'yf', 'ya'], ['Faule', 'ff', 'fa']
+  ].filter(([, keyFor]) => hasMetric(analysis, keyFor));
+
+  const column = (team, records) => `
+    <div class="st-profile">
+      <div class="st-profile-head">${esc(team)} <span>${records.length} meczów w próbce</span></div>
+      <table class="st-profile-tbl">
+        <thead><tr><th>Metryka</th><th>Zdobyte</th><th>Stracone</th><th>Suma</th></tr></thead>
+        <tbody>${metrics.map(([label, keyFor, keyAgainst]) => {
+          const window = records.slice(0, state.focusWindow);
+          const forAvg = mean(window.map(record => record[keyFor]));
+          const againstAvg = mean(window.map(record => record[keyAgainst]));
+          return `<tr><td class="lbl">${esc(label)}</td>
+            <td class="mono num">${fmtNum(forAvg, 2)}</td>
+            <td class="mono num">${fmtNum(againstAvg, 2)}</td>
+            <td class="mono num strong">${Number.isFinite(forAvg) && Number.isFinite(againstAvg) ? (forAvg + againstAvg).toFixed(2) : '—'}</td></tr>`;
+        }).join('')}</tbody>
+      </table>
+    </div>`;
+
+  return `<section class="tc-card st-group" id="grp-profile">
+    <div class="tc-card-head"><h3><span class="material-symbols-outlined">contrast</span>Profile drużyn</h3>
+      <span class="sub">średnie na mecz z ostatnich ${state.focusWindow} spotkań</span></div>
+    <div class="st-profiles">${column(analysis.homeTeam, analysis.home)}${column(analysis.awayTeam, analysis.away)}</div>
+  </section>`;
+}
+
+function buildH2H(analysis) {
+  if (!analysis.h2h.length) return '';
+  return `<section class="tc-card st-group" id="grp-h2h">
+    <div class="tc-card-head"><h3><span class="material-symbols-outlined">swap_horiz</span>Bezpośrednie starcia</h3>
+      <span class="sub">${analysis.h2h.length} ostatnich meczów w tej lidze</span></div>
+    <div class="tc-tbl-wrap">
+      <table class="tc-tbl">
+        <thead><tr><th>Data</th><th>Teren</th><th>Wynik</th><th class="num">Gole</th><th class="num">Rożne</th><th class="num">Żółte</th><th class="num">Strzały</th></tr></thead>
+        <tbody>${analysis.h2h.map(record => `<tr>
+          <td class="mono">${fmtDate(record.ts)}</td>
+          <td>${record.venue === 'H' ? 'dom' : 'wyjazd'}</td>
+          <td class="mono strong">${record.gf}:${record.ga}</td>
+          <td class="num mono">${record.gt ?? '—'}</td>
+          <td class="num mono">${record.ct ?? '—'}</td>
+          <td class="num mono">${record.yt ?? '—'}</td>
+          <td class="num mono">${record.st ?? '—'}</td>
+        </tr>`).join('')}</tbody>
+      </table>
+    </div>
+  </section>`;
+}
+
+function buildHistory(analysis) {
+  const table = (team, records) => `
+    <details class="st-history">
+      <summary><strong>${esc(team)}</strong><span>ostatnie ${Math.min(records.length, 20)} meczów — pełne dane</span></summary>
+      <div class="tc-tbl-wrap">
+        <table class="tc-tbl">
+          <thead><tr><th>Data</th><th>T</th><th>Rywal</th><th>Wynik</th><th class="num">Rożne</th><th class="num">Żółte</th><th class="num">Strzały</th><th class="num">Celne</th><th class="num">Faule</th></tr></thead>
+          <tbody>${records.slice(0, 20).map(record => `<tr>
+            <td class="mono">${fmtDate(record.ts)}</td>
+            <td>${record.venue === 'H' ? 'D' : 'W'}</td>
+            <td>${esc(record.opponent)}</td>
+            <td class="mono strong ${record.won ? 'win' : record.lost ? 'loss' : ''}">${record.gf}:${record.ga}</td>
+            <td class="num mono">${record.cf ?? '—'}:${record.ca ?? '—'}</td>
+            <td class="num mono">${record.yf ?? '—'}:${record.ya ?? '—'}</td>
+            <td class="num mono">${record.sf ?? '—'}:${record.sa ?? '—'}</td>
+            <td class="num mono">${record.tf ?? '—'}:${record.ta ?? '—'}</td>
+            <td class="num mono">${record.ff ?? '—'}:${record.fa ?? '—'}</td>
+          </tr>`).join('')}</tbody>
+        </table>
+      </div>
+    </details>`;
+  return `<section class="tc-card st-group" id="grp-historia">
+    <div class="tc-card-head"><h3><span class="material-symbols-outlined">history</span>Historia meczów</h3>
+      <span class="sub">dane źródłowe stojące za macierzami</span></div>
+    ${table(analysis.homeTeam, analysis.home)}${table(analysis.awayTeam, analysis.away)}
+  </section>`;
+}
+
+function buildHero(analysis) {
+  const p = analysis.projections;
+  const tiles = [
+    ['Gole', p.goals.total, 'sports_soccer'],
+    ['Rożne', p.corners.total, 'flag'],
+    ['Żółte', p.yellow.total, 'style'],
+    ['Strzały', p.shots.total, 'sports_handball'],
+    ['Celne', p.target.total, 'my_location'],
+    ['Faule', p.fouls.total, 'sports']
+  ].filter(([, value]) => Number.isFinite(value));
+
+  const warnings = [];
+  const minSample = Math.min(analysis.home.length, analysis.away.length);
+  if (minSample < 20) warnings.push(`Mniejsza z prób ma ${minSample} meczów — kolumna „20” opiera się na tym, co jest dostępne.`);
+  if (analysis.borrowed.length) warnings.push(`Historię uzupełniono meczami z ligi powiązanej dla: ${analysis.borrowed.join(', ')}.`);
+  if (state.venueSplit) warnings.push('Filtr dom–wyjazd jest włączony: gospodarz liczony tylko z meczów u siebie, gość tylko z wyjazdowych.');
+
+  return `<section class="tc-card">
+    <div class="st-hero">
+      <div class="st-hero-team"><div class="n">${esc(analysis.homeTeam)}</div><div class="s">gospodarz · ${analysis.home.length} meczów</div></div>
+      <div class="st-hero-mid">
+        <div class="k">Projekcja wyniku</div>
+        <div class="lam">${fmtNum(analysis.projections.goals.home, 2)} – ${fmtNum(analysis.projections.goals.away, 2)}</div>
+        ${analysis.fixture ? `<div class="odds">${fmtDate(analysis.fixture.ts)} ${esc(analysis.fixture.time || '')}</div>` : '<div class="odds">zestawienie własne</div>'}
+      </div>
+      <div class="st-hero-team away"><div class="n">${esc(analysis.awayTeam)}</div><div class="s">gość · ${analysis.away.length} meczów</div></div>
+    </div>
+    <div class="st-tiles">${tiles.map(([label, value, icon]) => `
+      <div class="st-tile"><span class="material-symbols-outlined">${icon}</span>
+        <div><div class="k">${esc(label)} w meczu</div><div class="v">${value.toFixed(2)}</div></div></div>`).join('')}</div>
+    ${warnings.length ? `<div class="st-notes">${warnings.map(text => `<div class="st-note warn"><span class="material-symbols-outlined">info</span><span>${esc(text)}</span></div>`).join('')}</div>` : ''}
+  </section>`;
+}
+
+function renderAnalysis() {
+  const block = el('analysis-block');
+  if (!state.analysis) { block.style.display = 'none'; return; }
+  const analysis = state.analysis;
+  block.style.display = '';
+  el('analysis-desc').textContent = `${analysis.homeTeam} – ${analysis.awayTeam} · ${state.loadedLabel}`;
+
+  const jump = [...GROUPS.map(group => ({ id: `grp-${group.id}`, label: group.label })),
+    { id: 'grp-zdarzenia', label: 'Zdarzenia' }, { id: 'grp-wynik', label: 'Wynik' },
+    { id: 'grp-profile', label: 'Profile' }, { id: 'grp-h2h', label: 'H2H' }, { id: 'grp-historia', label: 'Historia' }];
+
+  el('analysis').innerHTML =
+    buildHero(analysis) +
+    `<div class="st-jump">${jump.map(item => `<a href="#${item.id}">${esc(item.label)}</a>`).join('')}</div>` +
+    buildLegend() +
+    buildShortlist(analysis) +
+    GROUPS.map(group => buildMatrix(analysis, group)).join('') +
+    buildBooleanMatrix(analysis) +
+    buildOutcomes(analysis) +
+    buildProfiles(analysis) +
+    buildH2H(analysis) +
+    buildHistory(analysis);
+}
+
+async function runAnalysis(homeTeam, awayTeam, fixture = null) {
+  if (state.busy || !homeTeam || !awayTeam) return;
+  if (homeTeam === awayTeam) { toast('Wybierz dwie różne drużyny', 'err'); return; }
+  state.busy = true;
+  el('analysis-block').style.display = '';
+  el('analysis').innerHTML = `<section class="tc-card"><div class="tc-empty">
+    <span class="material-symbols-outlined spin">progress_activity</span><h4>Liczę macierze…</h4>
+    <p>Składam pokrycie linii dla obu drużyn.</p></div></section>`;
+  try {
+    state.analysis = await buildAnalysis(homeTeam, awayTeam, fixture);
+    el('home-select').value = homeTeam;
+    el('away-select').value = awayTeam;
+    setStep(4);
+    el('step3-sub').textContent = `${homeTeam} – ${awayTeam}`;
+    el('step4-sub').textContent = `${state.analysis.home.length} / ${state.analysis.away.length} meczów`;
+    renderAnalysis();
+    el('analysis-block').scrollIntoView({ behavior: 'smooth', block: 'start' });
+  } catch (error) {
+    state.analysis = null;
+    el('analysis').innerHTML = `<section class="tc-card"><div class="tc-empty">
+      <span class="material-symbols-outlined">error</span><h4>Nie udało się policzyć</h4><p>${esc(error.message)}</p></div></section>`;
+    toast(error.message, 'err');
+  } finally {
+    state.busy = false;
+  }
+}
+
+function refreshAnalysis() {
+  if (!state.analysis) return;
+  runAnalysis(state.analysis.homeTeam, state.analysis.awayTeam, state.analysis.fixture);
+}
+
+/* ---------- START ---------- */
+
+async function detectLocalProxy() {
+  try {
+    const response = await fetchWithTimeout('api/fd/health', 4000);
+    if (response.ok) { state.proxy = 'local'; savePrefs(); }
+  } catch { /* brak lokalnego proxy — zadziała łańcuch publicznych */ }
+  renderProxyBadge();
+}
+
+function clearCache() {
+  cache = {};
+  try { localStorage.removeItem(CACHE_KEY); } catch { /* nic nie szkodzi */ }
+  fetch('api/fd/purge').catch(() => {});
+  toast('Cache wyczyszczony — kolejne pobranie pójdzie do źródła');
+}
+
 function init() {
-  loadCache(); renderDayLabel(); setStep(1);
-  document.querySelectorAll('.sidebar__link[data-page]').forEach(link => link.classList.toggle('sidebar__link--active', link.dataset.page === 'stats'));
-  el('day-seg').querySelectorAll('button').forEach(button => button.addEventListener('click', () => { dayOffset = Number(button.dataset.day); el('day-seg').querySelectorAll('button').forEach(item => item.classList.toggle('active', item === button)); renderDayLabel(); }));
-  el('fetch-fixtures').addEventListener('click', fetchFixtures);
+  loadPrefs();
+  loadCache();
+  renderLeaguePicker();
+  renderProxyBadge();
+  setStep(1);
+  document.querySelectorAll('.sidebar__link[data-page]').forEach(link =>
+    link.classList.toggle('sidebar__link--active', link.dataset.page === 'stats'));
+
+  el('league-select').addEventListener('change', event => { state.leagueId = event.target.value; savePrefs(); });
+  el('season-select').addEventListener('change', event => { state.seasons = Number(event.target.value); savePrefs(); });
+  el('load-league').addEventListener('click', loadLeague);
+  el('venue-toggle').addEventListener('change', event => { state.venueSplit = event.target.checked; savePrefs(); refreshAnalysis(); });
+  el('focus-seg').querySelectorAll('button').forEach(button =>
+    button.addEventListener('click', () => {
+      state.focusWindow = Number(button.dataset.window);
+      renderLeaguePicker();
+      savePrefs();
+      renderAnalysis();
+    }));
+  el('analyse-custom').addEventListener('click', () => {
+    setStep(3);
+    runAnalysis(el('home-select').value, el('away-select').value, null);
+  });
+  el('swap-teams').addEventListener('click', () => {
+    const home = el('home-select').value;
+    el('home-select').value = el('away-select').value;
+    el('away-select').value = home;
+  });
   el('clear-cache-btn').addEventListener('click', clearCache);
-  el('league-search').addEventListener('input', event => { leagueFilter = event.target.value; renderLeagues(); });
+
+  detectLocalProxy();
 }
+
 document.addEventListener('DOMContentLoaded', init);

--- a/stats.js
+++ b/stats.js
@@ -160,7 +160,9 @@ const state = {
   afDay: 0,
   afFixtures: [],
   afLeagueFilter: '',
+  afOnlyCovered: false,
   afLoaded: false,
+  collapsed: {},
   /* Skaner dnia */
   scanRows: [],
   scanSkipped: [],
@@ -284,14 +286,18 @@ function loadPrefs() {
       seasons: [1, 2, 3, 4].includes(saved.seasons) ? saved.seasons : state.seasons,
       venueSplit: Boolean(saved.venueSplit),
       focusWindow: WINDOWS.includes(saved.focusWindow) ? saved.focusWindow : state.focusWindow,
-      proxy: saved.proxy || null
+      proxy: saved.proxy || null,
+      afOnlyCovered: Boolean(saved.afOnlyCovered),
+      collapsed: saved.collapsed && typeof saved.collapsed === 'object' ? saved.collapsed : {}
     });
   } catch { /* domyślne ustawienia wystarczą */ }
 }
 
 function savePrefs() {
-  const { leagueId, seasons, venueSplit, focusWindow, proxy } = state;
-  try { localStorage.setItem(PREFS_KEY, JSON.stringify({ leagueId, seasons, venueSplit, focusWindow, proxy })); } catch { /* opcjonalne */ }
+  const { leagueId, seasons, venueSplit, focusWindow, proxy, afOnlyCovered, collapsed } = state;
+  try {
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ leagueId, seasons, venueSplit, focusWindow, proxy, afOnlyCovered, collapsed }));
+  } catch { /* opcjonalne */ }
 }
 
 /* Klucz API trzymamy osobno od reszty ustawień i wyłącznie w tej
@@ -1181,13 +1187,22 @@ function afStatusTag(fixture) {
 function renderAfFixtures() {
   if (!state.afLoaded) return;
   const query = state.afLeagueFilter.trim().toLowerCase();
+  const covered = state.afFixtures.filter(fixture => fixture.div).length;
   const visible = state.afFixtures.filter(fixture =>
-    !query || `${fixture.leagueName} ${fixture.country} ${fixture.home} ${fixture.away}`.toLowerCase().includes(query));
+    (!state.afOnlyCovered || fixture.div) &&
+    (!query || `${fixture.leagueName} ${fixture.country} ${fixture.home} ${fixture.away}`.toLowerCase().includes(query)));
+
+  el('af-only-covered').checked = state.afOnlyCovered;
+  el('af-covered-count').textContent = covered;
 
   if (!visible.length) {
-    el('af-summary').textContent = `0 z ${state.afFixtures.length} meczów pasuje do filtra`;
+    el('af-summary').textContent = state.afOnlyCovered && !covered
+      ? `Żaden z ${state.afFixtures.length} meczów nie ma historii w CSV`
+      : `0 z ${state.afFixtures.length} meczów pasuje do filtra`;
     el('af-body').innerHTML = `<div class="st-note"><span class="material-symbols-outlined">event_busy</span>
-      <span>Brak meczów pasujących do filtra (pobrano ${state.afFixtures.length}).</span></div>`;
+      <span>${state.afOnlyCovered && !covered
+        ? 'Odznacz „tylko z analizą”, żeby zobaczyć pozostałe mecze terminarza.'
+        : `Brak meczów pasujących do filtra (pobrano ${state.afFixtures.length}).`}</span></div>`;
     return;
   }
 
@@ -1201,18 +1216,22 @@ function renderAfFixtures() {
   const ordered = [...groups.values()].sort((a, b) =>
     (b.div ? 1 : 0) - (a.div ? 1 : 0) || a.key.localeCompare(b.key, 'pl'));
 
-  const covered = ordered.filter(group => group.div).length;
   el('af-summary').textContent =
-    `${visible.length} meczów · ${ordered.length} rozgrywek · ${covered} z pełną statystyką historyczną`;
+    `${visible.length} z ${state.afFixtures.length} meczów · ${ordered.length} rozgrywek · ${covered} z analizą`;
 
+  /* Ligi bez historii startują zwinięte — przy 300 meczach to one robią
+     większość przewijania, a i tak nie da się z nich nic policzyć. */
   el('af-body').innerHTML = ordered.map(group => `
-    <div class="st-fx-group">
-      <div class="st-fx-head">
-        <strong>${esc(group.key)}</strong>
+    <details class="st-fx-group" ${group.div ? 'open' : ''}>
+      <summary class="st-fx-head">
+        <span class="st-fx-head-l">
+          <span class="material-symbols-outlined chev">expand_more</span>
+          <strong>${esc(group.key)}</strong>
+        </span>
         <span>${group.div
-          ? `<span class="st-badge ok">macierze dostępne</span>`
-          : `<span class="st-badge">brak historii w CSV</span>`} ${group.list.length} mecz(e)</span>
-      </div>
+          ? '<span class="st-badge ok">macierze dostępne</span>'
+          : '<span class="st-badge">brak historii w CSV</span>'} ${group.list.length} mecz(e)</span>
+      </summary>
       <div class="tc-tbl-wrap">
         <table class="tc-tbl st-fx-tbl">
           <tbody>${group.list.map(fixture => `
@@ -1227,7 +1246,7 @@ function renderAfFixtures() {
             </tr>`).join('')}</tbody>
         </table>
       </div>
-    </div>`).join('');
+    </details>`).join('');
 
   el('af-body').querySelectorAll('[data-af]').forEach(button =>
     button.addEventListener('click', () => analyseAfFixture(Number(button.dataset.af))));
@@ -1266,6 +1285,9 @@ async function analyseAfFixture(fixtureId) {
       renderBridgePrompt(fixture, home, away);
       return;
     }
+    /* Lista meczów zrobiła swoje — chowamy ją, żeby powrót do macierzy
+       nie wymagał przewijania przez cały terminarz. */
+    if (!state.collapsed['af-block']) setCollapsed('af-block', true);
     runAnalysis(home, away, null);
   } catch (error) {
     state.busy = false;
@@ -1297,6 +1319,31 @@ function renderBridgePrompt(fixture, home, away) {
     runAnalysis(picked[0], picked[1], null);
   });
 }
+
+/* ---------- ZWIJANIE PANELI ----------
+   Terminarz potrafi mieć 300 pozycji, więc panele muszą dać się schować,
+   żeby dojście do macierzy nie było przewijaniem przez pół strony. */
+
+function applyCollapse(id) {
+  const card = el(id);
+  if (!card) return;
+  const hidden = Boolean(state.collapsed[id]);
+  card.classList.toggle('is-collapsed', hidden);
+  const button = document.querySelector(`[data-collapse="${id}"]`);
+  if (button) {
+    button.querySelector('.material-symbols-outlined').textContent = hidden ? 'expand_more' : 'expand_less';
+    button.setAttribute('aria-expanded', String(!hidden));
+    button.title = hidden ? 'Rozwiń' : 'Zwiń';
+  }
+}
+
+function setCollapsed(id, hidden) {
+  state.collapsed[id] = hidden;
+  applyCollapse(id);
+  savePrefs();
+}
+
+function toggleCollapse(id) { setCollapsed(id, !state.collapsed[id]); }
 
 /* ---------- SKANER DNIA ----------
    Zamiast otwierać mecz po meczu, przeliczamy cały terminarz i układamy
@@ -1927,6 +1974,7 @@ function init() {
   renderProxyBadge();
   renderKeyPanel();
   el('af-day-label').textContent = afDayLabel(state.afDay);
+  el('af-only-covered').checked = state.afOnlyCovered;
   el('scan-upcoming').checked = state.scanUpcomingOnly;
   el('scan-min').value = String(state.scanMinCoverage);
   renderScanAvailability();
@@ -1970,6 +2018,7 @@ function init() {
       state.afDay = Number(button.dataset.day);
       el('af-day-seg').querySelectorAll('button').forEach(item => item.classList.toggle('active', item === button));
       el('af-day-label').textContent = afDayLabel(state.afDay);
+  el('af-only-covered').checked = state.afOnlyCovered;
   el('scan-upcoming').checked = state.scanUpcomingOnly;
   el('scan-min').value = String(state.scanMinCoverage);
   renderScanAvailability();
@@ -1979,6 +2028,16 @@ function init() {
     }));
   el('af-load').addEventListener('click', loadAfFixtures);
   el('af-filter').addEventListener('input', event => { state.afLeagueFilter = event.target.value; renderAfFixtures(); });
+
+  document.querySelectorAll('[data-collapse]').forEach(button =>
+    button.addEventListener('click', () => toggleCollapse(button.dataset.collapse)));
+  ['key-block', 'af-block', 'scan-block', 'source-block'].forEach(applyCollapse);
+
+  el('af-only-covered').addEventListener('change', event => {
+    state.afOnlyCovered = event.target.checked;
+    savePrefs();
+    renderAfFixtures();
+  });
 
   el('scan-run').addEventListener('click', scanDay);
   el('scan-upcoming').addEventListener('change', event => { state.scanUpcomingOnly = event.target.checked; });

--- a/stats.js
+++ b/stats.js
@@ -831,8 +831,8 @@ async function loadLeague() {
     renderTeamPickers();
     renderFixtures();
     renderAnalysis();
-    setStep(2);
-    el('step1-sub').textContent = state.loadedLabel;
+    setStep(3);
+    el('step3-sub').textContent = `${state.loadedLabel} · wybierz drużyny`;
   } catch (error) {
     renderLoadStatus(`<span class="material-symbols-outlined bad">error</span>${esc(error.message)}`);
     toast(error.message, 'err');
@@ -1156,8 +1156,9 @@ async function loadAfFixtures() {
     el('scan-body').innerHTML = '';
     renderAfFixtures();
     renderScanAvailability();
-    setStep(2);
-    el('step2-sub').textContent = `${state.afFixtures.length} meczów`;
+    setStep(3);
+    el('step1-sub').textContent = 'Klucz zapisany';
+    el('step2-sub').textContent = `${state.afFixtures.length} meczów · ${afDayLabel(state.afDay)}`;
   } catch (error) {
     state.afLoaded = false;
     el('af-body').innerHTML = `<div class="st-note bad"><span class="material-symbols-outlined">error</span><span>${esc(error.message)}</span></div>`;
@@ -1245,7 +1246,6 @@ async function ensureLeague(div) {
   savePrefs();
   renderLeaguePicker();
   renderTeamPickers();
-  el('step1-sub').textContent = state.loadedLabel;
 }
 
 async function analyseAfFixture(fixtureId) {
@@ -1346,6 +1346,7 @@ async function scanDay() {
     state.scanSkipped = skipped;
     state.scanDone = true;
     renderScan();
+    el('step3-sub').textContent = `${rows.length} typów z ${new Set(rows.map(row => row.fixture.id)).size} meczów`;
   } catch (error) {
     el('scan-body').innerHTML = `<div class="st-note bad"><span class="material-symbols-outlined">error</span><span>${esc(error.message)}</span></div>`;
     toast(error.message, 'err');
@@ -1929,7 +1930,8 @@ function init() {
   el('scan-upcoming').checked = state.scanUpcomingOnly;
   el('scan-min').value = String(state.scanMinCoverage);
   renderScanAvailability();
-  setStep(1);
+  if (state.apiKey) el('step1-sub').textContent = 'Klucz zapisany';
+  setStep(state.apiKey ? 2 : 1);
   document.querySelectorAll('.sidebar__link[data-page]').forEach(link =>
     link.classList.toggle('sidebar__link--active', link.dataset.page === 'stats'));
 
@@ -1958,6 +1960,8 @@ function init() {
   el('save-key').addEventListener('click', () => {
     saveApiKey(el('api-key').value);
     renderKeyPanel();
+    el('step1-sub').textContent = state.apiKey ? 'Klucz zapisany' : 'Jednorazowo, zostaje w przeglądarce';
+    setStep(state.apiKey ? 2 : 1);
     toast(state.apiKey ? 'Klucz zapisany lokalnie' : 'Klucz usunięty');
   });
   el('test-key').addEventListener('click', () => { saveApiKey(el('api-key').value); testApiKey(); });

--- a/stats.js
+++ b/stats.js
@@ -103,6 +103,24 @@ const PROXIES = [
 const LOCAL_PROXY_HINT = 'Uruchom `node server.js` i otwórz stronę pod http://localhost:8787 '
   + '— wtedy pliki idą przez lokalne proxy, bez publicznych pośredników.';
 
+/* Dwa układy blokują localhost niezależnie od tego, czy server.js działa:
+   strona otwarta jako plik (origin "null") i strona po https sięgająca
+   po http. W obu przypadkach fetch kończy się "Failed to fetch", więc
+   sama instrukcja "uruchom serwer" byłaby myląca. */
+function environmentHint() {
+  const protocol = typeof location === 'undefined' ? '' : location.protocol;
+  if (protocol === 'file:') {
+    return 'Strona jest otwarta bezpośrednio z dysku (file://). W tym trybie przeglądarka blokuje '
+      + 'zapytania do http://localhost — lokalne proxy nie zadziała, nawet jeśli server.js jest uruchomiony. '
+      + 'Otwórz stronę pod http://localhost:8787 albo wczytaj pliki CSV z dysku (sekcja „Źródło danych”).';
+  }
+  if (protocol === 'https:') {
+    return 'Strona działa po https, a lokalne proxy po http — przeglądarka blokuje takie mieszane żądania. '
+      + 'Otwórz stronę pod http://localhost:8787 albo wczytaj pliki CSV z dysku.';
+  }
+  return LOCAL_PROXY_HINT;
+}
+
 /* ---------- API-FOOTBALL ----------
    Terminarz na dziś i jutro ze statusami live. Klucz podaje użytkownik
    w ustawieniach i trzymany jest wyłącznie w localStorage tej przeglądarki
@@ -386,8 +404,7 @@ async function fetchCsv(target) {
   if (missing === problems.length && missing > 0) return null;
   const onlyPublic = !state.localProxy;
   throw new Error(onlyPublic
-    ? `Nie udało się pobrać ${target} — żadne z publicznych proxy CORS nie odpowiedziało. ${LOCAL_PROXY_HINT} `
-      + `Szczegóły: ${problems.join('; ')}`
+    ? `Nie udało się pobrać ${target}. ${environmentHint()} Szczegóły prób: ${problems.join('; ')}`
     : `Nie udało się pobrać ${target}. Próby — ${problems.join('; ')}`);
 }
 
@@ -826,6 +843,92 @@ function tone(p) {
   return 't1';
 }
 
+/* ---------- IMPORT PLIKÓW Z DYSKU ----------
+   Ostatnia deska ratunku, gdy ani lokalne, ani publiczne proxy nie działa:
+   pobranie pliku przez kliknięcie w link to zwykła nawigacja, której CORS
+   nie dotyczy. Wczytany plik zostaje w cache i ma pierwszeństwo przed siecią. */
+
+const IMPORT_PREFIX = 'fdimport:';
+
+function neededTargets(div) {
+  const league = LEAGUE_BY_ID.get(div);
+  if (!league) return [];
+  if (league.kind === 'extra') return [`new/${div}.csv`];
+  return seasonCodes(state.seasons).map(code => `mmz4281/${code}/${div}.csv`);
+}
+
+function importedRows(div) {
+  const entry = cache[IMPORT_PREFIX + div];
+  return entry && Array.isArray(entry.rows) ? entry.rows : null;
+}
+
+async function importCsvFiles(fileList) {
+  const files = [...fileList];
+  if (!files.length) return;
+  const collected = [];
+  const rejected = [];
+  for (const file of files) {
+    let text;
+    try { text = await file.text(); } catch { rejected.push(`${file.name}: nie udało się odczytać`); continue; }
+    const clean = unwrapCsv(text);
+    if (!looksLikeCsv(clean)) { rejected.push(`${file.name}: to nie jest plik z football-data.co.uk`); continue; }
+    const rows = parseCsv(clean).map(normalizeRow).filter(Boolean);
+    if (!rows.length) { rejected.push(`${file.name}: brak rozegranych meczów`); continue; }
+    collected.push(...rows);
+  }
+
+  if (!collected.length) {
+    renderImportStatus(`<span class="material-symbols-outlined bad">error</span>Nie wczytano nic. ${esc(rejected.join('; '))}`);
+    return;
+  }
+
+  const seen = new Set();
+  const merged = collected
+    .filter(match => {
+      const key = `${match.ts}|${match.home}|${match.away}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .sort((a, b) => b.ts - a.ts);
+
+  cache[IMPORT_PREFIX + state.leagueId] = { ts: Date.now(), rows: merged.map(packMatch) };
+  saveCache();
+  divisionPool.clear();
+  const league = LEAGUE_BY_ID.get(state.leagueId);
+  renderImportStatus(`<span class="material-symbols-outlined ok">check_circle</span>
+    Wczytano <strong>${merged.length}</strong> meczów do ligi <strong>${esc(league.country)} · ${esc(league.name)}</strong>
+    (${fmtDate(merged[merged.length - 1].ts)} – ${fmtDate(merged[0].ts)}).
+    ${rejected.length ? `Pominięto: ${esc(rejected.join('; '))}` : ''}`);
+  toast(`Zaimportowano ${merged.length} meczów`);
+  await loadLeague();
+}
+
+function clearImport() {
+  const key = IMPORT_PREFIX + state.leagueId;
+  if (!cache[key]) { toast('Ta liga nie ma zaimportowanych danych'); return; }
+  delete cache[key];
+  saveCache();
+  divisionPool.clear();
+  renderImportPanel();
+  toast('Import wyczyszczony — dane pójdą znów z sieci');
+}
+
+function renderImportStatus(html) { el('import-status').innerHTML = html; }
+
+function renderImportPanel() {
+  const div = state.leagueId;
+  const rows = importedRows(div);
+  el('import-links').innerHTML = neededTargets(div)
+    .map(target => `<a href="${UPSTREAM}/${target}" download target="_blank" rel="noopener">${esc(target)}</a>`)
+    .join('');
+  renderImportStatus(rows
+    ? `<span class="material-symbols-outlined ok">check_circle</span>
+       Ta liga korzysta z <strong>${rows.length}</strong> meczów wczytanych z dysku (mają pierwszeństwo przed siecią).`
+    : `<span class="material-symbols-outlined">info</span>
+       Pobierz pliki z linków powyżej i wskaż je przyciskiem — działa nawet bez serwera i bez proxy.`);
+}
+
 /* ---------- WCZYTYWANIE LIGI ---------- */
 
 function indexTeams(matches) {
@@ -837,6 +940,15 @@ function indexTeams(matches) {
 async function loadDivision(id, seasons) {
   const league = LEAGUE_BY_ID.get(id);
   if (!league) return [];
+
+  const imported = importedRows(id);
+  if (imported) {
+    const rows = imported.map(unpackMatch);
+    if (league.kind !== 'extra') return rows;
+    const cutoff = Date.now() - seasons * 400 * 24 * 60 * 60 * 1000;
+    return rows.filter(match => match.ts >= cutoff);
+  }
+
   if (league.kind === 'extra') {
     const rows = await getMatches(`new/${id}.csv`, TTL.season);
     const cutoff = Date.now() - seasons * 400 * 24 * 60 * 60 * 1000;
@@ -1123,6 +1235,12 @@ function renderProxyWarning(show) {
   const banner = el('proxy-warning');
   if (!banner) return;
   banner.style.display = show ? '' : 'none';
+  if (!show) return;
+  const blocked = typeof location !== 'undefined' && (location.protocol === 'file:' || location.protocol === 'https:');
+  banner.innerHTML = `<span class="material-symbols-outlined">running_with_errors</span>
+    <span><strong>${blocked ? 'Lokalne proxy jest zablokowane przez przeglądarkę.' : 'Brak lokalnego proxy.'}</strong>
+    ${esc(environmentHint())}
+    Publiczne pośredniki CORS bywają wyłączane bez ostrzeżenia i wtedy analiza kończy się błędem „Failed to fetch”.</span>`;
 }
 
 function renderProxyBadge() {
@@ -2039,12 +2157,24 @@ function init() {
   el('scan-upcoming').checked = state.scanUpcomingOnly;
   el('scan-min').value = String(state.scanMinCoverage);
   renderScanAvailability();
+  renderImportPanel();
   if (state.apiKey) el('step1-sub').textContent = 'Klucz zapisany';
   setStep(state.apiKey ? 2 : 1);
   document.querySelectorAll('.sidebar__link[data-page]').forEach(link =>
     link.classList.toggle('sidebar__link--active', link.dataset.page === 'stats'));
 
-  el('league-select').addEventListener('change', event => { state.leagueId = event.target.value; savePrefs(); });
+  el('league-select').addEventListener('change', event => {
+    state.leagueId = event.target.value;
+    savePrefs();
+    renderImportPanel();
+  });
+  el('season-select').addEventListener('change', renderImportPanel);
+  el('import-btn').addEventListener('click', () => el('import-input').click());
+  el('import-input').addEventListener('change', event => {
+    importCsvFiles(event.target.files);
+    event.target.value = '';
+  });
+  el('import-clear').addEventListener('click', clearImport);
   el('season-select').addEventListener('change', event => { state.seasons = Number(event.target.value); savePrefs(); });
   el('load-league').addEventListener('click', loadLeague);
   el('venue-toggle').addEventListener('change', event => { state.venueSplit = event.target.checked; savePrefs(); refreshAnalysis(); });

--- a/stats.js
+++ b/stats.js
@@ -78,12 +78,30 @@ const LEAGUE_BY_ID = new Map([...MAIN_LEAGUES.map(l => [l.id, { ...l, kind: 'mai
 /* ---------- PROXY ---------- */
 
 const UPSTREAM = 'https://www.football-data.co.uk';
+
+/* server.js odpowiada z Access-Control-Allow-Origin: *, więc lokalne proxy
+   działa także wtedy, gdy strona jest otwarta z innego miejsca (file://,
+   Live Server, inny port). Dlatego obok ścieżki względnej próbujemy też
+   pełnego adresu. */
+const LOCAL_PROXY_ORIGIN = 'http://localhost:8787';
+const LOCAL_PROXY_IDS = ['local', 'local-abs'];
+
 const PROXIES = [
-  { id: 'local', label: 'lokalne proxy (server.js)', build: (_url, target) => `api/fd/csv?path=${encodeURIComponent(target)}` },
+  { id: 'local', label: 'lokalne proxy (ta sama strona)', local: true,
+    build: (_url, target) => `api/fd/csv?path=${encodeURIComponent(target)}` },
+  { id: 'local-abs', label: `lokalne proxy (${LOCAL_PROXY_ORIGIN})`, local: true,
+    build: (_url, target) => `${LOCAL_PROXY_ORIGIN}/api/fd/csv?path=${encodeURIComponent(target)}` },
   { id: 'allorigins', label: 'allorigins.win', build: url => `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}` },
   { id: 'codetabs', label: 'codetabs.com', build: url => `https://api.codetabs.com/v1/proxy?quest=${encodeURIComponent(url)}` },
   { id: 'jina', label: 'r.jina.ai', build: url => `https://r.jina.ai/${url}` }
 ];
+
+/* Publiczne proxy bywają wyłączane bez ostrzeżenia — r.jina.ai zaczął
+   wymagać logowania, a allorigins i codetabs potrafią nie dosięgnąć
+   źródła. Ich awarie widać w przeglądarce jako „Failed to fetch”, bo
+   odpowiedź błędu nie niesie nagłówka CORS i skrypt nie może jej odczytać. */
+const LOCAL_PROXY_HINT = 'Uruchom `node server.js` i otwórz stronę pod http://localhost:8787 '
+  + '— wtedy pliki idą przez lokalne proxy, bez publicznych pośredników.';
 
 /* ---------- API-FOOTBALL ----------
    Terminarz na dziś i jutro ze statusami live. Klucz podaje użytkownik
@@ -152,6 +170,7 @@ const state = {
   fixtures: [],
   analysis: null,
   proxy: null,
+  localProxy: null,
   busy: false,
   loadedLabel: '',
   /* API-Football */
@@ -335,16 +354,22 @@ function looksLikeCsv(text) {
 
 async function fetchCsv(target) {
   const url = `${UPSTREAM}/${target}`;
-  const ordered = state.proxy
-    ? [...PROXIES.filter(p => p.id === state.proxy), ...PROXIES.filter(p => p.id !== state.proxy)]
-    : PROXIES;
+  /* Lokalne proxy zawsze idzie pierwsze — jest szybsze i nie znika bez
+     ostrzeżenia. Dopiero potem to, które ostatnio zadziałało. */
+  const rank = proxy => (proxy.local ? 0 : proxy.id === state.proxy ? 1 : 2);
+  const ordered = [...PROXIES].sort((a, b) => rank(a) - rank(b));
   const problems = [];
+  let missing = 0;
   for (const proxy of ordered) {
     try {
       const response = await fetchWithTimeout(proxy.build(url, target));
       if (!response.ok) {
-        /* 404 to brak sezonu u źródła, a nie wina proxy — nie próbujemy dalej. */
-        if (response.status === 404) return null;
+        /* 404 potwierdzone nagłówkiem znaczy, że pliku nie ma u źródła —
+           tylko wtedy wolno przerwać. Samo 404 może pochodzić z serwera,
+           który nie zna endpointu proxy (np. inny serwer statyczny),
+           więc idziemy do kolejnego pośrednika. */
+        if (response.status === 404 && response.headers.get('x-fd-missing') === '1') return null;
+        if (response.status === 404) missing++;
         problems.push(`${proxy.label}: HTTP ${response.status}`);
         continue;
       }
@@ -357,7 +382,13 @@ async function fetchCsv(target) {
       problems.push(`${proxy.label}: ${error.name === 'AbortError' ? 'przekroczony czas' : error.message}`);
     }
   }
-  throw new Error(`Nie udało się pobrać ${target}. Próby — ${problems.join('; ')}`);
+  /* Gdy każde proxy odpowiedziało 404, plik faktycznie nie istnieje. */
+  if (missing === problems.length && missing > 0) return null;
+  const onlyPublic = !state.localProxy;
+  throw new Error(onlyPublic
+    ? `Nie udało się pobrać ${target} — żadne z publicznych proxy CORS nie odpowiedziało. ${LOCAL_PROXY_HINT} `
+      + `Szczegóły: ${problems.join('; ')}`
+    : `Nie udało się pobrać ${target}. Próby — ${problems.join('; ')}`);
 }
 
 async function getMatches(target, ttl) {
@@ -1088,11 +1119,32 @@ function setStep(n) {
 
 function renderLoadStatus(html) { el('load-status').innerHTML = html; }
 
+function renderProxyWarning(show) {
+  const banner = el('proxy-warning');
+  if (!banner) return;
+  banner.style.display = show ? '' : 'none';
+}
+
 function renderProxyBadge() {
+  const node = el('proxy-badge');
   const proxy = PROXIES.find(item => item.id === state.proxy);
-  el('proxy-badge').innerHTML = proxy
-    ? `<strong>${esc(proxy.id === 'local' ? 'Proxy lokalne' : 'Proxy publiczne')}</strong> · ${esc(proxy.label)}`
-    : '<strong>football-data.co.uk</strong> · darmowe CSV';
+  if (proxy && proxy.local) {
+    node.className = 'st-quota';
+    node.title = 'Pliki CSV idą przez lokalne proxy — bez limitów i pośredników';
+    node.innerHTML = `<strong>Proxy lokalne</strong> · ${esc(proxy.label)}`;
+    renderProxyWarning(false);
+    return;
+  }
+  if (state.localProxy === false) {
+    node.className = 'st-quota warn';
+    node.title = LOCAL_PROXY_HINT;
+    node.innerHTML = `<strong>Bez lokalnego proxy</strong> · ${esc(proxy ? proxy.label : 'publiczne pośredniki')}`;
+    renderProxyWarning(true);
+    return;
+  }
+  node.className = 'st-quota';
+  node.title = 'Źródło danych historycznych';
+  node.innerHTML = '<strong>football-data.co.uk</strong> · darmowe CSV';
 }
 
 function renderQuota() {
@@ -1948,10 +2000,19 @@ function refreshAnalysis() {
 /* ---------- START ---------- */
 
 async function detectLocalProxy() {
-  try {
-    const response = await fetchWithTimeout('api/fd/health', 4000);
-    if (response.ok) { state.proxy = 'local'; savePrefs(); }
-  } catch { /* brak lokalnego proxy — zadziała łańcuch publicznych */ }
+  for (const [id, url] of [['local', 'api/fd/health'], ['local-abs', `${LOCAL_PROXY_ORIGIN}/api/fd/health`]]) {
+    try {
+      const response = await fetchWithTimeout(url, 4000);
+      if (response.ok) {
+        state.proxy = id;
+        state.localProxy = true;
+        savePrefs();
+        renderProxyBadge();
+        return;
+      }
+    } catch { /* próbujemy następnego wariantu */ }
+  }
+  state.localProxy = false;
   renderProxyBadge();
 }
 

--- a/stats.js
+++ b/stats.js
@@ -85,6 +85,48 @@ const PROXIES = [
   { id: 'jina', label: 'r.jina.ai', build: url => `https://r.jina.ai/${url}` }
 ];
 
+/* ---------- API-FOOTBALL ----------
+   Terminarz na dziś i jutro ze statusami live. Klucz podaje użytkownik
+   w ustawieniach i trzymany jest wyłącznie w localStorage tej przeglądarki
+   — nigdy w repozytorium.
+
+   Ograniczenia planu Free (sprawdzone na żywo):
+     • /fixtures?date=      tylko dziś ±1 dzień
+     • sezony               wyłącznie 2022–2024
+     • parametr last        zablokowany
+     • budżet               100 zapytań na dobę, 10 na minutę
+   Dlatego terminarz idzie z API-Football, a historia do macierzy
+   domyślnie z football-data.co.uk, gdzie limitów nie ma. */
+
+const AF_BASE = 'https://v3.football.api-sports.io';
+const AF_KEY_STORE = 'lifeos_apifootball_key_v1';
+const AF_CACHE_KEY = 'lifeos_af_cache_v1';
+const AF_TTL = { fixtures: 3 * 60 * 1000, season: 6 * 60 * 60 * 1000, stats: 30 * 24 * 60 * 60 * 1000 };
+const AF_RATE = { max: 9, windowMs: 60 * 1000 };
+const AF_QUOTA_STORE = 'lifeos_af_quota_v1';
+
+/* Identyfikatory lig API-Football sprawdzone przez /leagues i zestawione
+   z kodami dywizji football-data.co.uk. */
+const AF_LEAGUE_TO_DIV = {
+  39: 'E0', 40: 'E1', 41: 'E2', 42: 'E3', 43: 'EC',
+  179: 'SC0', 180: 'SC1', 183: 'SC2', 184: 'SC3',
+  78: 'D1', 79: 'D2', 135: 'I1', 136: 'I2', 140: 'SP1', 141: 'SP2',
+  61: 'F1', 62: 'F2', 88: 'N1', 144: 'B1', 94: 'P1', 203: 'T1', 197: 'G1',
+  106: 'POL', 253: 'USA', 71: 'BRA', 128: 'ARG', 218: 'AUT', 207: 'SWZ',
+  119: 'DNK', 103: 'NOR', 113: 'SWE', 98: 'JPN', 262: 'MEX', 283: 'ROU',
+  235: 'RUS', 169: 'CHN', 244: 'FIN', 357: 'IRL'
+};
+const DIV_TO_AF_LEAGUE = Object.fromEntries(Object.entries(AF_LEAGUE_TO_DIV).map(([id, div]) => [div, Number(id)]));
+
+/* Nazwy statystyk API-Football przełożone na pola naszego modelu meczu. */
+const AF_STAT_MAP = {
+  'Corner Kicks': 'c', 'Total Shots': 's', 'Shots on Goal': 'st',
+  Fouls: 'f', 'Yellow Cards': 'y', 'Red Cards': 'r', expected_goals: 'xg'
+};
+
+const AF_STATUS_LIVE = new Set(['1H', 'HT', '2H', 'ET', 'BT', 'P', 'LIVE', 'INT']);
+const AF_STATUS_DONE = new Set(['FT', 'AET', 'PEN']);
+
 /* ---------- STAŁE ---------- */
 
 const CACHE_KEY = 'lifeos_fd_cache_v1';
@@ -111,10 +153,18 @@ const state = {
   analysis: null,
   proxy: null,
   busy: false,
-  loadedLabel: ''
+  loadedLabel: '',
+  /* API-Football */
+  apiKey: '',
+  afQuota: null,
+  afDay: 0,
+  afFixtures: [],
+  afLeagueFilter: '',
+  afLoaded: false
 };
 
 let cache = {};
+let afCache = {};
 
 /* ---------- NARZĘDZIA ---------- */
 
@@ -144,6 +194,14 @@ function toast(message, kind = '') {
 function mean(values) {
   const valid = values.filter(Number.isFinite);
   return valid.length ? valid.reduce((sum, value) => sum + value, 0) / valid.length : null;
+}
+
+/* Data w formacie YYYY-MM-DD liczona lokalnie, bo terminarz pytamy
+   o „dziś” w strefie użytkownika, a nie w UTC. */
+function todayISO(offset = 0) {
+  const date = new Date();
+  date.setDate(date.getDate() + offset);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 }
 
 /* Kody sezonów football-data: 2526 = 2025/26. Nowy sezon liczymy od lipca. */
@@ -229,12 +287,26 @@ function savePrefs() {
   try { localStorage.setItem(PREFS_KEY, JSON.stringify({ leagueId, seasons, venueSplit, focusWindow, proxy })); } catch { /* opcjonalne */ }
 }
 
+/* Klucz API trzymamy osobno od reszty ustawień i wyłącznie w tej
+   przeglądarce — nie trafia do żadnego pliku w repozytorium. */
+function loadApiKey() {
+  try { state.apiKey = localStorage.getItem(AF_KEY_STORE) || ''; } catch { state.apiKey = ''; }
+}
+
+function saveApiKey(value) {
+  state.apiKey = value.trim();
+  try {
+    if (state.apiKey) localStorage.setItem(AF_KEY_STORE, state.apiKey);
+    else localStorage.removeItem(AF_KEY_STORE);
+  } catch { /* prywatny tryb przeglądarki */ }
+}
+
 /* ---------- POBIERANIE ---------- */
 
-async function fetchWithTimeout(url, ms = 30000) {
+async function fetchWithTimeout(url, ms = 30000, headers = null) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), ms);
-  try { return await fetch(url, { signal: controller.signal }); }
+  try { return await fetch(url, headers ? { signal: controller.signal, headers } : { signal: controller.signal }); }
   finally { clearTimeout(timer); }
 }
 
@@ -284,6 +356,215 @@ async function getMatches(target, ttl) {
   cache[target] = { ts: Date.now(), rows: rows.map(packMatch) };
   saveCache();
   return rows;
+}
+
+/* ---------- WARSTWA API-FOOTBALL ---------- */
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+const afCalls = [];
+
+function loadAfCache() {
+  try { afCache = JSON.parse(localStorage.getItem(AF_CACHE_KEY) || '{}') || {}; } catch { afCache = {}; }
+}
+
+function saveAfCache() {
+  try {
+    let payload = JSON.stringify(afCache);
+    while (payload.length > CACHE_BUDGET) {
+      const oldest = Object.entries(afCache).sort((a, b) => a[1].ts - b[1].ts)[0];
+      if (!oldest) break;
+      delete afCache[oldest[0]];
+      payload = JSON.stringify(afCache);
+    }
+    localStorage.setItem(AF_CACHE_KEY, payload);
+  } catch { /* cache jest opcjonalny */ }
+}
+
+/* Plan Free dopuszcza 10 zapytań na minutę — kolejkujemy, zamiast dostawać 429. */
+async function afThrottle(onWait) {
+  for (;;) {
+    const now = Date.now();
+    while (afCalls.length && now - afCalls[0] >= AF_RATE.windowMs) afCalls.shift();
+    if (afCalls.length < AF_RATE.max) { afCalls.push(now); return; }
+    const wait = AF_RATE.windowMs - (now - afCalls[0]) + 300;
+    if (onWait) onWait(Math.ceil(wait / 1000));
+    await sleep(Math.min(wait, 5000));
+  }
+}
+
+/* Licznik zapytań trzymamy sami. Nagłówki x-ratelimit-* są wprawdzie
+   wysyłane, ale api-sports.io nie ustawia Access-Control-Expose-Headers,
+   więc z poziomu przeglądarki headers.get() zwraca dla nich null.
+   Wartość autorytatywną pobiera przycisk „Sprawdź połączenie” z /status. */
+function afQuotaLoad() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(AF_QUOTA_STORE) || 'null');
+    if (saved && saved.date === todayISO()) return saved;
+  } catch { /* licznik odtworzymy od zera */ }
+  return { date: todayISO(), used: 0, limit: 100 };
+}
+
+function afQuotaSave(quota) {
+  state.afQuota = quota;
+  try { localStorage.setItem(AF_QUOTA_STORE, JSON.stringify(quota)); } catch { /* opcjonalne */ }
+  renderQuota();
+}
+
+function afQuotaBump() {
+  const quota = afQuotaLoad();
+  afQuotaSave({ ...quota, used: quota.used + 1 });
+}
+
+function afQuotaSync(used, limit) {
+  afQuotaSave({ date: todayISO(), used, limit: limit || 100 });
+}
+
+async function afGet(path, params, ttl, onWait) {
+  if (!state.apiKey) throw new Error('Brak klucza API-Football. Wklej go w sekcji „Klucz API-Football”.');
+  const query = new URLSearchParams(params).toString();
+  const key = `${path}?${query}`;
+  const hit = afCache[key];
+  if (hit && Date.now() - hit.ts < ttl) return hit.data;
+
+  await afThrottle(onWait);
+  let response;
+  try {
+    response = await fetchWithTimeout(`${AF_BASE}/${path}?${query}`, 30000, { 'x-apisports-key': state.apiKey });
+  } catch (error) {
+    throw new Error(`API-Football nie odpowiada: ${error.name === 'AbortError' ? 'przekroczony czas' : error.message}`);
+  }
+  afQuotaBump();
+  if (response.status === 429) throw new Error('API-Football: wyczerpany limit zapytań. Spróbuj za chwilę lub jutro.');
+  if (!response.ok) throw new Error(`API-Football zwróciło HTTP ${response.status}.`);
+  const data = await response.json();
+
+  /* Błędy przychodzą w polu errors z kodem 200 — czasem jako obiekt, czasem jako pusta tablica. */
+  const errors = data.errors;
+  if (errors && !Array.isArray(errors) && Object.keys(errors).length) {
+    throw new Error(`API-Football: ${Object.values(errors).join(' ')}`);
+  }
+  afCache[key] = { ts: Date.now(), data };
+  saveAfCache();
+  return data;
+}
+
+function afStatusKind(short) {
+  if (AF_STATUS_DONE.has(short)) return 'done';
+  if (AF_STATUS_LIVE.has(short)) return 'live';
+  if (['PST', 'CANC', 'ABD', 'SUSP', 'AWD', 'WO'].includes(short)) return 'off';
+  return 'next';
+}
+
+function afNormalizeFixture(entry) {
+  const { fixture, league, teams, goals } = entry;
+  return {
+    id: fixture.id,
+    ts: Date.parse(fixture.date),
+    status: fixture.status.short,
+    kind: afStatusKind(fixture.status.short),
+    elapsed: fixture.status.elapsed,
+    leagueId: league.id,
+    leagueName: league.name,
+    country: league.country,
+    season: league.season,
+    round: league.round || '',
+    div: AF_LEAGUE_TO_DIV[league.id] || null,
+    home: teams.home.name,
+    away: teams.away.name,
+    homeId: teams.home.id,
+    awayId: teams.away.id,
+    goalsHome: goals.home,
+    goalsAway: goals.away
+  };
+}
+
+async function afFetchFixtures(offset) {
+  const date = todayISO(offset);
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'Europe/Warsaw';
+  const data = await afGet('fixtures', { date, timezone }, AF_TTL.fixtures);
+  return (data.response || []).map(afNormalizeFixture).sort((a, b) => a.ts - b.ts);
+}
+
+/* Statystyki jednego meczu -> nasz kanoniczny rekord. Kosztuje 1 zapytanie. */
+async function afFetchStats(fixtureId, onWait) {
+  const data = await afGet('fixtures/statistics', { fixture: fixtureId }, AF_TTL.stats, onWait);
+  const rows = data.response || [];
+  if (rows.length < 2) return null;
+  const read = row => {
+    const out = {};
+    for (const item of row.statistics || []) {
+      const field = AF_STAT_MAP[item.type];
+      if (!field) continue;
+      const raw = item.value;
+      out[field] = raw === null || raw === undefined ? null : Number(String(raw).replace('%', ''));
+    }
+    return out;
+  };
+  return { homeId: rows[0].team.id, home: read(rows[0]), away: read(rows[1]) };
+}
+
+/* ---------- MOSTEK NAZW DRUŻYN ----------
+   API-Football pisze „Manchester City", football-data.co.uk „Man City".
+   Dopasowujemy tokenami: równe, prefiks albo podciąg liter w kolejności
+   („nottm" wewnątrz „nottingham"). Gdy pewności brak — użytkownik wybiera ręcznie. */
+
+const NAME_NOISE = new Set(['fc', 'cf', 'afc', 'sc', 'ac', 'as', 'ss', 'us', 'sv', 'vfb', 'vfl',
+  'bv', 'bsc', 'cd', 'ud', 'rc', 'sd', 'ca', 'club', 'de', 'the', 'calcio', 'futbol', 'football', 'sport']);
+
+function nameTokens(name) {
+  return String(name).toLowerCase()
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim().split(' ')
+    .filter(token => token && !NAME_NOISE.has(token));
+}
+
+function isSubsequence(short, long) {
+  let i = 0;
+  for (const char of long) if (char === short[i] && ++i === short.length) return true;
+  return i === short.length;
+}
+
+function commonPrefix(a, b) {
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return i;
+}
+
+function tokenMatch(a, b) {
+  if (a === b) return true;
+  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
+  if (short.length < 3) return false;
+  if (long.startsWith(short)) return true;
+  /* Skróty typu „nottm” wewnątrz „nottingham”. Sam podciąg to za mało —
+     bez wspólnego prefiksu „real” pasowałoby do „arsenal”. */
+  return short.length >= 4
+    && long.length <= short.length * 2.5
+    && commonPrefix(short, long) >= 3
+    && isSubsequence(short, long);
+}
+
+function nameScore(a, b) {
+  const left = nameTokens(a), right = nameTokens(b);
+  if (!left.length || !right.length) return 0;
+  const used = new Set();
+  let hits = 0;
+  for (const token of left) {
+    const index = right.findIndex((other, i) => !used.has(i) && tokenMatch(token, other));
+    if (index >= 0) { used.add(index); hits++; }
+  }
+  return (2 * hits) / (left.length + right.length);
+}
+
+/* Zwraca najlepszą nazwę z listy kandydatów albo null, gdy wybór jest niepewny. */
+function bridgeTeam(name, candidates) {
+  const ranked = candidates
+    .map(candidate => ({ candidate, score: nameScore(name, candidate) }))
+    .sort((a, b) => b.score - a.score);
+  if (!ranked.length || ranked[0].score < 0.6) return null;
+  const runnerUp = ranked[1]?.score ?? 0;
+  if (ranked[0].score === runnerUp) return null;
+  return ranked[0].candidate;
 }
 
 /* ---------- NORMALIZACJA ---------- */
@@ -774,6 +1055,210 @@ function renderProxyBadge() {
     : '<strong>football-data.co.uk</strong> · darmowe CSV';
 }
 
+function renderQuota() {
+  const node = el('af-quota');
+  if (!node) return;
+  if (!state.apiKey) { node.innerHTML = '<span class="material-symbols-outlined">key_off</span>Brak klucza'; node.className = 'st-quota'; return; }
+  const quota = state.afQuota || afQuotaLoad();
+  const remaining = Math.max(quota.limit - quota.used, 0);
+  const share = quota.limit ? remaining / quota.limit : 1;
+  node.className = `st-quota ${share <= 0.1 ? 'bad' : share <= 0.3 ? 'warn' : ''}`;
+  node.title = 'Licznik lokalny; „Sprawdź połączenie” synchronizuje go z serwerem';
+  node.innerHTML = `<strong>${remaining}</strong> / ${quota.limit} zapytań dziś`;
+}
+
+function renderKeyPanel() {
+  el('api-key').value = state.apiKey;
+  el('key-state').innerHTML = state.apiKey
+    ? '<span class="material-symbols-outlined ok">check_circle</span>Klucz zapisany w tej przeglądarce'
+    : '<span class="material-symbols-outlined">info</span>Bez klucza działa terminarz z pliku CSV; klucz włącza terminarz live z 39 lig';
+  el('af-block').classList.toggle('is-locked', !state.apiKey);
+  renderQuota();
+}
+
+async function testApiKey() {
+  const button = el('test-key');
+  button.disabled = true;
+  el('key-state').innerHTML = '<span class="material-symbols-outlined spin">progress_activity</span>Sprawdzam klucz…';
+  try {
+    const data = await afGet('status', {}, 0);
+    const account = data.response || {};
+    const plan = account.subscription?.plan || '—';
+    const used = account.requests?.current ?? 0;
+    const limit = account.requests?.limit_day ?? 100;
+    afQuotaSync(used, limit);
+    const free = String(plan).toLowerCase() === 'free';
+    el('key-state').innerHTML = `<span class="material-symbols-outlined ok">check_circle</span>
+      Plan <strong>${esc(plan)}</strong> · wykorzystano ${used} z ${limit} zapytań
+      ${free ? '· terminarz dziś/jutro dostępny, historia meczów zablokowana na tym planie' : ''}`;
+    el('af-block').classList.remove('is-locked');
+  } catch (error) {
+    el('key-state').innerHTML = `<span class="material-symbols-outlined bad">error</span>${esc(error.message)}`;
+  } finally {
+    button.disabled = false;
+  }
+}
+
+/* ---------- TERMINARZ LIVE ---------- */
+
+function afDayLabel(offset) {
+  const date = new Date(`${todayISO(offset)}T12:00:00`);
+  return date.toLocaleDateString('pl-PL', { weekday: 'long', day: '2-digit', month: 'long' });
+}
+
+async function loadAfFixtures() {
+  if (state.busy) return;
+  if (!state.apiKey) { toast('Najpierw zapisz klucz API-Football', 'err'); return; }
+  state.busy = true;
+  el('af-load').disabled = true;
+  el('af-body').innerHTML = `<div class="st-note"><span class="material-symbols-outlined spin">progress_activity</span>
+    <span>Pobieram terminarz na ${esc(afDayLabel(state.afDay))}…</span></div>`;
+  try {
+    state.afFixtures = await afFetchFixtures(state.afDay);
+    state.afLoaded = true;
+    renderAfFixtures();
+    setStep(2);
+    el('step2-sub').textContent = `${state.afFixtures.length} meczów`;
+  } catch (error) {
+    state.afLoaded = false;
+    el('af-body').innerHTML = `<div class="st-note bad"><span class="material-symbols-outlined">error</span><span>${esc(error.message)}</span></div>`;
+    toast(error.message, 'err');
+  } finally {
+    state.busy = false;
+    el('af-load').disabled = false;
+  }
+}
+
+function afStatusTag(fixture) {
+  if (fixture.kind === 'live') {
+    return `<span class="st-status live">${esc(fixture.status)}${fixture.elapsed ? ` ${fixture.elapsed}'` : ''}</span>`;
+  }
+  if (fixture.kind === 'done') return '<span class="st-status ft">Koniec</span>';
+  if (fixture.kind === 'off') return `<span class="st-status off">${esc(fixture.status)}</span>`;
+  return `<span class="st-status ns">${new Date(fixture.ts).toLocaleTimeString('pl-PL', { hour: '2-digit', minute: '2-digit' })}</span>`;
+}
+
+function renderAfFixtures() {
+  if (!state.afLoaded) return;
+  const query = state.afLeagueFilter.trim().toLowerCase();
+  const visible = state.afFixtures.filter(fixture =>
+    !query || `${fixture.leagueName} ${fixture.country} ${fixture.home} ${fixture.away}`.toLowerCase().includes(query));
+
+  if (!visible.length) {
+    el('af-summary').textContent = `0 z ${state.afFixtures.length} meczów pasuje do filtra`;
+    el('af-body').innerHTML = `<div class="st-note"><span class="material-symbols-outlined">event_busy</span>
+      <span>Brak meczów pasujących do filtra (pobrano ${state.afFixtures.length}).</span></div>`;
+    return;
+  }
+
+  /* Ligi, które mamy w CSV, idą na górę — tylko dla nich policzymy macierze. */
+  const groups = new Map();
+  for (const fixture of visible) {
+    const key = `${fixture.country} — ${fixture.leagueName}`;
+    if (!groups.has(key)) groups.set(key, { key, div: fixture.div, list: [] });
+    groups.get(key).list.push(fixture);
+  }
+  const ordered = [...groups.values()].sort((a, b) =>
+    (b.div ? 1 : 0) - (a.div ? 1 : 0) || a.key.localeCompare(b.key, 'pl'));
+
+  const covered = ordered.filter(group => group.div).length;
+  el('af-summary').textContent =
+    `${visible.length} meczów · ${ordered.length} rozgrywek · ${covered} z pełną statystyką historyczną`;
+
+  el('af-body').innerHTML = ordered.map(group => `
+    <div class="st-fx-group">
+      <div class="st-fx-head">
+        <strong>${esc(group.key)}</strong>
+        <span>${group.div
+          ? `<span class="st-badge ok">macierze dostępne</span>`
+          : `<span class="st-badge">brak historii w CSV</span>`} ${group.list.length} mecz(e)</span>
+      </div>
+      <div class="tc-tbl-wrap">
+        <table class="tc-tbl st-fx-tbl">
+          <tbody>${group.list.map(fixture => `
+            <tr>
+              <td class="st-fx-status">${afStatusTag(fixture)}</td>
+              <td class="st-fx-name"><strong>${esc(fixture.home)}</strong></td>
+              <td class="mono num st-fx-score">${fixture.goalsHome === null ? '–' : `${fixture.goalsHome} : ${fixture.goalsAway}`}</td>
+              <td class="st-fx-name">${esc(fixture.away)}</td>
+              <td class="num">${group.div
+                ? `<button class="st-btn primary" data-af="${fixture.id}"><span class="material-symbols-outlined">insights</span>Analizuj</button>`
+                : '<span class="st-muted">—</span>'}</td>
+            </tr>`).join('')}</tbody>
+        </table>
+      </div>
+    </div>`).join('');
+
+  el('af-body').querySelectorAll('[data-af]').forEach(button =>
+    button.addEventListener('click', () => analyseAfFixture(Number(button.dataset.af))));
+}
+
+/* Wczytuje dywizję CSV odpowiadającą meczowi, jeśli nie jest jeszcze w pamięci. */
+async function ensureLeague(div) {
+  if (state.leagueId === div && state.matches.length) return;
+  const matches = await loadDivision(div, state.seasons);
+  if (!matches.length) throw new Error(`Brak danych CSV dla ligi ${div}.`);
+  state.leagueId = div;
+  state.matches = matches.sort((a, b) => b.ts - a.ts);
+  state.teams = indexTeams(state.matches);
+  const league = LEAGUE_BY_ID.get(div);
+  state.loadedLabel = `${league.country} · ${league.name}`;
+  savePrefs();
+  renderLeaguePicker();
+  renderTeamPickers();
+  el('step1-sub').textContent = state.loadedLabel;
+}
+
+async function analyseAfFixture(fixtureId) {
+  const fixture = state.afFixtures.find(item => item.id === fixtureId);
+  if (!fixture || !fixture.div) return;
+  if (state.busy) return;
+  state.busy = true;
+  el('analysis-block').style.display = '';
+  el('analysis').innerHTML = `<section class="tc-card"><div class="tc-empty">
+    <span class="material-symbols-outlined spin">progress_activity</span><h4>Przygotowuję analizę…</h4>
+    <p>Wczytuję historię ligi ${esc(fixture.div)} i dopasowuję nazwy drużyn.</p></div></section>`;
+  try {
+    await ensureLeague(fixture.div);
+    const home = bridgeTeam(fixture.home, state.teams);
+    const away = bridgeTeam(fixture.away, state.teams);
+    state.busy = false;
+    if (!home || !away) {
+      renderBridgePrompt(fixture, home, away);
+      return;
+    }
+    runAnalysis(home, away, null);
+  } catch (error) {
+    state.busy = false;
+    el('analysis').innerHTML = `<section class="tc-card"><div class="tc-empty">
+      <span class="material-symbols-outlined">error</span><h4>Nie udało się przygotować analizy</h4>
+      <p>${esc(error.message)}</p></div></section>`;
+    toast(error.message, 'err');
+  }
+}
+
+/* Gdy automat nie ma pewności, kogo dotyczy mecz, pytamy zamiast zgadywać. */
+function renderBridgePrompt(fixture, home, away) {
+  const options = selected => ['<option value="">— wybierz —</option>',
+    ...state.teams.map(team => `<option value="${esc(team)}" ${team === selected ? 'selected' : ''}>${esc(team)}</option>`)].join('');
+  el('analysis').innerHTML = `<section class="tc-card">
+    <div class="tc-card-head"><h3><span class="material-symbols-outlined">link_off</span>Dopasuj drużyny</h3></div>
+    <div class="st-note warn"><span class="material-symbols-outlined">info</span>
+      <span>API-Football podaje <strong>${esc(fixture.home)}</strong> i <strong>${esc(fixture.away)}</strong>,
+      ale w danych CSV nie znalazłem jednoznacznego odpowiednika. Wskaż drużyny ręcznie.</span></div>
+    <div class="st-controls">
+      <label class="st-field wide"><span>Gospodarz (${esc(fixture.home)})</span><select id="bridge-home">${options(home)}</select></label>
+      <label class="st-field wide"><span>Gość (${esc(fixture.away)})</span><select id="bridge-away">${options(away)}</select></label>
+      <button class="st-btn primary" id="bridge-go"><span class="material-symbols-outlined">insights</span>Analizuj</button>
+    </div>
+  </section>`;
+  el('bridge-go').addEventListener('click', () => {
+    const picked = [el('bridge-home').value, el('bridge-away').value];
+    if (!picked[0] || !picked[1]) { toast('Wybierz obie drużyny', 'err'); return; }
+    runAnalysis(picked[0], picked[1], null);
+  });
+}
+
 function renderLeaguePicker() {
   const optionsFor = list => list.map(league =>
     `<option value="${esc(league.id)}" ${state.leagueId === league.id ? 'selected' : ''}>${esc(league.country)} — ${esc(league.name)}</option>`).join('');
@@ -1243,16 +1728,22 @@ async function detectLocalProxy() {
 
 function clearCache() {
   cache = {};
-  try { localStorage.removeItem(CACHE_KEY); } catch { /* nic nie szkodzi */ }
+  afCache = {};
+  try { localStorage.removeItem(CACHE_KEY); localStorage.removeItem(AF_CACHE_KEY); } catch { /* nic nie szkodzi */ }
   fetch('api/fd/purge').catch(() => {});
   toast('Cache wyczyszczony — kolejne pobranie pójdzie do źródła');
 }
 
 function init() {
   loadPrefs();
+  loadApiKey();
   loadCache();
+  loadAfCache();
+  state.afQuota = afQuotaLoad();
   renderLeaguePicker();
   renderProxyBadge();
+  renderKeyPanel();
+  el('af-day-label').textContent = afDayLabel(state.afDay);
   setStep(1);
   document.querySelectorAll('.sidebar__link[data-page]').forEach(link =>
     link.classList.toggle('sidebar__link--active', link.dataset.page === 'stats'));
@@ -1278,6 +1769,24 @@ function init() {
     el('away-select').value = home;
   });
   el('clear-cache-btn').addEventListener('click', clearCache);
+
+  el('save-key').addEventListener('click', () => {
+    saveApiKey(el('api-key').value);
+    renderKeyPanel();
+    toast(state.apiKey ? 'Klucz zapisany lokalnie' : 'Klucz usunięty');
+  });
+  el('test-key').addEventListener('click', () => { saveApiKey(el('api-key').value); testApiKey(); });
+  el('af-day-seg').querySelectorAll('button').forEach(button =>
+    button.addEventListener('click', () => {
+      state.afDay = Number(button.dataset.day);
+      el('af-day-seg').querySelectorAll('button').forEach(item => item.classList.toggle('active', item === button));
+      el('af-day-label').textContent = afDayLabel(state.afDay);
+      state.afLoaded = false;
+      el('af-body').innerHTML = '';
+      el('af-summary').textContent = '';
+    }));
+  el('af-load').addEventListener('click', loadAfFixtures);
+  el('af-filter').addEventListener('input', event => { state.afLeagueFilter = event.target.value; renderAfFixtures(); });
 
   detectLocalProxy();
 }

--- a/stats.js
+++ b/stats.js
@@ -160,7 +160,14 @@ const state = {
   afDay: 0,
   afFixtures: [],
   afLeagueFilter: '',
-  afLoaded: false
+  afLoaded: false,
+  /* Skaner dnia */
+  scanRows: [],
+  scanSkipped: [],
+  scanDone: false,
+  scanUpcomingOnly: true,
+  scanMinCoverage: 0.6,
+  scanGroup: 'all'
 };
 
 let cache = {};
@@ -705,13 +712,17 @@ const GROUPS = [
 ];
 
 /* Rynki zerojedynkowe — bez linii, liczone tak samo jak pokrycie. */
+/* „Czyste konto" to dokładnie „gole stracone pon. 0,5", a „drużyna nie
+   strzeli" to „gole strzelone pon. 0,5". W macierzy zdarzeń zostają, bo
+   pod tymi nazwami szuka się ich u bukmachera, ale ze skrótu typów i ze
+   skanera są wyłączone — inaczej ten sam rynek zajmowałby dwa wiersze. */
 const BOOLEAN_MARKETS = [
   { key: 'btts', label: 'Obie drużyny strzelą', no: 'Któraś drużyna nie strzeli', scope: 'match' },
   { key: 'won', label: 'Wygrana drużyny', no: 'Drużyna nie wygra', scope: 'team' },
   { key: 'lost', label: 'Porażka drużyny', no: 'Drużyna nie przegra', scope: 'team' },
   { key: 'drew', label: 'Remis', no: 'Rozstrzygnięcie', scope: 'match' },
-  { key: 'clean', label: 'Czyste konto', no: 'Drużyna straci gola', scope: 'team' },
-  { key: 'blank', label: 'Drużyna nie strzeli', no: 'Drużyna strzeli gola', scope: 'team' }
+  { key: 'clean', label: 'Czyste konto', no: 'Drużyna straci gola', scope: 'team', duplicateOf: 'gole stracone' },
+  { key: 'blank', label: 'Drużyna nie strzeli', no: 'Drużyna strzeli gola', scope: 'team', duplicateOf: 'gole strzelone' }
 ];
 
 /* ---------- STATYSTYKA ---------- */
@@ -848,12 +859,25 @@ async function loadFixtures() {
   } catch { state.fixtures = []; }
 }
 
+/* Skaner przerabia mecze z wielu lig naraz, więc sparsowane dywizje
+   trzymamy w pamięci — klucz zawiera liczbę sezonów, bo jej zmiana
+   unieważnia pulę. */
+const divisionPool = new Map();
+
+async function getDivisionMatches(div) {
+  const key = `${div}:${state.seasons}`;
+  if (divisionPool.has(key)) return divisionPool.get(key);
+  const matches = (await loadDivision(div, state.seasons)).sort((a, b) => b.ts - a.ts);
+  divisionPool.set(key, matches);
+  return matches;
+}
+
 /* Drużyna po awansie/spadku ma za mało meczów — dobieramy z ligi sąsiedniej. */
-async function topUpTeam(team, needed) {
-  const related = RELATED_DIVISIONS[state.leagueId] || [];
+async function topUpTeam(team, needed, div) {
+  const related = RELATED_DIVISIONS[div] || [];
   const extra = [];
-  for (const div of related) {
-    const rows = await loadDivision(div, state.seasons).catch(() => []);
+  for (const other of related) {
+    const rows = await getDivisionMatches(other).catch(() => []);
     extra.push(...rows.filter(match => match.home === team || match.away === team));
     if (extra.length >= needed) break;
   }
@@ -862,9 +886,10 @@ async function topUpTeam(team, needed) {
 
 /* ---------- ANALIZA ---------- */
 
-async function buildAnalysis(homeTeam, awayTeam, fixture = null) {
+async function buildAnalysis(homeTeam, awayTeam, fixture = null, context = null) {
+  const { div, matches: pool } = context || { div: state.leagueId, matches: state.matches };
   const maxWindow = Math.max(...WINDOWS);
-  const forTeam = team => state.matches
+  const forTeam = team => pool
     .filter(match => match.home === team || match.away === team)
     .map(match => perspective(match, team))
     .sort((a, b) => b.ts - a.ts);
@@ -875,7 +900,7 @@ async function buildAnalysis(homeTeam, awayTeam, fixture = null) {
 
   for (const [team, list, label] of [[homeTeam, home, 'home'], [awayTeam, away, 'away']]) {
     if (list.length >= maxWindow) continue;
-    const extra = await topUpTeam(team, maxWindow - list.length);
+    const extra = await topUpTeam(team, maxWindow - list.length, div);
     if (!extra.length) continue;
     const merged = [...list, ...extra.map(match => perspective(match, team))]
       .filter((record, index, all) => all.findIndex(other => other.ts === record.ts && other.opponent === record.opponent) === index)
@@ -888,7 +913,7 @@ async function buildAnalysis(homeTeam, awayTeam, fixture = null) {
   const homeRecs = state.venueSplit ? home.filter(record => record.venue === 'H') : home;
   const awayRecs = state.venueSplit ? away.filter(record => record.venue === 'A') : away;
 
-  const h2h = state.matches
+  const h2h = pool
     .filter(match => (match.home === homeTeam && match.away === awayTeam) || (match.home === awayTeam && match.away === homeTeam))
     .map(match => perspective(match, homeTeam))
     .sort((a, b) => b.ts - a.ts)
@@ -955,7 +980,7 @@ function modelProb(analysis, key, line) {
    kurs godziwy 1,00, więc na taki rynek i tak nie ma jak zagrać. */
 const CERTAINTY_CAP = 0.93;
 
-function shortlist(analysis) {
+function shortlist(analysis, limit = 12) {
   const picks = [];
   const push = (label, group, samples, modelP) => {
     const pooled = samples.pooled;
@@ -964,7 +989,15 @@ function shortlist(analysis) {
     if (consistent.length < 2) return;
     const worst = Math.min(...consistent.map(w => w.p));
     const lower = wilsonLower(pooled.hits, pooled.n);
-    picks.push({ label, group, p: pooled.p, hits: pooled.hits, n: pooled.n, lower, worst, modelP });
+    /* Najszersze dostępne okno daje najwięcej obserwacji, więc jego granica
+       Wilsona różnicuje typy znacznie lepiej niż okno główne, gdzie próbki
+       bywają identyczne (18/20 wszędzie to ten sam wynik 78%). */
+    const deep = consistent[consistent.length - 1];
+    picks.push({
+      label, group, p: pooled.p, hits: pooled.hits, n: pooled.n, lower, worst, modelP,
+      windows: samples.windows,
+      deepHits: deep.hits, deepN: deep.n, lowerDeep: wilsonLower(deep.hits, deep.n)
+    });
   };
 
   /* Rynki drużynowe pooluje się z prób obu ekip — etykieta musi to mówić. */
@@ -983,6 +1016,7 @@ function shortlist(analysis) {
     }
   }
   for (const market of BOOLEAN_MARKETS) {
+    if (market.duplicateOf) continue;
     const pack = poolBoolean(analysis, market);
     push(scoped(market, market.label), 'Zdarzenia', pack.yes, null);
     push(scoped(market, market.no), 'Zdarzenia', pack.no, null);
@@ -991,7 +1025,7 @@ function shortlist(analysis) {
   return picks
     .filter(pick => pick.worst >= 0.5 && pick.lower >= 0.5 && pick.p <= CERTAINTY_CAP)
     .sort((a, b) => (b.lower - a.lower) || (b.worst - a.worst))
-    .slice(0, 12);
+    .slice(0, limit);
 }
 
 const invert = p => Number.isFinite(p) ? 1 - p : null;
@@ -1116,7 +1150,12 @@ async function loadAfFixtures() {
   try {
     state.afFixtures = await afFetchFixtures(state.afDay);
     state.afLoaded = true;
+    state.scanDone = false;
+    state.scanRows = [];
+    state.scanSkipped = [];
+    el('scan-body').innerHTML = '';
     renderAfFixtures();
+    renderScanAvailability();
     setStep(2);
     el('step2-sub').textContent = `${state.afFixtures.length} meczów`;
   } catch (error) {
@@ -1196,10 +1235,10 @@ function renderAfFixtures() {
 /* Wczytuje dywizję CSV odpowiadającą meczowi, jeśli nie jest jeszcze w pamięci. */
 async function ensureLeague(div) {
   if (state.leagueId === div && state.matches.length) return;
-  const matches = await loadDivision(div, state.seasons);
+  const matches = await getDivisionMatches(div);
   if (!matches.length) throw new Error(`Brak danych CSV dla ligi ${div}.`);
   state.leagueId = div;
-  state.matches = matches.sort((a, b) => b.ts - a.ts);
+  state.matches = matches;
   state.teams = indexTeams(state.matches);
   const league = LEAGUE_BY_ID.get(div);
   state.loadedLabel = `${league.country} · ${league.name}`;
@@ -1257,6 +1296,148 @@ function renderBridgePrompt(fixture, home, away) {
     if (!picked[0] || !picked[1]) { toast('Wybierz obie drużyny', 'err'); return; }
     runAnalysis(picked[0], picked[1], null);
   });
+}
+
+/* ---------- SKANER DNIA ----------
+   Zamiast otwierać mecz po meczu, przeliczamy cały terminarz i układamy
+   jeden ranking rynków. Dane historyczne siedzą już w cache, więc koszt
+   to wyłącznie procesor — żadnych dodatkowych zapytań do API. */
+
+async function scanDay() {
+  if (state.busy) return;
+  const pool = state.afFixtures.filter(fixture => fixture.div);
+  if (!pool.length) {
+    el('scan-body').innerHTML = `<div class="st-note"><span class="material-symbols-outlined">info</span>
+      <span>W pobranym terminarzu nie ma meczów z lig, dla których mamy historię CSV. Pobierz terminarz na inny dzień.</span></div>`;
+    return;
+  }
+  const candidates = state.scanUpcomingOnly ? pool.filter(fixture => fixture.kind !== 'done') : pool;
+  if (!candidates.length) {
+    el('scan-body').innerHTML = `<div class="st-note warn"><span class="material-symbols-outlined">info</span>
+      <span>Wszystkie ${pool.length} meczów z pokryciem CSV jest już rozegranych. Odznacz „tylko nierozpoczęte”, żeby je mimo to przeliczyć.</span></div>`;
+    return;
+  }
+
+  state.busy = true;
+  el('scan-run').disabled = true;
+  const rows = [];
+  const skipped = [];
+  try {
+    for (let i = 0; i < candidates.length; i++) {
+      const fixture = candidates[i];
+      el('scan-body').innerHTML = `<div class="st-note"><span class="material-symbols-outlined spin">progress_activity</span>
+        <span>Przeliczam ${i + 1} z ${candidates.length}: ${esc(fixture.home)} – ${esc(fixture.away)}…</span></div>`;
+      await sleep(0);
+      let matches;
+      try { matches = await getDivisionMatches(fixture.div); }
+      catch { skipped.push({ fixture, why: 'nie udało się pobrać historii ligi' }); continue; }
+      if (!matches.length) { skipped.push({ fixture, why: 'brak danych w CSV' }); continue; }
+
+      const teams = indexTeams(matches);
+      const home = bridgeTeam(fixture.home, teams);
+      const away = bridgeTeam(fixture.away, teams);
+      if (!home || !away) { skipped.push({ fixture, why: 'nie rozpoznano nazw drużyn' }); continue; }
+
+      const analysis = await buildAnalysis(home, away, fixture, { div: fixture.div, matches });
+      for (const pick of shortlist(analysis, 40)) rows.push({ fixture, home, away, pick });
+    }
+    state.scanRows = rows.sort((a, b) =>
+      (b.pick.lowerDeep - a.pick.lowerDeep) || (b.pick.worst - a.pick.worst) || (b.pick.p - a.pick.p));
+    state.scanSkipped = skipped;
+    state.scanDone = true;
+    renderScan();
+  } catch (error) {
+    el('scan-body').innerHTML = `<div class="st-note bad"><span class="material-symbols-outlined">error</span><span>${esc(error.message)}</span></div>`;
+    toast(error.message, 'err');
+  } finally {
+    state.busy = false;
+    el('scan-run').disabled = false;
+  }
+}
+
+function scanWindowCell(sample) {
+  if (!sample) return '<td class="mx-td"><div class="mx empty"><span class="p">—</span></div></td>';
+  return `<td class="mx-td"><div class="mx ${tone(sample.p)}" title="${sample.hits} z ${sample.n}">
+    <span class="p">${fmtPct(sample.p)}</span><span class="h">${sample.hits}/${sample.n}</span></div></td>`;
+}
+
+function renderScan() {
+  if (!state.scanDone) return;
+  const minCoverage = state.scanMinCoverage;
+  const group = state.scanGroup;
+  /* Filtrujemy po surowym pokryciu puli, bo to wartość z etykiety progu.
+     Granica Wilsona zostaje jako kolumna i kryterium sortowania — przy
+     20 obserwacjach nie przekracza ~78%, więc próg 80% byłby nieosiągalny. */
+  const visible = state.scanRows.filter(row =>
+    row.pick.p >= minCoverage && (group === 'all' || row.pick.group === group));
+
+  const groups = [...new Set(state.scanRows.map(row => row.pick.group))].sort((a, b) => a.localeCompare(b, 'pl'));
+  el('scan-group').innerHTML = ['<option value="all">Wszystkie rynki</option>',
+    ...groups.map(name => `<option value="${esc(name)}" ${group === name ? 'selected' : ''}>${esc(name)}</option>`)].join('');
+
+  const fixtures = new Set(visible.map(row => row.fixture.id));
+  el('scan-summary').textContent = state.scanRows.length
+    ? `${visible.length} typów z ${fixtures.size} meczów (przeliczono ${new Set(state.scanRows.map(r => r.fixture.id)).size})`
+    : 'Żaden mecz nie dał typu spełniającego kryteria spójności';
+
+  if (!visible.length) {
+    el('scan-body').innerHTML = `<div class="st-note"><span class="material-symbols-outlined">filter_alt_off</span>
+      <span>Brak typów spełniających filtr. Obniż próg pokrycia albo zmień grupę rynków.</span></div>
+      ${renderScanSkipped()}`;
+    return;
+  }
+
+  const shown = visible.slice(0, 80);
+  el('scan-body').innerHTML = `
+    <div class="st-matrix-wrap">
+      <table class="st-matrix st-scan">
+        <thead>
+          <tr>
+            <th class="lbl">Mecz</th>
+            <th class="lbl">Rynek</th>
+            <th>5</th><th>10</th><th>20</th>
+            <th>Najsłabsze<br><small>okno</small></th>
+            <th>Wilson<br><small>80%</small></th>
+            <th>Kurs<br><small>godziwy</small></th><th></th>
+          </tr>
+        </thead>
+        <tbody>${shown.map(row => `
+          <tr>
+            <td class="lbl">
+              <div class="st-scan-fx"><strong>${esc(row.fixture.home)}</strong> – ${esc(row.fixture.away)}</div>
+              <div class="st-scan-meta">${afStatusTag(row.fixture)} ${esc(row.fixture.country)} · ${esc(row.fixture.leagueName)}</div>
+            </td>
+            <td class="lbl"><span class="st-scan-grp">${esc(row.pick.group)}</span> ${esc(row.pick.label)}</td>
+            ${row.pick.windows.map(scanWindowCell).join('')}
+            <td class="mx-td"><div class="mx ${tone(row.pick.worst)} pooled" title="Najniższe pokrycie wśród okien 5/10/20"><span class="p">${fmtPct(row.pick.worst)}</span><span class="h">min</span></div></td>
+            <td class="mx-td"><div class="mx ${tone(row.pick.lowerDeep)} model" title="Dolna granica Wilsona na najszerszej próbce ${row.pick.deepHits}/${row.pick.deepN}"><span class="p">${fmtPct(row.pick.lowerDeep)}</span><span class="h">${row.pick.deepHits}/${row.pick.deepN}</span></div></td>
+            <td class="mono num strong">${fairOdds(row.pick.lowerDeep)}</td>
+            <td><button class="st-btn" data-scan="${row.fixture.id}"><span class="material-symbols-outlined">insights</span></button></td>
+          </tr>`).join('')}</tbody>
+      </table>
+    </div>
+    ${visible.length > shown.length ? `<div class="st-note"><span class="material-symbols-outlined">more_horiz</span><span>Pokazano 80 najlepszych z ${visible.length}. Zawęź filtr, żeby zobaczyć resztę.</span></div>` : ''}
+    ${renderScanSkipped()}`;
+
+  el('scan-body').querySelectorAll('[data-scan]').forEach(button =>
+    button.addEventListener('click', () => analyseAfFixture(Number(button.dataset.scan))));
+}
+
+function renderScanSkipped() {
+  if (!state.scanSkipped.length) return '';
+  return `<div class="st-note warn"><span class="material-symbols-outlined">info</span>
+    <span>Pominięto ${state.scanSkipped.length}: ${state.scanSkipped
+      .map(item => `${esc(item.fixture.home)} – ${esc(item.fixture.away)} (${esc(item.why)})`).join('; ')}</span></div>`;
+}
+
+/* Skaner ma sens tylko dla lig z historią w CSV — pokazujemy ile ich jest. */
+function renderScanAvailability() {
+  const covered = state.afFixtures.filter(fixture => fixture.div);
+  const upcoming = covered.filter(fixture => fixture.kind !== 'done');
+  el('scan-block').classList.toggle('is-locked', !covered.length);
+  el('scan-summary').textContent = covered.length
+    ? `${covered.length} meczów z historią CSV (${upcoming.length} nierozpoczętych) — przeliczenie nie zużywa limitu API`
+    : 'Pobierz terminarz, żeby zobaczyć, ile meczów ma pokrycie historyczne';
 }
 
 function renderLeaguePicker() {
@@ -1729,6 +1910,7 @@ async function detectLocalProxy() {
 function clearCache() {
   cache = {};
   afCache = {};
+  divisionPool.clear();
   try { localStorage.removeItem(CACHE_KEY); localStorage.removeItem(AF_CACHE_KEY); } catch { /* nic nie szkodzi */ }
   fetch('api/fd/purge').catch(() => {});
   toast('Cache wyczyszczony — kolejne pobranie pójdzie do źródła');
@@ -1744,6 +1926,9 @@ function init() {
   renderProxyBadge();
   renderKeyPanel();
   el('af-day-label').textContent = afDayLabel(state.afDay);
+  el('scan-upcoming').checked = state.scanUpcomingOnly;
+  el('scan-min').value = String(state.scanMinCoverage);
+  renderScanAvailability();
   setStep(1);
   document.querySelectorAll('.sidebar__link[data-page]').forEach(link =>
     link.classList.toggle('sidebar__link--active', link.dataset.page === 'stats'));
@@ -1781,12 +1966,20 @@ function init() {
       state.afDay = Number(button.dataset.day);
       el('af-day-seg').querySelectorAll('button').forEach(item => item.classList.toggle('active', item === button));
       el('af-day-label').textContent = afDayLabel(state.afDay);
+  el('scan-upcoming').checked = state.scanUpcomingOnly;
+  el('scan-min').value = String(state.scanMinCoverage);
+  renderScanAvailability();
       state.afLoaded = false;
       el('af-body').innerHTML = '';
       el('af-summary').textContent = '';
     }));
   el('af-load').addEventListener('click', loadAfFixtures);
   el('af-filter').addEventListener('input', event => { state.afLeagueFilter = event.target.value; renderAfFixtures(); });
+
+  el('scan-run').addEventListener('click', scanDay);
+  el('scan-upcoming').addEventListener('change', event => { state.scanUpcomingOnly = event.target.checked; });
+  el('scan-min').addEventListener('change', event => { state.scanMinCoverage = Number(event.target.value); renderScan(); });
+  el('scan-group').addEventListener('change', event => { state.scanGroup = event.target.value; renderScan(); });
 
   detectLocalProxy();
 }

--- a/stats.js
+++ b/stats.js
@@ -1236,11 +1236,18 @@ function renderProxyWarning(show) {
   if (!banner) return;
   banner.style.display = show ? '' : 'none';
   if (!show) return;
-  const blocked = typeof location !== 'undefined' && (location.protocol === 'file:' || location.protocol === 'https:');
+  const isFile = typeof location !== 'undefined' && location.protocol === 'file:';
+  const blocked = isFile || (typeof location !== 'undefined' && location.protocol === 'https:');
+  /* Przejście na http://localhost to zmiana origin, a więc inny magazyn
+     localStorage — bez uprzedzenia wyglądałoby to jak utrata danych. */
+  const migration = isFile
+    ? ' <br><strong>Uwaga przy przejściu na http://localhost:</strong> to inny origin, więc dane pozostałych modułów '
+      + '(budżet, zadania, zakłady) nie przeniosą się same. Zrób najpierw <em>Eksport</em> na Dashboardzie, '
+      + 'a po otwarciu nowego adresu <em>Import</em>. Terminarz live działa też z file:// — blokowane są tylko pliki CSV.'
+    : '';
   banner.innerHTML = `<span class="material-symbols-outlined">running_with_errors</span>
     <span><strong>${blocked ? 'Lokalne proxy jest zablokowane przez przeglądarkę.' : 'Brak lokalnego proxy.'}</strong>
-    ${esc(environmentHint())}
-    Publiczne pośredniki CORS bywają wyłączane bez ostrzeżenia i wtedy analiza kończy się błędem „Failed to fetch”.</span>`;
+    ${esc(environmentHint())}${migration}</span>`;
 }
 
 function renderProxyBadge() {


### PR DESCRIPTION
## Summary

Completely rewrote the statistics module to use football-data.co.uk as the data source instead of TheSportsDB. The previous implementation was severely limited by TheSportsDB's free tier (3 match records, 5 stat fields), making it unsuitable for meaningful analysis. The new implementation provides comprehensive match statistics including corners, fouls, and cards across 38 football leagues.

## Key Changes

- **Data Source Migration**: Switched from TheSportsDB API to football-data.co.uk CSV files
  - Supports 22 primary leagues (England 5 tiers, Scotland 4, Germany, Italy, Spain, France, Netherlands, Belgium, Portugal, Turkey, Greece)
  - Supports 16 additional leagues with limited stats (goals and odds only)
  - No API key required, no rate limits

- **Proxy System**: Implemented multi-proxy fallback mechanism for CORS handling
  - Local Node.js proxy (server.js) as primary option
  - Automatic fallback to public proxies (allorigins.win, codetabs.com, r.jina.ai)
  - Disk caching on server, browser localStorage caching with 3.5MB budget

- **CSV Parsing**: Built custom CSV parser with quote handling for referee names and proper date/time parsing

- **Enhanced Statistics**: Now tracks complete match data:
  - Goals (full-time, half-time)
  - Shots (total and on target)
  - Corners, fouls, yellow/red cards
  - Closing odds for 1X2, Over/Under 2.5, Asian Handicap

- **Analysis Engine**: Implemented Poisson distribution model for match outcome probabilities and coverage analysis
  - Wilson score lower bound for confidence intervals
  - Empirical coverage tracking across 5/10/20 match windows
  - Venue split analysis (home/away)
  - Multi-season aggregation (1-4 seasons configurable)

- **UI Overhaul**: Redesigned interface with new workflow
  - Step-by-step process: league selection → fixtures → match analysis → coverage matrices
  - Dynamic market groups (goals, corners, cards, shots, fouls)
  - Boolean markets (BTTS, clean sheet, etc.)
  - Real-time proxy status indicator

- **Server Implementation**: Added Node.js server (server.js) for local proxy and static file serving
  - Disk caching with separate TTLs for fixtures (30min) and seasons (6hr)
  - Path validation to prevent arbitrary file access
  - CORS headers and proper error handling

- **Preferences Persistence**: Saves user selections (league, seasons, window, proxy) to localStorage

## Notable Implementation Details

- Compact match storage format using field arrays to minimize cache size
- Automatic season code calculation (2526 = 2025/26, new season from July)
- Graceful degradation when stats unavailable (shows which categories missing)
- Timeout handling (30s) with automatic proxy switching on failure
- Color-coded confidence tones (t1-t6) based on probability ranges

https://claude.ai/code/session_01UhyiwSeincCRan7ihU9rtx