### PR TITLE
Dodaj lejek kapitału do zakładki Przegląd (UI, CSS, render logic)

### DIFF
--- a/CARDS.md
+++ b/CARDS.md
@@ -18,7 +18,7 @@ Dane siedzą w `localStorage` pod kluczem **`lifeos_cards_v1`**.
 
 | Zakładka | Do czego służy |
 |---|---|
-| **Przegląd** | Wartość kolekcji, wynik łączny, krzywa wyceny vs koszt, lista „do zrobienia", ruchy wyceny, najcenniejsze karty |
+| **Przegląd** | Wartość kolekcji, lejek kapitału od zakupu przez stock do sprzedaży, wynik łączny, krzywa wyceny vs koszt, lista „do zrobienia", ruchy wyceny, najcenniejsze karty |
 | **Kolekcja** | Tabela kart z filtrami i sortowaniem, szczegóły karty z historią wyceny i osią zdarzeń |
 | **Boxy i breaki** | Sealed na stanie, wynik każdego breaka, EV produktów, flipy sealed |
 | **Sprzedaż** | Pipeline wystawionych, historia transakcji z rozbiciem na prowizje, analiza kanałów |

--- a/cards.css
+++ b/cards.css
@@ -313,6 +313,54 @@ body[data-page="cards"] .tc-kpi[data-tone="accent"] {
 body[data-page="cards"] .tc-kpi .v { font-size: 20px; }
 
 /* ============================================================
+   Lejek kapitału — koszt → stock → sprzedaż
+   ============================================================ */
+.cd-funnel { overflow: hidden; }
+.cd-funnel-head {
+  display: flex; justify-content: space-between; align-items: flex-start; gap: 20px;
+  padding: 17px 19px 14px; border-bottom: 1px solid var(--tc-line);
+}
+.cd-funnel-head h3 { margin: 0; font-size: 14px; color: var(--tc-ink); }
+.cd-funnel-head p { margin: 5px 0 0; max-width: 680px; font-size: 11.5px; line-height: 1.45; color: var(--tc-muted); }
+.cd-funnel-badge { padding: 6px 10px; border-radius: 999px; background: var(--tc-pos-tint); color: var(--tc-pos); font-size: 10.5px; font-weight: 700; white-space: nowrap; }
+.cd-funnel-table-wrap { overflow-x: auto; }
+.cd-funnel-table { width: 100%; border-collapse: collapse; min-width: 760px; font-size: 12px; }
+.cd-funnel-table th { padding: 9px 14px; background: var(--tc-surface); color: var(--tc-muted); font-size: 9.5px; letter-spacing: .07em; text-transform: uppercase; text-align: left; }
+.cd-funnel-table th.num, .cd-funnel-table td.num { text-align: right; }
+.cd-funnel-table td { padding: 12px 14px; border-top: 1px solid var(--tc-line); color: var(--tc-ink-2); vertical-align: middle; }
+.cd-funnel-table tbody tr.is-paper td { color: var(--tc-muted); background: #fbfcfe; }
+.cd-funnel-table td.pos, .cd-funnel-summary .pos { color: var(--tc-pos) !important; }
+.cd-funnel-table td.neg, .cd-funnel-summary .neg { color: var(--tc-neg) !important; }
+.cd-funnel-table td.num small { display: block; margin-top: 2px; color: var(--tc-muted-2); font-family: Inter, sans-serif; font-size: 9.5px; }
+.cd-funnel-stage { display: flex; align-items: center; gap: 10px; min-width: 245px; }
+.cd-funnel-stage strong { display: block; color: var(--tc-ink); font-size: 12px; }
+.cd-funnel-stage small { display: block; margin-top: 2px; color: var(--tc-muted); font-size: 10px; }
+.cd-funnel-icon { width: 30px; height: 30px; display: grid; place-items: center; flex: 0 0 auto; border-radius: 9px; background: var(--tc-surface); color: var(--tc-muted); }
+.cd-funnel-icon .material-symbols-outlined { font-size: 17px; }
+.cd-funnel-icon.realized { background: var(--tc-pos-tint); color: var(--tc-pos); }
+.cd-funnel-icon.paper { background: var(--tc-accent-tint); color: var(--tc-accent); }
+.cd-funnel-icon.sealed { background: var(--cd-gold-tint); color: var(--cd-gold); }
+.cd-funnel-bar { display: block; width: 190px; height: 3px; margin: 7px 0 0 40px; border-radius: 2px; background: var(--tc-line); overflow: hidden; }
+.cd-funnel-bar i { display: block; height: 100%; border-radius: inherit; background: var(--tc-muted-2); opacity: .7; }
+.cd-funnel-bar i.realized { background: var(--tc-pos); opacity: 1; }
+.cd-funnel-bar i.paper { background: var(--tc-accent); }
+.cd-funnel-bar i.sealed { background: var(--cd-gold); }
+.cd-funnel-table tfoot td { border-top: 2px solid var(--tc-line-strong); background: var(--tc-surface); color: var(--tc-ink); font-weight: 700; }
+.cd-funnel-summary { display: grid; grid-template-columns: repeat(4, 1fr); border-top: 1px solid var(--tc-line); }
+.cd-funnel-summary > div { padding: 12px 15px; border-right: 1px solid var(--tc-line); }
+.cd-funnel-summary > div:last-child { border-right: 0; }
+.cd-funnel-summary span { display: block; color: var(--tc-muted); font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; }
+.cd-funnel-summary strong { display: block; margin-top: 3px; color: var(--tc-ink); font: 600 15px var(--mono); }
+.cd-funnel-summary .paper { background: #fbfcfe; opacity: .82; }
+.cd-funnel-summary .total { background: var(--tc-accent-tint); }
+@media (max-width: 800px) {
+  .cd-funnel-head { flex-direction: column; gap: 10px; }
+  .cd-funnel-summary { grid-template-columns: repeat(2, 1fr); }
+  .cd-funnel-summary > div:nth-child(2) { border-right: 0; }
+  .cd-funnel-summary > div:nth-child(-n+2) { border-bottom: 1px solid var(--tc-line); }
+}
+
+/* ============================================================
    Alerty / lista zadań
    ============================================================ */
 .cd-alert {

--- a/cards.html
+++ b/cards.html
@@ -123,6 +123,24 @@
           </div>
 
           <div class="cd-section">
+            <span class="ico"><span class="material-symbols-outlined">account_tree</span></span>
+            <h2>Lejek kapitału</h2>
+            <span class="desc">Od zakupu do zrealizowanego wyniku</span>
+            <span class="line"></span>
+          </div>
+          <section class="tc-card cd-funnel" aria-labelledby="funnel-title">
+            <div class="cd-funnel-head">
+              <div>
+                <h3 id="funnel-title">Gdzie są Twoje pieniądze</h3>
+                <p>Koszt pokazuje, ile kapitału przypada na dany etap. Wartość kart na stanie i ich wynik są jeszcze papierowe.</p>
+              </div>
+              <span class="cd-funnel-badge" id="funnel-recovered">—</span>
+            </div>
+            <div class="cd-funnel-table-wrap" id="funnel-wrap"></div>
+            <div class="cd-funnel-summary" id="funnel-summary"></div>
+          </section>
+
+          <div class="cd-section">
             <span class="ico"><span class="material-symbols-outlined">query_stats</span></span>
             <h2>Kluczowe wskaźniki</h2>
             <span class="desc" id="kpi-desc">—</span>

--- a/cards.js
+++ b/cards.js
@@ -670,10 +670,65 @@ function renderOverview() {
   setKpi('k-overhead', fmtPLN0(M.overhead), M.cashOut > 0 ? `${fmtPct(M.overhead / M.cashOut * 100, false)} wszystkich kosztów` : '—');
   setKpi('k-cash', fmtPLN0(M.netCash, true), M.netCash < 0 ? 'tyle jeszcze nie wróciło' : 'jesteś na plusie kasowo', posClass(M.netCash));
 
+  renderCapitalFunnel();
   renderEquityChart(series);
   renderTodo();
   renderMovers();
   renderTopCards();
+}
+
+function renderCapitalFunnel() {
+  const soldBasis = sum(M.sales, sale => sale.basis);
+  const otherCost = Math.max(0, M.cashOut - soldBasis - M.heldBasis - M.sealedValue);
+  const otherValue = M.bulkValue;
+  const rows = [
+    {
+      tone: 'realized', icon: 'check_circle', label: 'Sprzedany towar',
+      sub: `${M.sales.length} ${plural(M.sales.length, 'zamknięta transakcja', 'zamknięte transakcje', 'zamkniętych transakcji')}`,
+      cost: soldBasis, value: M.cashIn, pnl: M.cashIn - soldBasis, paper: false
+    },
+    {
+      tone: 'paper', icon: 'style', label: 'Karty na stanie',
+      sub: `${nCards(M.held.length)} · wycena rynkowa`,
+      cost: M.heldBasis, value: M.heldValue, pnl: M.unrealized, paper: true
+    },
+    {
+      tone: 'sealed', icon: 'package_2', label: 'Nieotwarte boxy',
+      sub: `${nBoxes(M.sealed.length)} · wycenione po koszcie`,
+      cost: M.sealedValue, value: M.sealedValue, pnl: 0, paper: true
+    }
+  ];
+  if (otherCost || otherValue) rows.push({
+    tone: 'other', icon: 'inventory_2', label: 'Bulk i pozostałe koszty',
+    sub: 'Bulk z breaków, nieprzypisany koszt i koszty ogólne',
+    cost: otherCost, value: otherValue, pnl: otherValue - otherCost, paper: true
+  });
+
+  const maxCost = Math.max(...rows.map(row => row.cost), 1);
+  el('funnel-wrap').innerHTML = `<table class="cd-funnel-table">
+    <thead><tr><th>Etap</th><th class="num">Kapitał / koszt</th><th class="num">Przychód / wartość</th><th class="num">P&amp;L</th><th class="num">ROI</th></tr></thead>
+    <tbody>${rows.map(row => {
+      const roi = row.cost > 0 ? row.pnl / row.cost * 100 : null;
+      return `<tr class="${row.paper ? 'is-paper' : ''}">
+        <td><div class="cd-funnel-stage"><span class="cd-funnel-icon ${row.tone}"><span class="material-symbols-outlined">${row.icon}</span></span><span><strong>${row.label}</strong><small>${row.sub}</small></span></div><span class="cd-funnel-bar"><i class="${row.tone}" style="width:${row.cost / maxCost * 100}%"></i></span></td>
+        <td class="num mono">${fmtPLN0(row.cost)}</td>
+        <td class="num mono">${fmtPLN0(row.value)}${row.paper ? '<small>papierowo</small>' : '<small>netto</small>'}</td>
+        <td class="num mono ${posClass(row.pnl)}">${fmtPLN0(row.pnl, true)}</td>
+        <td class="num mono ${posClass(roi)}">${fmtPct(roi)}</td>
+      </tr>`;
+    }).join('')}</tbody>
+    <tfoot><tr><td>Łącznie</td><td class="num mono">${fmtPLN0(M.cashOut)}</td><td class="num mono">${fmtPLN0(M.cashIn + M.assets)}</td><td class="num mono ${posClass(M.totalResult)}">${fmtPLN0(M.totalResult, true)}</td><td class="num mono ${posClass(M.roiTotal)}">${fmtPct(M.roiTotal)}</td></tr></tfoot>
+  </table>`;
+
+  const inventory = M.heldBasis + M.sealedValue + Math.max(0, M.unallocated);
+  const paperGain = M.totalResult - M.realized;
+  const recovery = M.cashOut > 0 ? M.cashIn / M.cashOut * 100 : 0;
+  el('funnel-recovered').textContent = `${fmtPct(recovery, false, 0)} wydatków wróciło w gotówce`;
+  el('funnel-summary').innerHTML = `
+    <div><span>Kapitał nadal w towarze</span><strong>${fmtPLN0(inventory)}</strong></div>
+    <div class="paper"><span>Wynik papierowy</span><strong class="${posClass(paperGain)}">${fmtPLN0(paperGain, true)}</strong></div>
+    <div><span>Zysk zrealizowany</span><strong class="${posClass(M.realized)}">${fmtPLN0(M.realized, true)}</strong></div>
+    <div class="total"><span>Wynik całego biznesu</span><strong class="${posClass(M.totalResult)}">${fmtPLN0(M.totalResult, true)}</strong></div>`;
 }
 
 function setKpiHero(id, value, note, cls) {


### PR DESCRIPTION
### Motivation
- Pokazać prosty „lejek kapitału” w widoku Przegląd, żeby użytkownik widział ile kapitału jest w sprzedanym towarze, ile w niesprzedanych kartach (papierowo) i ile w nieotwartych boxach. 

### Description
- Dodano sekcję lejka w `cards.html` z nagłówkiem, tabelą i podsumowaniem (`.cd-funnel`).
- Dodano funkcję `renderCapitalFunnel()` w `cards.js` i wywołanie jej z `renderOverview()`, która buduje wiersze (sprzedany, karty na stanie, nieotwarte boxy, bulk/pozostałe) oraz podsumowanie P&L/paperowej wartości; poprawiono obliczenia używane w widoku. 
- Dodano style dla komponentu lejka w `cards.css` (`.cd-funnel`, `.cd-funnel-table`, `.cd-funnel-summary` itp.).
- Zaktualizowano dokumentację modułu w `CARDS.md`, dopisując „Lejek kapitału” w opisie Przeglądu.

### Testing
- ✅ `node --check cards.js` — sprawdzenie składni pliku `cards.js` zakończone pomyślnie.  
- ✅ `git diff --stat` — zmiany dotyczyły 4 plików: `cards.html`, `cards.css`, `cards.js`, `CARDS.md`.  
- ✅ `node server.js` — uruchomienie serwera (LifeOS działa na http://localhost:8787).  
- ⚠️ `npx playwright@1.55.0 install chromium` — początkowa próba pobrania przeglądarki zakończyła się błędem pobrania (403 / ograniczenia środowiska), próbowano instalacji zależności i screenshotu; końcowo wykonano zrzut ekranu strony z użyciem Playwright i zapisano go jako `/tmp/cards-funnel.png` lecz proces wymagał dodatkowych zależności i wygenerował ostrzeżenia środowiskowe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82a87a155883319bb37484b369cf59)